### PR TITLE
Fix doc links

### DIFF
--- a/docs/source/aggregation/cat.rst
+++ b/docs/source/aggregation/cat.rst
@@ -12,6 +12,6 @@ Concatenation
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.CatMetric
+.. autoclass:: torchmetrics.aggregation.CatMetric
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/max.rst
+++ b/docs/source/aggregation/max.rst
@@ -12,6 +12,6 @@ Maximum
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MaxMetric
+.. autoclass:: torchmetrics.aggregation.MaxMetric
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/mean.rst
+++ b/docs/source/aggregation/mean.rst
@@ -12,6 +12,6 @@ Mean
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MeanMetric
+.. autoclass:: torchmetrics.aggregation.MeanMetric
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/min.rst
+++ b/docs/source/aggregation/min.rst
@@ -12,6 +12,6 @@ Minimum
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MinMetric
+.. autoclass:: torchmetrics.aggregation.MinMetric
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/running_mean.rst
+++ b/docs/source/aggregation/running_mean.rst
@@ -12,6 +12,6 @@ Running Mean
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RunningMean
+.. autoclass:: torchmetrics.aggregation.RunningMean
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/running_sum.rst
+++ b/docs/source/aggregation/running_sum.rst
@@ -12,6 +12,6 @@ Running Sum
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RunningSum
+.. autoclass:: torchmetrics.aggregation.RunningSum
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/sum.rst
+++ b/docs/source/aggregation/sum.rst
@@ -12,6 +12,6 @@ Sum
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.SumMetric
+.. autoclass:: torchmetrics.aggregation.SumMetric
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/audio/permutation_invariant_training.rst
+++ b/docs/source/audio/permutation_invariant_training.rst
@@ -12,12 +12,12 @@ Permutation Invariant Training (PIT)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.PermutationInvariantTraining
+.. autoclass:: torchmetrics.audio.PermutationInvariantTraining
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.permutation_invariant_training
+.. autofunction:: torchmetrics.functional.audio.permutation_invariant_training
     :noindex:

--- a/docs/source/audio/scale_invariant_signal_distortion_ratio.rst
+++ b/docs/source/audio/scale_invariant_signal_distortion_ratio.rst
@@ -12,12 +12,12 @@ Scale-Invariant Signal-to-Distortion Ratio (SI-SDR)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.ScaleInvariantSignalDistortionRatio
+.. autoclass:: torchmetrics.audio.ScaleInvariantSignalDistortionRatio
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.scale_invariant_signal_distortion_ratio
+.. autofunction:: torchmetrics.functional.audio.scale_invariant_signal_distortion_ratio
     :noindex:

--- a/docs/source/audio/scale_invariant_signal_noise_ratio.rst
+++ b/docs/source/audio/scale_invariant_signal_noise_ratio.rst
@@ -12,12 +12,12 @@ Scale-Invariant Signal-to-Noise Ratio (SI-SNR)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.ScaleInvariantSignalNoiseRatio
+.. autoclass:: torchmetrics.audio.ScaleInvariantSignalNoiseRatio
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.scale_invariant_signal_noise_ratio
+.. autofunction:: torchmetrics.functional.audio.scale_invariant_signal_noise_ratio
     :noindex:

--- a/docs/source/audio/signal_distortion_ratio.rst
+++ b/docs/source/audio/signal_distortion_ratio.rst
@@ -12,12 +12,12 @@ Signal to Distortion Ratio (SDR)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.SignalDistortionRatio
+.. autoclass:: torchmetrics.audio.SignalDistortionRatio
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.signal_distortion_ratio
+.. autofunction:: torchmetrics.functional.audio.signal_distortion_ratio
     :noindex:

--- a/docs/source/audio/signal_noise_ratio.rst
+++ b/docs/source/audio/signal_noise_ratio.rst
@@ -12,12 +12,12 @@ Signal-to-Noise Ratio (SNR)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.SignalNoiseRatio
+.. autoclass:: torchmetrics.audio.SignalNoiseRatio
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.signal_noise_ratio
+.. autofunction:: torchmetrics.functional.audio.signal_noise_ratio
     :noindex:

--- a/docs/source/detection/modified_panoptic_quality.rst
+++ b/docs/source/detection/modified_panoptic_quality.rst
@@ -12,12 +12,12 @@ Modified Panoptic Quality
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.ModifiedPanopticQuality
+.. autoclass:: torchmetrics.detection.ModifiedPanopticQuality
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.modified_panoptic_quality
+.. autofunction:: torchmetrics.functional.detection.modified_panoptic_quality
     :noindex:

