### PR TITLE
revert sphinx to `5.3` to recover icon with anchor links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,7 @@ if SPHINX_FETCH_ASSETS:
 
 # If your documentation needs a minimal Sphinx version, state it here.
 
-needs_sphinx = "6.2"
+needs_sphinx = "5.3"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx >6.0, <7.0
+sphinx >5.0, <6.0
 myst-parser
 nbsphinx >=0.8
 pandoc >=1.0


### PR DESCRIPTION
## What does this PR do?

Trying to get to state when each section/title had an icon for copy anchor links
Note, the `<a href=#...>` is present still in the code but the fancy icon is missing

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1956.org.readthedocs.build/en/1956/

<!-- readthedocs-preview torchmetrics end -->