### PR TITLE
Fix computing iou when there have empty predicted boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed bug related to empty predictions for `IntersectionOverUnion` metric ([#1892](https://github.com/Lightning-AI/torchmetrics/pull/1892))
 
 
 ## [1.0.0] - 2022-07-04

--- a/src/torchmetrics/functional/detection/iou.py
+++ b/src/torchmetrics/functional/detection/iou.py
@@ -38,7 +38,10 @@ def _iou_update(
 def _iou_compute(iou: torch.Tensor, labels_eq: bool = True) -> torch.Tensor:
     if labels_eq:
         return iou.diag().mean()
-    return iou.mean()
+    if iou.numel() > 0:
+        return iou.mean()
+    else:
+        return torch.tensor(0.0)
 
 
 def intersection_over_union(

--- a/src/torchmetrics/functional/detection/iou.py
+++ b/src/torchmetrics/functional/detection/iou.py
@@ -38,10 +38,7 @@ def _iou_update(
 def _iou_compute(iou: torch.Tensor, labels_eq: bool = True) -> torch.Tensor:
     if labels_eq:
         return iou.diag().mean()
-    if iou.numel() > 0:
-        return iou.mean()
-    else:
-        return torch.tensor(0.0)
+    return iou.mean() if iou.numel() > 0 else torch.tensor(0.0)
 
 
 def intersection_over_union(


### PR DESCRIPTION
If the iou has 0 in its shape (i.e., the predicted boxes is empty), the computed iou should be 0.0.

## What does this PR do?

Fixes #1889 

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1892.org.readthedocs.build/en/1892/

<!-- readthedocs-preview torchmetrics end -->