### PR TITLE
docs: remove empty `(,,,)` from plots docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,7 +126,8 @@ redirects = {"all-metrics": "pages/all-metrics.html"}
 
 # Set that source code from plotting is always included
 plot_include_source = True
-plot_html_show_source_link = True
+plot_html_show_formats = False
+plot_html_show_source_link = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
## What does this PR do?

Fixes part of #1962 

Removes the (,,,) that are above each plot currently:
![image](https://github.com/Lightning-AI/torchmetrics/assets/24896311/08733729-6504-4e1a-95ae-5bc17e99bfd2)


<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1965.org.readthedocs.build/en/1965/

<!-- readthedocs-preview torchmetrics end -->