### PR TITLE
change the lower and upper bounds of audio metrics

### DIFF
--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -85,7 +85,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
     full_state_update: bool = False
     is_differentiable: bool = False
     higher_is_better: bool = True
-    plot_lower_bound: float = 1.0
+    plot_lower_bound: float = -0.5
     plot_upper_bound: float = 4.5
 
     def __init__(

--- a/src/torchmetrics/audio/pit.py
+++ b/src/torchmetrics/audio/pit.py
@@ -69,8 +69,8 @@ class PermutationInvariantTraining(Metric):
     is_differentiable: bool = True
     sum_pit_metric: Tensor
     total: Tensor
-    plot_lower_bound: float = -10.0
-    plot_upper_bound: float = 1.0
+    plot_lower_bound: float = None
+    plot_upper_bound: float = None
 
     def __init__(
         self,

--- a/src/torchmetrics/audio/sdr.py
+++ b/src/torchmetrics/audio/sdr.py
@@ -85,8 +85,8 @@ class SignalDistortionRatio(Metric):
     full_state_update: bool = False
     is_differentiable: bool = True
     higher_is_better: bool = True
-    plot_lower_bound: float = -20.0
-    plot_upper_bound: float = 1.0
+    plot_lower_bound: float = None
+    plot_upper_bound: float = None
 
     def __init__(
         self,
@@ -195,8 +195,8 @@ class ScaleInvariantSignalDistortionRatio(Metric):
     higher_is_better = True
     sum_si_sdr: Tensor
     total: Tensor
-    plot_lower_bound: float = -40.0
-    plot_upper_bound: float = 20.0
+    plot_lower_bound: float = None
+    plot_upper_bound: float = None
 
     def __init__(
         self,

--- a/src/torchmetrics/audio/snr.py
+++ b/src/torchmetrics/audio/snr.py
@@ -64,8 +64,8 @@ class SignalNoiseRatio(Metric):
     higher_is_better: bool = True
     sum_snr: Tensor
     total: Tensor
-    plot_lower_bound: float = -20.0
-    plot_upper_bound: float = 5.0
+    plot_lower_bound: float = None
+    plot_upper_bound: float = None
 
     def __init__(
         self,
@@ -164,8 +164,8 @@ class ScaleInvariantSignalNoiseRatio(Metric):
     sum_si_snr: Tensor
     total: Tensor
     higher_is_better = True
-    plot_lower_bound: float = -20.0
-    plot_upper_bound: float = 10.0
+    plot_lower_bound: float = None
+    plot_upper_bound: float = None
 
     def __init__(
         self,

--- a/src/torchmetrics/audio/stoi.py
+++ b/src/torchmetrics/audio/stoi.py
@@ -77,8 +77,8 @@ class ShortTimeObjectiveIntelligibility(Metric):
     full_state_update: bool = False
     is_differentiable: bool = False
     higher_is_better: bool = True
-    plot_lower_bound: float = -20.0
-    plot_upper_bound: float = 5.0
+    plot_lower_bound: float = 0.0
+    plot_upper_bound: float = 1.0
 
     def __init__(
         self,


### PR DESCRIPTION
## What does this PR do?

The current lower and upper ploting bounds for audio metrics is incorrect, this PR correct these bounds.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
