### PR TITLE
Feature: Base wrapper class

### DIFF
--- a/src/torchmetrics/wrappers/abstract.py
+++ b/src/torchmetrics/wrappers/abstract.py
@@ -1,0 +1,41 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Callable
+
+from torchmetrics.metric import Metric
+
+
+class WrapperMetric(Metric):
+    """Abstract base class for wrapper metrics.
+
+    Wrapper metrics are characterized by them wrapping another metric, and forwarding all calls to the wrapped metric.
+    This means that all logic regarding syncronization etc. is handled by the wrapped metric, and the wrapper metric
+    should not do anything in this regard.
+
+    This class therefore overwrites all methods that are related to syncronization, and does nothing in them.
+
+    Additionally, the forward method is not implemented by default as custom logic is required for each wrapper metric.
+    """
+
+    def _wrap_update(self, update: Callable) -> Callable:
+        """Overwrite to do nothing, because the default wrapped functionality is handled by the wrapped metric."""
+        return update
+
+    def _wrap_compute(self, compute: Callable) -> Callable:
+        """Overwrite to do nothing, because the default wrapped functionality is handled by the wrapped metric."""
+        return compute
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Overwrite to do nothing, because the default wrapped functionality is handled by the wrapped metric."""
+        raise NotImplementedError

--- a/src/torchmetrics/wrappers/bootstrapping.py
+++ b/src/torchmetrics/wrappers/bootstrapping.py
@@ -22,6 +22,7 @@ from torchmetrics.metric import Metric
 from torchmetrics.utilities import apply_to_collection
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.wrappers.abstract import WrapperMetric
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["BootStrapper.plot"]
@@ -49,7 +50,7 @@ def _bootstrap_sampler(
     raise ValueError("Unknown sampling strategy")
 
 
-class BootStrapper(Metric):
+class BootStrapper(WrapperMetric):
     r"""Using `Turn a Metric into a Bootstrapped`_.
 
     That can automate the process of getting confidence intervals for metric values. This wrapper

--- a/src/torchmetrics/wrappers/classwise.py
+++ b/src/torchmetrics/wrappers/classwise.py
@@ -18,12 +18,13 @@ from torch import Tensor
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.wrappers.abstract import WrapperMetric
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["ClasswiseWrapper.plot"]
 
 
-class ClasswiseWrapper(Metric):
+class ClasswiseWrapper(WrapperMetric):
     """Wrapper metric for altering the output of classification metrics.
 
     This metric works together with classification metrics that returns multiple values (one value per class) such that
@@ -163,14 +164,6 @@ class ClasswiseWrapper(Metric):
     def reset(self) -> None:
         """Reset metric."""
         self.metric.reset()
-
-    def _wrap_update(self, update: Callable) -> Callable:
-        """Overwrite to do nothing."""
-        return update
-
-    def _wrap_compute(self, compute: Callable) -> Callable:
-        """Overwrite to do nothing."""
-        return compute
 
     def plot(
         self, val: Optional[Union[Tensor, Sequence[Tensor]]] = None, ax: Optional[_AX_TYPE] = None

--- a/src/torchmetrics/wrappers/minmax.py
+++ b/src/torchmetrics/wrappers/minmax.py
@@ -20,12 +20,13 @@ from torch import Tensor
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.wrappers.abstract import WrapperMetric
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["MinMaxMetric.plot"]
 
 
-class MinMaxMetric(Metric):
+class MinMaxMetric(WrapperMetric):
     """Wrapper metric that tracks both the minimum and maximum of a scalar/tensor across an experiment.
 
     The min/max value will be updated each time ``.compute`` is called.
@@ -94,6 +95,10 @@ class MinMaxMetric(Metric):
         self.max_val = val if self.max_val.to(val.device) < val else self.max_val.to(val.device)
         self.min_val = val if self.min_val.to(val.device) > val else self.min_val.to(val.device)
         return {"raw": val, "max": self.max_val, "min": self.min_val}
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Use the original forward method of the base metric class."""
+        return super(WrapperMetric, self).forward(*args, **kwargs)
 
     def reset(self) -> None:
         """Set ``max_val`` and ``min_val`` to the initialization bounds and resets the base metric."""

--- a/src/torchmetrics/wrappers/multioutput.py
+++ b/src/torchmetrics/wrappers/multioutput.py
@@ -1,3 +1,16 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from copy import deepcopy
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
@@ -9,6 +22,7 @@ from torchmetrics.metric import Metric
 from torchmetrics.utilities import apply_to_collection
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.wrappers.abstract import WrapperMetric
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["MultioutputWrapper.plot"]
@@ -26,7 +40,7 @@ def _get_nan_indices(*tensors: Tensor) -> Tensor:
     return nan_idxs
 
 
-class MultioutputWrapper(Metric):
+class MultioutputWrapper(WrapperMetric):
     """Wrap a base metric to enable it to support multiple outputs.
 
     Several torchmetrics metrics, such as :class:`torchmetrics.regression.spearman.SpearmanCorrcoef` lack support for
@@ -140,14 +154,6 @@ class MultioutputWrapper(Metric):
         for metric in self.metrics:
             metric.reset()
         super().reset()
-
-    def _wrap_update(self, update: Callable) -> Callable:
-        """Overwrite to do nothing."""
-        return update
-
-    def _wrap_compute(self, compute: Callable) -> Callable:
-        """Overwrite to do nothing."""
-        return compute
 
     def plot(
         self, val: Optional[Union[Tensor, Sequence[Tensor]]] = None, ax: Optional[_AX_TYPE] = None

--- a/src/torchmetrics/wrappers/multitask.py
+++ b/src/torchmetrics/wrappers/multitask.py
@@ -20,12 +20,13 @@ from torchmetrics.collections import MetricCollection
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.wrappers.abstract import WrapperMetric
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["MultitaskWrapper.plot"]
 
 
-class MultitaskWrapper(Metric):
+class MultitaskWrapper(WrapperMetric):
     """Wrapper class for computing different metrics on different tasks in the context of multitask learning.
 
     In multitask learning the different tasks requires different metrics to be evaluated. This wrapper allows
@@ -151,14 +152,6 @@ class MultitaskWrapper(Metric):
         for metric in self.task_metrics.values():
             metric.reset()
         super().reset()
-
-    def _wrap_update(self, update: Callable) -> Callable:
-        """Overwrite to do nothing."""
-        return update
-
-    def _wrap_compute(self, compute: Callable) -> Callable:
-        """Overwrite to do nothing."""
-        return compute
 
     def plot(
         self, val: Optional[Union[Dict, Sequence[Dict]]] = None, axes: Optional[Sequence[_AX_TYPE]] = None

--- a/src/torchmetrics/wrappers/running.py
+++ b/src/torchmetrics/wrappers/running.py
@@ -11,19 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Sequence, Union
 
 from torch import Tensor
 
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.wrappers.abstract import WrapperMetric
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["Running.plot"]
 
 
-class Running(Metric):
+class Running(WrapperMetric):
     """Running wrapper for metrics.
 
     Using this wrapper allows for calculating metrics over a running window of values, instead of the whole history of


### PR DESCRIPTION
## What does this PR do?

Fixes #1899 
Add an base class for metric wrappers. Is primary function is to disable functionality which is already handled by the base classes being wrapped. This is already being done in all wrapper classes, so this is just an attempt to formalize it a bit.
We could probably move more to this class over time.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
