### PR TITLE
docs: include silent images from raw HTML

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,6 +74,7 @@ if SPHINX_FETCH_ASSETS:
         assets_folder="_static/fetched-s3-assets",
         retrieve_pattern=r"https?://[-a-zA-Z0-9_]+\.s3\.[-a-zA-Z0-9()_\\+.\\/=]+",
     )
+    # todo: seems we still have soem icons used in raw HTML missing in final buils
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Post of #1880 as we still have some linked images in fancy raw HTML cards which are not linked anywhere else and sphinx extra include directives are not working...
Alternative/fake include just create empty page with these images
BTW, seems someone else also had similar idea: https://stackoverflow.com/questions/73843297/image-included-via-raw-html-not-showing

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
