### PR TITLE
Fix prefix/postfix interaction between `MetricCollection` and `ClasswiseWrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug related to expected input format of pycoco in `MeanAveragePrecision` ([#1913](https://github.com/Lightning-AI/torchmetrics/pull/1913))
 
 
+- Fixed bug related to the `prefix/postfix` arguments in `MetricCollection` and `ClasswiseWrapper` being duplicated ([#1918](https://github.com/Lightning-AI/torchmetrics/pull/1918))
+
 ## [1.0.0] - 2022-07-04
 
 ### Added

--- a/src/torchmetrics/wrappers/classwise.py
+++ b/src/torchmetrics/wrappers/classwise.py
@@ -128,22 +128,22 @@ class ClasswiseWrapper(Metric):
 
         if prefix is not None and not isinstance(prefix, str):
             raise ValueError(f"Expected argument `prefix` to either be `None` or a string but got {prefix}")
-        self.prefix = prefix
+        self._prefix = prefix
 
         if postfix is not None and not isinstance(postfix, str):
             raise ValueError(f"Expected argument `postfix` to either be `None` or a string but got {postfix}")
-        self.postfix = postfix
+        self._postfix = postfix
 
         self._update_count = 1
 
     def _convert(self, x: Tensor) -> Dict[str, Any]:
         # Will set the class name as prefix if neither prefix nor postfix is given
-        if not self.prefix and not self.postfix:
+        if not self._prefix and not self._postfix:
             prefix = f"{self.metric.__class__.__name__.lower()}_"
             postfix = ""
         else:
-            prefix = self.prefix or ""
-            postfix = self.postfix or ""
+            prefix = self._prefix or ""
+            postfix = self._postfix or ""
         if self.labels is None:
             return {f"{prefix}{i}{postfix}": val for i, val in enumerate(x)}
         return {f"{prefix}{lab}{postfix}": val for lab, val in zip(self.labels, x)}

--- a/tests/unittests/wrappers/test_classwise.py
+++ b/tests/unittests/wrappers/test_classwise.py
@@ -126,6 +126,7 @@ def test_double_use_of_prefix_with_metriccollection():
     """Test that the expected output is produced when using prefix/postfix with metric collection.
 
     See issue: https://github.com/Lightning-AI/torchmetrics/issues/1915
+
     """
     category_names = ["Tree", "Bush"]
     num_classes = len(category_names)

--- a/tests/unittests/wrappers/test_classwise.py
+++ b/tests/unittests/wrappers/test_classwise.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from torchmetrics import MetricCollection
-from torchmetrics.classification import MulticlassAccuracy, MulticlassRecall
+from torchmetrics.classification import MulticlassAccuracy, MulticlassF1Score, MulticlassRecall
 from torchmetrics.wrappers import ClasswiseWrapper
 
 
@@ -120,3 +120,32 @@ def test_using_metriccollection(prefix, postfix):
         assert name in val
         name = _get_correct_name(f"multiclassrecall_{lab}")
         assert name in val
+
+
+def test_double_use_of_prefix_with_metriccollection():
+    """Test that the expected output is produced when using prefix/postfix with metric collection.
+
+    See issue: https://github.com/Lightning-AI/torchmetrics/issues/1915
+    """
+    category_names = ["Tree", "Bush"]
+    num_classes = len(category_names)
+
+    input_ = torch.rand((5, 2, 3, 3))
+    target = torch.ones((5, 2, 3, 3)).long()
+
+    val_metrics = MetricCollection(
+        {
+            "accuracy": MulticlassAccuracy(num_classes=num_classes),
+            "f1": ClasswiseWrapper(
+                MulticlassF1Score(num_classes=num_classes, average="none"),
+                category_names,
+                prefix="f_score_",
+            ),
+        },
+        prefix="val/",
+    )
+
+    res = val_metrics(input_, target)
+    assert "val/accuracy" in res
+    assert "val/f_score_Tree" in res
+    assert "val/f_score_Bush" in res


### PR DESCRIPTION
## What does this PR do?

Fixes #1915
The introduction of `prefix/postfix` (introduced here https://github.com/Lightning-AI/torchmetrics/pull/1866) arguments in `ClasswiseWrapper` had some untested interaction with the same arguments in `MetricCollection`, that leads to the wrong result. PR fixes this with a simple internal renaming and add test.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1918.org.readthedocs.build/en/1918/

<!-- readthedocs-preview torchmetrics end -->