--- a/docs/source/detection/panoptic_quality.rst
+++ b/docs/source/detection/panoptic_quality.rst
@@ -10,12 +10,12 @@ Panoptic Quality
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.PanopticQuality
+.. autoclass:: torchmetrics.detection.PanopticQuality
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.panoptic_quality
+.. autofunction:: torchmetrics.functional.detection.panoptic_quality
     :noindex:

--- a/docs/source/image/error_relative_global_dimensionless_synthesis.rst
+++ b/docs/source/image/error_relative_global_dimensionless_synthesis.rst
@@ -12,7 +12,7 @@ Error Relative Global Dim. Synthesis (ERGAS)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.image.ergas.ErrorRelativeGlobalDimensionlessSynthesis
+.. autoclass:: torchmetrics.image.ErrorRelativeGlobalDimensionlessSynthesis
     :noindex:
     :exclude-members: update, compute
 
@@ -20,5 +20,5 @@ ________________
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.error_relative_global_dimensionless_synthesis
+.. autofunction:: torchmetrics.functional.image.error_relative_global_dimensionless_synthesis
     :noindex:

--- a/docs/source/image/image_gradients.rst
+++ b/docs/source/image/image_gradients.rst
@@ -12,5 +12,5 @@ Image Gradients
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.image_gradients
+.. autofunction:: torchmetrics.functional.image.image_gradients
     :noindex:

--- a/docs/source/image/multi_scale_structural_similarity.rst
+++ b/docs/source/image/multi_scale_structural_similarity.rst
@@ -12,12 +12,12 @@ Multi-Scale SSIM
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MultiScaleStructuralSimilarityIndexMeasure
+.. autoclass:: torchmetrics.image.MultiScaleStructuralSimilarityIndexMeasure
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.multiscale_structural_similarity_index_measure
+.. autofunction:: torchmetrics.functional.image.multiscale_structural_similarity_index_measure
     :noindex:

--- a/docs/source/image/peak_signal_noise_ratio.rst
+++ b/docs/source/image/peak_signal_noise_ratio.rst
@@ -12,12 +12,12 @@ Peak Signal-to-Noise Ratio (PSNR)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.PeakSignalNoiseRatio
+.. autoclass:: torchmetrics.image.PeakSignalNoiseRatio
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.peak_signal_noise_ratio
+.. autofunction:: torchmetrics.functional.image.peak_signal_noise_ratio
     :noindex:

--- a/docs/source/image/relative_average_spectral_error.rst
+++ b/docs/source/image/relative_average_spectral_error.rst
@@ -12,12 +12,12 @@ Relative Average Spectral Error (RASE)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RelativeAverageSpectralError
+.. autoclass:: torchmetrics.image.RelativeAverageSpectralError
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.relative_average_spectral_error
+.. autofunction:: torchmetrics.functional.image.relative_average_spectral_error
     :noindex:

--- a/docs/source/image/root_mean_squared_error_using_sliding_window.rst
+++ b/docs/source/image/root_mean_squared_error_using_sliding_window.rst
@@ -12,12 +12,12 @@ Root Mean Squared Error Using Sliding Window
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RootMeanSquaredErrorUsingSlidingWindow
+.. autoclass:: torchmetrics.image.RootMeanSquaredErrorUsingSlidingWindow
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.root_mean_squared_error_using_sliding_window
+.. autofunction:: torchmetrics.functional.image.root_mean_squared_error_using_sliding_window
     :noindex:

--- a/docs/source/image/spectral_angle_mapper.rst
+++ b/docs/source/image/spectral_angle_mapper.rst
@@ -10,12 +10,12 @@ Spectral Angle Mapper
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.SpectralAngleMapper
+.. autoclass:: torchmetrics.image.SpectralAngleMapper
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.spectral_angle_mapper
+.. autofunction:: torchmetrics.functional.image.spectral_angle_mapper
     :noindex:

--- a/docs/source/image/spectral_distortion_index.rst
+++ b/docs/source/image/spectral_distortion_index.rst
@@ -12,11 +12,11 @@ Spectral Distortion Index
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.SpectralDistortionIndex
+.. autoclass:: torchmetrics.image.SpectralDistortionIndex
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.spectral_distortion_index
+.. autofunction:: torchmetrics.functional.image.spectral_distortion_index

