### PR TITLE
Bugfix for using metric collection and aggregation metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixes corner case when using `MetricCollection` together with aggregation metrics ([#1896](https://github.com/Lightning-AI/torchmetrics/pull/1896))
 
 
 ## [1.0.0] - 2022-07-04

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -419,22 +419,22 @@ def test_dtype_in_pl_module_transfer(tmpdir):
             return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
     model = BoringModel()
-    assert model.metric.value.dtype == torch.float32
+    assert model.metric.sum_value.dtype == torch.float32
     model = model.half()
-    assert model.metric.value.dtype == torch.float32
+    assert model.metric.sum_value.dtype == torch.float32
 
     model = BoringModel()
-    assert model.metric.value.dtype == torch.float32
+    assert model.metric.sum_value.dtype == torch.float32
     model = model.double()
-    assert model.metric.value.dtype == torch.float32
+    assert model.metric.sum_value.dtype == torch.float32
 
     model = BoringModel(metric_dtype=torch.float16)
-    assert model.metric.value.dtype == torch.float16
+    assert model.metric.sum_value.dtype == torch.float16
     model = model.float()
-    assert model.metric.value.dtype == torch.float16
+    assert model.metric.sum_value.dtype == torch.float16
 
     model = BoringModel()
-    assert model.metric.value.dtype == torch.float32
+    assert model.metric.sum_value.dtype == torch.float32
 
     model = model.type(torch.half)
-    assert model.metric.value.dtype == torch.float32
+    assert model.metric.sum_value.dtype == torch.float32


### PR DESCRIPTION
## What does this PR do?

Fixes #1890

Essentially, if a user provides a single value like `torch(1.0) then the state of `SumMetric`, `MeanMetric`, `MinMetric`, `MaxMetric` is the exact same after the first `metric.update` call (sum(1) == mean(1) == max(1) == min(1)). In this case metric collection interprets that these should be in the same compute group, which is wrong.
Fixes this by given unique state names

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1896.org.readthedocs.build/en/1896/

<!-- readthedocs-preview torchmetrics end -->