### PR TITLE
Fix number of issues in `SpectralDistortionIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,7 +203,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ax` plotting logging in `MetricCollection ([#1783](https://github.com/Lightning-AI/torchmetrics/pull/1783))
 
 
-- Fixed lookup for punkt sources being downloaded in `RougeScore` [#1789](https://github.com/Lightning-AI/torchmetrics/pull/1789)
+- Fixed lookup for punkt sources being downloaded in `RougeScore` ([#1789](https://github.com/Lightning-AI/torchmetrics/pull/1789))
+
+
+- Fixed several bugs in `SpectralDistortionIndex` metric ([#1808](https://github.com/Lightning-AI/torchmetrics/pull/1808))
 
 
 ## [0.11.4] - 2023-03-10

--- a/src/torchmetrics/functional/image/uqi.py
+++ b/src/torchmetrics/functional/image/uqi.py
@@ -112,7 +112,7 @@ def _uqi_compute(
     sigma_pred_target = output_list[4] - mu_pred_target
 
     upper = 2 * sigma_pred_target
-    lower = sigma_pred_sq + sigma_target_sq
+    lower = sigma_pred_sq + sigma_target_sq + torch.finfo(sigma_pred_sq.dtype).eps
 
     uqi_idx = ((2 * mu_pred_target) * upper) / ((mu_pred_sq + mu_target_sq) * lower)
     uqi_idx = uqi_idx[..., pad_h:-pad_h, pad_w:-pad_w]

--- a/tests/unittests/image/test_d_lambda.py
+++ b/tests/unittests/image/test_d_lambda.py
@@ -32,7 +32,7 @@ Input = namedtuple("Input", ["preds", "target", "p"])
 
 _inputs = []
 for size, channel, p, dtype in [
-    (12, 3, 1, torch.float),
+    (12, 10, 1, torch.float),
     (13, 1, 3, torch.float32),
     (14, 1, 4, torch.double),
     (15, 3, 1, torch.float64),
@@ -152,3 +152,11 @@ def test_d_lambda_invalid_type():
     target_t = torch.rand((1, 1, 16, 16), dtype=torch.float64)
     with pytest.raises(TypeError, match="Expected `ms` and `fused` to have the same data type.*"):
         spectral_distortion_index(preds_t, target_t, p=1)
+
+
+def test_d_lambda_different_sizes():
+    """Since d lambda is reference free, it can accept different number of targets and preds."""
+    preds = torch.rand(1, 1, 32, 32)
+    target = torch.rand(1, 1, 16, 16)
+    out = spectral_distortion_index(preds, target, p=1)
+    assert isinstance(out, torch.Tensor)

--- a/tests/unittests/image/test_d_lambda.py
+++ b/tests/unittests/image/test_d_lambda.py
@@ -32,7 +32,7 @@ Input = namedtuple("Input", ["preds", "target", "p"])
 
 _inputs = []
 for size, channel, p, dtype in [
-    (12, 10, 1, torch.float),
+    (12, 3, 1, torch.float),
     (13, 1, 3, torch.float32),
     (14, 1, 4, torch.double),
     (15, 3, 1, torch.float64),

--- a/tests/unittests/image/test_d_lambda.py
+++ b/tests/unittests/image/test_d_lambda.py
@@ -118,12 +118,6 @@ class TestSpectralDistortionIndex(MetricTester):
             metric_args={"p": p},
         )
 
-    # SpectralDistortionIndex half + cpu does not work due to missing support in torch.log
-    @pytest.mark.xfail(reason="Spectral Distortion Index metric does not support cpu + half precision")
-    def test_d_lambda_half_cpu(self, preds, target, p):
-        """Test dtype support of the metric on CPU."""
-        self.run_precision_test_cpu(preds, target, SpectralDistortionIndex, spectral_distortion_index, {"p": p})
-
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires cuda")
     def test_d_lambda_half_gpu(self, preds, target, p):
         """Test dtype support of the metric on GPU."""


### PR DESCRIPTION
## What does this PR do?

Fixes #1520

Three changes are taking place:
* Metric supports preds and target having different height/width. Removes restrictive check
* Corner case can lead to zero division. Adds `eps` to calculation
* Metric is slow due to double for-loop over channels, when calculated on many channels. Improves this by vectorizing the inner for loop. A quick timing of the old and new implementation showed that it is similar when number of channels are in the 1-3 range but the new implementation is up to 10x faster for 10 channels.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1808.org.readthedocs.build/en/1808/

<!-- readthedocs-preview torchmetrics end -->