--- a/docs/source/image/structural_similarity.rst
+++ b/docs/source/image/structural_similarity.rst
@@ -12,12 +12,12 @@ Structural Similarity Index Measure (SSIM)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.StructuralSimilarityIndexMeasure
+.. autoclass:: torchmetrics.image.StructuralSimilarityIndexMeasure
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.structural_similarity_index_measure
+.. autofunction:: torchmetrics.functional.image.structural_similarity_index_measure
     :noindex:

--- a/docs/source/image/total_variation.rst
+++ b/docs/source/image/total_variation.rst
@@ -12,12 +12,12 @@ Total Variation (TV)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.TotalVariation
+.. autoclass:: torchmetrics.image.TotalVariation
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.total_variation
+.. autofunction:: torchmetrics.functional.image.total_variation
     :noindex:

--- a/docs/source/image/universal_image_quality_index.rst
+++ b/docs/source/image/universal_image_quality_index.rst
@@ -12,12 +12,12 @@ Universal Image Quality Index
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.UniversalImageQualityIndex
+.. autoclass:: torchmetrics.image.UniversalImageQualityIndex
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.universal_image_quality_index
+.. autofunction:: torchmetrics.functional.image.universal_image_quality_index
     :noindex:

--- a/docs/source/nominal/cramers_v.rst
+++ b/docs/source/nominal/cramers_v.rst
@@ -10,14 +10,14 @@ Cramer's V
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.CramersV
+.. autoclass:: torchmetrics.nominal.CramersV
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.cramers_v
+.. autofunction:: torchmetrics.functional.nominal.cramers_v
     :noindex:
 
 cramers_v_matrix

--- a/docs/source/nominal/fleiss_kappa.rst
+++ b/docs/source/nominal/fleiss_kappa.rst
@@ -10,12 +10,12 @@ Fleiss Kappa
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.FleissKappa
+.. autoclass:: torchmetrics.nominal.FleissKappa
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.fleiss_kappa
+.. autofunction:: torchmetrics.functional.nominal.fleiss_kappa
     :noindex:

--- a/docs/source/nominal/pearsons_contingency_coefficient.rst
+++ b/docs/source/nominal/pearsons_contingency_coefficient.rst
@@ -10,14 +10,14 @@ Pearson's Contingency Coefficient
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.PearsonsContingencyCoefficient
+.. autoclass:: torchmetrics.nominal.PearsonsContingencyCoefficient
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.pearsons_contingency_coefficient
+.. autofunction:: torchmetrics.functional.nominal.pearsons_contingency_coefficient
     :noindex:
 
 pearsons_contingency_coefficient_matrix

--- a/docs/source/nominal/theils_u.rst
+++ b/docs/source/nominal/theils_u.rst
@@ -10,14 +10,14 @@ Theil's U
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.TheilsU
+.. autoclass:: torchmetrics.nominal.TheilsU
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.theils_u
+.. autofunction:: torchmetrics.functional.nominal.theils_u
     :noindex:
 
 theils_u_matrix

--- a/docs/source/nominal/tschuprows_t.rst
+++ b/docs/source/nominal/tschuprows_t.rst
@@ -10,14 +10,14 @@ Tschuprow's T
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.TschuprowsT
+.. autoclass:: torchmetrics.nominal.TschuprowsT
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.tschuprows_t
+.. autofunction:: torchmetrics.functional.nominal.tschuprows_t
     :noindex:
 
 tschuprows_t_matrix

--- a/docs/source/retrieval/fall_out.rst
+++ b/docs/source/retrieval/fall_out.rst
@@ -12,12 +12,12 @@ Retrieval Fall-Out
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalFallOut
+.. autoclass:: torchmetrics.retrieval.RetrievalFallOut
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_fall_out
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_fall_out
     :noindex:

--- a/docs/source/retrieval/hit_rate.rst
+++ b/docs/source/retrieval/hit_rate.rst
@@ -10,12 +10,12 @@ Retrieval Hit Rate
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalHitRate
+.. autoclass:: torchmetrics.retrieval.RetrievalHitRate
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_hit_rate
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_hit_rate
     :noindex:

--- a/docs/source/retrieval/map.rst
+++ b/docs/source/retrieval/map.rst
@@ -12,12 +12,12 @@ Retrieval Mean Average Precision (MAP)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalMAP
+.. autoclass:: torchmetrics.retrieval.RetrievalMAP
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_average_precision
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_average_precision
     :noindex:

