### PR TITLE
Small fix for SacreBLEUScore and the mteval-v13a tokenizer

### DIFF
--- a/src/torchmetrics/functional/text/sacre_bleu.py
+++ b/src/torchmetrics/functional/text/sacre_bleu.py
@@ -174,7 +174,7 @@ class _SacreBLEUTokenizer:
 
     @classmethod
     def _tokenize_13a(cls, line: str) -> str:
-        """Tokenizes an line using a relatively minimal tokenization that is equivalent to mteval-v13a, used by WMT.
+        """Tokenizes a line using a relatively minimal tokenization that is equivalent to mteval-v13a, used by WMT.
 
         Args:
             line: input sentence
@@ -193,7 +193,7 @@ class _SacreBLEUTokenizer:
             line = line.replace("&lt;", "<")
             line = line.replace("&gt;", ">")
 
-        return cls._tokenize_regex(line)
+        return cls._tokenize_regex(f" {line} ")
 
     @classmethod
     def _tokenize_zh(cls, line: str) -> str:


### PR DESCRIPTION
The behaviour of the mteval-v13a tokenizer (the ones used by WMT ) is the same as the [original implementation](https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/tokenizers/tokenizer_13a.py) now.

## What does this PR do?

Fixes #1776 

<details>
  <summary>Before submitting</summary>

- [X] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1778.org.readthedocs.build/en/1778/

<!-- readthedocs-preview torchmetrics end -->