### PR TITLE
Fix `Auroc` metric when `max_fpr` is set and a class is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed the use of `max_fpr` in `AUROC` metric when only one class is present ([#1895](https://github.com/Lightning-AI/torchmetrics/pull/1895))
 
 
 ## [1.0.0] - 2022-07-04

--- a/src/torchmetrics/functional/classification/auroc.py
+++ b/src/torchmetrics/functional/classification/auroc.py
@@ -86,7 +86,7 @@ def _binary_auroc_compute(
     pos_label: int = 1,
 ) -> Tensor:
     fpr, tpr, _ = _binary_roc_compute(state, thresholds, pos_label)
-    if max_fpr is None or max_fpr == 1:
+    if max_fpr is None or max_fpr == 1 or fpr.sum() == 0 or tpr.sum() == 0:
         return _auc_compute_without_check(fpr, tpr, 1.0)
 
     _device = fpr.device if isinstance(fpr, Tensor) else fpr[0].device

--- a/tests/unittests/classification/test_auroc.py
+++ b/tests/unittests/classification/test_auroc.py
@@ -393,3 +393,17 @@ def test_valid_input_thresholds(metric, thresholds):
     with pytest.warns(None) as record:
         metric(thresholds=thresholds)
     assert len(record) == 0
+
+
+@pytest.mark.parametrize("max_fpr", [None, 0.8, 0.5])
+def test_corner_case_max_fpr(max_fpr):
+    """Check that metric returns 0 when one class is missing and `max_fpr` is set."""
+    preds = torch.tensor([0.1, 0.2, 0.3, 0.4])
+    target = torch.tensor([0, 0, 0, 0])
+    metric = BinaryAUROC(max_fpr=max_fpr)
+    assert metric(preds, target) == 0.0
+
+    preds = torch.tensor([0.5, 0.6, 0.7, 0.8])
+    target = torch.tensor([1, 1, 1, 1])
+    metric = BinaryAUROC(max_fpr=max_fpr)
+    assert metric(preds, target) == 0.0


### PR DESCRIPTION
## What does this PR do?

Fixes #1891

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1895.org.readthedocs.build/en/1895/

<!-- readthedocs-preview torchmetrics end -->