### PR TITLE
fix `max_det_threshold` in MAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed padding removal for 3d input in `MSSSIM` ([#1674](https://github.com/Lightning-AI/torchmetrics/pull/1674))
 
 
+- Fixed `max_det_threshold` in MAP detection ([#1712](https://github.com/Lightning-AI/torchmetrics/pull/1712))
+
+
 ## [0.11.4] - 2023-03-10
 
 ### Fixed

--- a/src/torchmetrics/detection/mean_ap.py
+++ b/src/torchmetrics/detection/mean_ap.py
@@ -394,10 +394,10 @@ class MeanAveragePrecision(Metric):
             raise ModuleNotFoundError("When `iou_type` is set to 'segm', pycocotools need to be installed")
         self.iou_type = iou_type
         self.bbox_area_ranges = {
-            "all": (float(0**2), float(1e5**2)),
-            "small": (float(0**2), float(32**2)),
-            "medium": (float(32**2), float(96**2)),
-            "large": (float(96**2), float(1e5**2)),
+            "all": (float(0 ** 2), float(1e5 ** 2)),
+            "small": (float(0 ** 2), float(32 ** 2)),
+            "medium": (float(32 ** 2), float(96 ** 2)),
+            "large": (float(96 ** 2), float(1e5 ** 2)),
         }
 
         if not isinstance(class_metrics, bool):
@@ -795,8 +795,8 @@ class MeanAveragePrecision(Metric):
         """
         results = {"precision": precisions, "recall": recalls}
         map_metrics = MAPMetricResults()
-        map_metrics.map = self._summarize(results, True)
         last_max_det_thr = self.max_detection_thresholds[-1]
+        map_metrics.map = self._summarize(results, True, max_dets=last_max_det_thr)
         if 0.5 in self.iou_thresholds:
             map_metrics.map_50 = self._summarize(results, True, iou_threshold=0.5, max_dets=last_max_det_thr)
         else:

--- a/src/torchmetrics/detection/mean_ap.py
+++ b/src/torchmetrics/detection/mean_ap.py
@@ -394,10 +394,10 @@ class MeanAveragePrecision(Metric):
             raise ModuleNotFoundError("When `iou_type` is set to 'segm', pycocotools need to be installed")
         self.iou_type = iou_type
         self.bbox_area_ranges = {
-            "all": (float(0 ** 2), float(1e5 ** 2)),
-            "small": (float(0 ** 2), float(32 ** 2)),
-            "medium": (float(32 ** 2), float(96 ** 2)),
-            "large": (float(96 ** 2), float(1e5 ** 2)),
+            "all": (float(0**2), float(1e5**2)),
+            "small": (float(0**2), float(32**2)),
+            "medium": (float(32**2), float(96**2)),
+            "large": (float(96**2), float(1e5**2)),
         }
 
         if not isinstance(class_metrics, bool):


### PR DESCRIPTION
When modifying the max_det_thresholds the modified values aren't applied for the calculation of the overall MAP yet. I backchecked that this is actually the way it is implemented in [pycocotools ](https://github.com/cocodataset/cocoapi/blob/8c9bcc3cf640524c4c20a9c40e89cb6a2f2fa0e9/PythonAPI/pycocotools/cocoeval.py#L460) in the first place, but guess that it is already a bug there because it makes no sense and also doesn't occur in the [matlab ](https://github.com/cocodataset/cocoapi/blob/8c9bcc3cf640524c4c20a9c40e89cb6a2f2fa0e9/MatlabAPI/CocoEval.m#L197) implementation. 