--- a/docs/source/retrieval/mrr.rst
+++ b/docs/source/retrieval/mrr.rst
@@ -12,12 +12,12 @@ Retrieval Mean Reciprocal Rank (MRR)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalMRR
+.. autoclass:: torchmetrics.retrieval.RetrievalMRR
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_reciprocal_rank
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_reciprocal_rank
     :noindex:

--- a/docs/source/retrieval/normalized_dcg.rst
+++ b/docs/source/retrieval/normalized_dcg.rst
@@ -12,12 +12,12 @@ Retrieval Normalized DCG
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalNormalizedDCG
+.. autoclass:: torchmetrics.retrieval.RetrievalNormalizedDCG
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_normalized_dcg
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_normalized_dcg
     :noindex:

--- a/docs/source/retrieval/precision.rst
+++ b/docs/source/retrieval/precision.rst
@@ -12,12 +12,12 @@ Retrieval Precision
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalPrecision
+.. autoclass:: torchmetrics.retrieval.RetrievalPrecision
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_precision
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_precision
     :noindex:

--- a/docs/source/retrieval/precision_recall_curve.rst
+++ b/docs/source/retrieval/precision_recall_curve.rst
@@ -12,12 +12,12 @@ Precision Recall Curve
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalPrecisionRecallCurve
+.. autoclass:: torchmetrics.retrieval.RetrievalPrecisionRecallCurve
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_precision_recall_curve
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_precision_recall_curve
     :noindex:

--- a/docs/source/retrieval/r_precision.rst
+++ b/docs/source/retrieval/r_precision.rst
@@ -12,12 +12,12 @@ Retrieval R-Precision
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalRPrecision
+.. autoclass:: torchmetrics.retrieval.RetrievalRPrecision
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_r_precision
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_r_precision
     :noindex:

--- a/docs/source/retrieval/recall.rst
+++ b/docs/source/retrieval/recall.rst
@@ -12,12 +12,12 @@ Retrieval Recall
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.RetrievalRecall
+.. autoclass:: torchmetrics.retrieval.RetrievalRecall
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.retrieval_recall
+.. autofunction:: torchmetrics.functional.retrieval.retrieval_recall
     :noindex:

--- a/docs/source/text/bleu_score.rst
+++ b/docs/source/text/bleu_score.rst
@@ -12,12 +12,12 @@ BLEU Score
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.BLEUScore
+.. autoclass:: torchmetrics.text.BLEUScore
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.bleu_score
+.. autofunction:: torchmetrics.functional.text.bleu_score
     :noindex:

--- a/docs/source/text/char_error_rate.rst
+++ b/docs/source/text/char_error_rate.rst
@@ -12,12 +12,12 @@ Char Error Rate
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.CharErrorRate
+.. autoclass:: torchmetrics.text.CharErrorRate
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.char_error_rate
+.. autofunction:: torchmetrics.functional.text.char_error_rate
     :noindex:

--- a/docs/source/text/chrf_score.rst
+++ b/docs/source/text/chrf_score.rst
@@ -12,12 +12,12 @@ ChrF Score
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.CHRFScore
+.. autoclass:: torchmetrics.text.CHRFScore
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.chrf_score
+.. autofunction:: torchmetrics.functional.text.chrf_score
     :noindex:

--- a/docs/source/text/extended_edit_distance.rst
+++ b/docs/source/text/extended_edit_distance.rst
@@ -12,12 +12,12 @@ Extended Edit Distance
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.ExtendedEditDistance
+.. autoclass:: torchmetrics.text.ExtendedEditDistance
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.extended_edit_distance
+.. autofunction:: torchmetrics.functional.text.extended_edit_distance
     :noindex:

--- a/docs/source/text/match_error_rate.rst
+++ b/docs/source/text/match_error_rate.rst
@@ -12,12 +12,12 @@ Match Error Rate
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MatchErrorRate
+.. autoclass:: torchmetrics.text.MatchErrorRate
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.match_error_rate
+.. autofunction:: torchmetrics.functional.text.match_error_rate
     :noindex:

--- a/docs/source/text/sacre_bleu_score.rst
+++ b/docs/source/text/sacre_bleu_score.rst
@@ -12,12 +12,12 @@ Sacre BLEU Score
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.SacreBLEUScore
+.. autoclass:: torchmetrics.text.SacreBLEUScore
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.sacre_bleu_score
+.. autofunction:: torchmetrics.functional.text.sacre_bleu_score
     :noindex:

