### PR TITLE
Fix AttributeError: module 'matplotlib' has no attribute 'axes'

### DIFF
--- a/src/torchmetrics/utilities/plot.py
+++ b/src/torchmetrics/utilities/plot.py
@@ -23,6 +23,7 @@ from torchmetrics.utilities.imports import _LATEX_AVAILABLE, _MATPLOTLIB_AVAILAB
 
 if _MATPLOTLIB_AVAILABLE:
     import matplotlib
+    import matplotlib.axes
     import matplotlib.pyplot as plt
 
     _PLOT_OUT_TYPE = Tuple[plt.Figure, Union[matplotlib.axes.Axes, np.ndarray]]


### PR DESCRIPTION
## What does this PR do?

Fixes `AttributeError: module 'matplotlib' has no attribute 'axes'`

I'm seeing the following error when installing `torchmetrics` along with `matplotlib`:
```
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/__init__.py", line 14, in <module>
    from torchmetrics import functional  # noqa: E402
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/functional/__init__.py", line 14, in <module>
    from torchmetrics.functional.audio._deprecated import _permutation_invariant_training as permutation_invariant_training
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/functional/audio/__init__.py", line 14, in <module>
    from torchmetrics.functional.audio.pit import permutation_invariant_training, pit_permutate
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/functional/audio/pit.py", line 23, in <module>
    from torchmetrics.utilities import rank_zero_warn
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/utilities/__init__.py", line 14, in <module>
    from torchmetrics.utilities.checks import check_forward_full_state_property
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/utilities/checks.py", line 25, in <module>
    from torchmetrics.metric import Metric
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/metric.py", line 42, in <module>
    from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE, plot_single_or_multi_val
  File "/usr/local/lib/python3.10/site-packages/torchmetrics/utilities/plot.py", line 28, in <module>
    _PLOT_OUT_TYPE = Tuple[plt.Figure, Union[matplotlib.axes.Axes, np.ndarray]]
  File "/usr/local/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 226, in __getattr__
    raise AttributeError(
AttributeError: module 'matplotlib' has no attribute 'axes'
```

It looks like `matplotlib.axes` is not imported correctly in the `torchmetrics/utilities/plot.py`.