### PR TITLE
CI: fix out of memory error

### DIFF
--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -72,7 +72,7 @@ def _ssim_update(
             The luminance term can be obtained with luminance=ssim/contrast
             Mutually exclusive with ``return_full_image``
     """
-    is_3d = len(preds.shape) == 5
+    is_3d = preds.ndim == 5
 
     if not isinstance(kernel_size, Sequence):
         kernel_size = 3 * [kernel_size] if is_3d else 2 * [kernel_size]
@@ -367,7 +367,7 @@ def _multiscale_ssim_update(
     """
     mcs_list: List[Tensor] = []
 
-    is_3d = len(preds.shape) == 5
+    is_3d = preds.ndim == 5
 
     if not isinstance(kernel_size, Sequence):
         kernel_size = 3 * [kernel_size] if is_3d else 2 * [kernel_size]

--- a/tests/unittests/image/test_ms_ssim.py
+++ b/tests/unittests/image/test_ms_ssim.py
@@ -100,9 +100,9 @@ class TestMultiScaleStructuralSimilarityIndexMeasure(MetricTester):
 
 def test_ms_ssim_contrast_sensitivity():
     """Test that the contrast sensitivity is correctly computed with 3d input."""
-    preds = torch.rand(1, 1, 182, 182, 182)
-    target = torch.rand(1, 1, 182, 182, 182)
+    preds = torch.rand(1, 1, 50, 50, 50)
+    target = torch.rand(1, 1, 50, 50, 50)
     out = multiscale_structural_similarity_index_measure(
-        preds, target, data_range=1.0, kernel_size=11, betas=(1.0, 0.5, 0.25)
+        preds, target, data_range=1.0, kernel_size=3, betas=(1.0, 0.5, 0.25)
     )
     assert isinstance(out, torch.Tensor)


### PR DESCRIPTION
## What does this PR do?

In PR https://github.com/Lightning-AI/torchmetrics/pull/1674 a test was introduced that seems to run out of memory in CI on windows machines:
https://github.com/Lightning-AI/torchmetrics/actions/runs/4681300369/jobs/8307412215?pr=1697
https://github.com/Lightning-AI/torchmetrics/actions/runs/4687229805/jobs/8306269418?pr=1682
Reduce the input shape to the test to reduce memory used.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
