### PR TITLE
Reduce CI flakyness

### DIFF
--- a/src/torchmetrics/functional/image/lpips.py
+++ b/src/torchmetrics/functional/image/lpips.py
@@ -46,6 +46,13 @@ else:
 
 
 def _get_net(net: str, pretrained: bool) -> nn.modules.container.Sequential:
+    """Get torchvision network.
+
+    Args:
+        net: Name of network
+        pretrained: If pretrained weights should be used
+
+    """
     if _TORCHVISION_GREATER_EQUAL_0_13:
         if pretrained:
             pretrained_features = getattr(tv, net)(weights=getattr(tv, _weight_map[net]).IMAGENET1K_V1).features
@@ -380,8 +387,8 @@ def learned_perceptual_image_patch_similarity(
         >>> from torchmetrics.functional.image.lpips import learned_perceptual_image_patch_similarity
         >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
-        >>> learned_perceptual_image_patch_similarity(img1, img2, net_type='vgg')
-        tensor(0.3485, grad_fn=<DivBackward0>)
+        >>> learned_perceptual_image_patch_similarity(img1, img2, net_type='squeeze')
+        tensor(0.1008, grad_fn=<DivBackward0>)
 
     """
     net = _NoTrainLpips(net=net_type)

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -83,12 +83,12 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
         >>> import torch
         >>> _ = torch.manual_seed(123)
         >>> from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
-        >>> lpips = LearnedPerceptualImagePatchSimilarity(net_type='vgg')
+        >>> lpips = LearnedPerceptualImagePatchSimilarity(net_type='squeeze')
         >>> # LPIPS needs the images to be in the [-1, 1] range.
         >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> lpips(img1, img2)
-        tensor(0.3493, grad_fn=<SqueezeBackward0>)
+        tensor(0.1046, grad_fn=<SqueezeBackward0>)
     """
 
     is_differentiable: bool = True
@@ -105,7 +105,7 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
 
     def __init__(
         self,
-        net_type: Literal["alex", "alex", "squeeze"] = "alex",
+        net_type: Literal["vgg", "alex", "squeeze"] = "alex",
         reduction: Literal["sum", "mean"] = "mean",
         normalize: bool = False,
         **kwargs: Any,
@@ -168,7 +168,7 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
             >>> # Example plotting a single value
             >>> import torch
             >>> from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
-            >>> metric = LearnedPerceptualImagePatchSimilarity()
+            >>> metric = LearnedPerceptualImagePatchSimilarity(net_type='squeeze')
             >>> metric.update(torch.rand(10, 3, 100, 100), torch.rand(10, 3, 100, 100))
             >>> fig_, ax_ = metric.plot()
 
@@ -178,7 +178,7 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
             >>> # Example plotting multiple values
             >>> import torch
             >>> from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
-            >>> metric = LearnedPerceptualImagePatchSimilarity()
+            >>> metric = LearnedPerceptualImagePatchSimilarity(net_type='squeeze')
             >>> values = [ ]
             >>> for _ in range(3):
             ...     values.append(metric(torch.rand(10, 3, 100, 100), torch.rand(10, 3, 100, 100)))

--- a/tests/unittests/image/test_lpips.py
+++ b/tests/unittests/image/test_lpips.py
@@ -49,7 +49,7 @@ class TestLPIPS(MetricTester):
 
     atol: float = 1e-4
 
-    @pytest.mark.parametrize("net_type", ["vgg", "alex", "squeeze"])
+    @pytest.mark.parametrize("net_type", ["alex", "squeeze"])
     @pytest.mark.parametrize("ddp", [True, False])
     def test_lpips(self, net_type, ddp):
         """Test class implementation of metric."""
@@ -86,9 +86,9 @@ class TestLPIPS(MetricTester):
 @pytest.mark.parametrize("normalize", [False, True])
 def test_normalize_arg(normalize):
     """Test that normalize argument works as expected."""
-    metric = LearnedPerceptualImagePatchSimilarity(net_type="vgg", normalize=normalize)
+    metric = LearnedPerceptualImagePatchSimilarity(net_type="squeeze", normalize=normalize)
     res = metric(_inputs.img1[0], _inputs.img2[1])
-    res2 = _compare_fn(_inputs.img1[0], _inputs.img2[1], net_type="vgg", normalize=normalize)
+    res2 = _compare_fn(_inputs.img1[0], _inputs.img2[1], net_type="squeeze", normalize=normalize)
     assert res == res2
 
 
@@ -99,7 +99,7 @@ def test_error_on_wrong_init():
         LearnedPerceptualImagePatchSimilarity(net_type="resnet")
 
     with pytest.raises(ValueError, match="Argument `reduction` must be one .*"):
-        LearnedPerceptualImagePatchSimilarity(reduction=None)
+        LearnedPerceptualImagePatchSimilarity(net_type="squeeze", reduction=None)
 
 
 @pytest.mark.skipif(not _LPIPS_AVAILABLE, reason="test requires that lpips is installed")


### PR DESCRIPTION
## What does this PR do?

In general CI seems to be fairly stable but we still have it fail from time to time.
At least a couple of these are due to the `LPIPS` metric running out of memory:
https://github.com/Lightning-AI/torchmetrics/actions/runs/5049631496/jobs/9059558156
https://github.com/Lightning-AI/torchmetrics/actions/runs/5176757713/jobs/9325989425
https://github.com/Lightning-AI/torchmetrics/actions/runs/5398474491/jobs/9804330734
https://github.com/Lightning-AI/torchmetrics/actions/runs/5399208646/jobs/9806572657

This PR moves most of the testing from using the `vgg` backbone to `squeezenet` backbone which is ~100x smaller.
Hopefully, this will make CI even more stable.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