--- a/docs/source/text/squad.rst
+++ b/docs/source/text/squad.rst
@@ -12,12 +12,12 @@ SQuAD
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.SQuAD
+.. autoclass:: torchmetrics.text.SQuAD
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.squad
+.. autofunction:: torchmetrics.functional.text.squad
     :noindex:

--- a/docs/source/text/translation_edit_rate.rst
+++ b/docs/source/text/translation_edit_rate.rst
@@ -12,12 +12,12 @@ Translation Edit Rate (TER)
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.TranslationEditRate
+.. autoclass:: torchmetrics.text.TranslationEditRate
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.translation_edit_rate
+.. autofunction:: torchmetrics.functional.text.translation_edit_rate
     :noindex:

--- a/docs/source/text/word_error_rate.rst
+++ b/docs/source/text/word_error_rate.rst
@@ -12,12 +12,12 @@ Word Error Rate
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.WordErrorRate
+.. autoclass:: torchmetrics.text.WordErrorRate
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.word_error_rate
+.. autofunction:: torchmetrics.functional.text.word_error_rate
     :noindex:

--- a/docs/source/text/word_info_lost.rst
+++ b/docs/source/text/word_info_lost.rst
@@ -12,12 +12,12 @@ Word Info. Lost
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.WordInfoLost
+.. autoclass:: torchmetrics.text.WordInfoLost
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.word_information_lost
+.. autofunction:: torchmetrics.functional.text.word_information_lost
     :noindex:

--- a/docs/source/text/word_info_preserved.rst
+++ b/docs/source/text/word_info_preserved.rst
@@ -12,12 +12,12 @@ Word Info. Preserved
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.WordInfoPreserved
+.. autoclass:: torchmetrics.text.WordInfoPreserved
     :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
-.. autofunction:: torchmetrics.functional.word_information_preserved
+.. autofunction:: torchmetrics.functional.text.word_information_preserved
     :noindex:

--- a/docs/source/wrappers/bootstrapper.rst
+++ b/docs/source/wrappers/bootstrapper.rst
@@ -12,5 +12,5 @@ Bootstrapper
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.BootStrapper
+.. autoclass:: torchmetrics.wrappers.BootStrapper
     :noindex:

--- a/docs/source/wrappers/classwise_wrapper.rst
+++ b/docs/source/wrappers/classwise_wrapper.rst
@@ -12,5 +12,5 @@ Classwise Wrapper
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.ClasswiseWrapper
+.. autoclass:: torchmetrics.wrappers.ClasswiseWrapper
     :noindex:

--- a/docs/source/wrappers/metric_tracker.rst
+++ b/docs/source/wrappers/metric_tracker.rst
@@ -12,6 +12,6 @@ Metric Tracker
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MetricTracker
+.. autoclass:: torchmetrics.wrappers.MetricTracker
     :noindex:
     :exclude-members: update, compute

--- a/docs/source/wrappers/min_max.rst
+++ b/docs/source/wrappers/min_max.rst
@@ -12,5 +12,5 @@ Min / Max
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MinMaxMetric
+.. autoclass:: torchmetrics.wrappers.MinMaxMetric
     :noindex:

--- a/docs/source/wrappers/multi_output_wrapper.rst
+++ b/docs/source/wrappers/multi_output_wrapper.rst
@@ -12,5 +12,5 @@ Multi-output Wrapper
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MultioutputWrapper
+.. autoclass:: torchmetrics.wrappers.MultioutputWrapper
     :noindex:

--- a/docs/source/wrappers/multi_task_wrapper.rst
+++ b/docs/source/wrappers/multi_task_wrapper.rst
@@ -12,5 +12,5 @@ Multi-task Wrapper
 Module Interface
 ________________
 
-.. autoclass:: torchmetrics.MultitaskWrapper
+.. autoclass:: torchmetrics.wrappers.MultitaskWrapper
     :noindex:


### PR DESCRIPTION
## What does this PR do?

After the refactor in PR https://github.com/Lightning-AI/torchmetrics/pull/1681 and the deprecation that followed, documentation is not proper showing for a lot of metrics. Take this for example:
https://torchmetrics.readthedocs.io/en/latest/image/total_variation.html

Updates paths in docs to be the correct.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1881.org.readthedocs.build/en/1881/

<!-- readthedocs-preview torchmetrics end -->