### PR TITLE
Fix docstring typos for `MulticlassAveragePrecision`, `MultilabelAveragePrecision`

### DIFF
--- a/src/torchmetrics/classification/average_precision.py
+++ b/src/torchmetrics/classification/average_precision.py
@@ -158,7 +158,7 @@ class BinaryAveragePrecision(BinaryPrecisionRecallCurve):
 
 
 class MulticlassAveragePrecision(MulticlassPrecisionRecallCurve):
-    r"""Compute the average precision (AP) score for binary tasks.
+    r"""Compute the average precision (AP) score for multiclass tasks.
 
     The AP score summarizes a precision-recall curve as an weighted mean of precisions at each threshold, with the
     difference in recall from the previous threshold as weight:
@@ -307,7 +307,7 @@ class MulticlassAveragePrecision(MulticlassPrecisionRecallCurve):
 
 
 class MultilabelAveragePrecision(MultilabelPrecisionRecallCurve):
-    r"""Compute the average precision (AP) score for binary tasks.
+    r"""Compute the average precision (AP) score for multilabel tasks.
 
     The AP score summarizes a precision-recall curve as an weighted mean of precisions at each threshold, with the
     difference in recall from the previous threshold as weight:


### PR DESCRIPTION
## What does this PR do?

Fixes docstring typos for `classification.MulticlassAveragePrecision`, `classification.MultilabelAveragePrecision`.

The class docstrings previously stated that they compute the average precision for binary tasks.  They should state that they compute the average precision for multiclass and multilabel tasks respectively.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1820.org.readthedocs.build/en/1820/

<!-- readthedocs-preview torchmetrics end -->