### PR TITLE
fix property name in docs example

### DIFF
--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -280,7 +280,7 @@ inside your LightningModule. In most cases we just have to replace ``self.log`` 
         def validation_epoch_end(self, outputs):
             # use log_dict instead of log
             # metrics are logged with keys: val_Accuracy, val_Precision and val_Recall
-            output = self.valid_metric.compute()
+            output = self.valid_metrics.compute()
             self.log_dict(output)
             # remember to reset metrics at the end of the epoch
             self.valid_metrics.reset()


### PR DESCRIPTION
## What does this PR do?  

[Docs Typo] Fix property name from `self.valid_metric.compute` to `self.valid_metrics.compute` as defined in the start of the class.


## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Yes.
