### PR TITLE
Correction for docstring for multiclass stat scores tensor validation function

### DIFF
--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -254,7 +254,7 @@ def _multiclass_stat_scores_tensor_validation(
 ) -> None:
     """Validate tensor input.
 
-    - if target has one more dimension than preds, then all dimensions except for preds.shape[1] should match
+    - if preds has one more dimension than target, then all dimensions except for preds.shape[1] should match
     exactly. preds.shape[1] should have size equal to number of classes
     - if preds and target have same number of dims, then all dimensions should match
     - if ``multidim_average`` is set to ``samplewise`` preds tensor needs to be atleast 2 dimensional in the


### PR DESCRIPTION
Function docstring for _multiclass_stat_scores_tensor_validation does not match what it actually validates: it is the predictions tensor that can be one dimension larger than the target tensor, not the other way around.