### PR TITLE
docs: fix math render with legacy sphinx 5.3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,7 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
-    "sphinx.ext.imgmath",
+    "sphinx.ext.mathjax",
     "myst_parser",
     "sphinx.ext.autosectionlabel",
     "nbsphinx",

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,19 +1,19 @@
-sphinx >5.0, <6.0
-myst-parser
-nbsphinx >=0.8
-pandoc >=1.0
-docutils >=0.16
+sphinx ==5.3.0
+myst-parser ==1.0.0
+nbsphinx ==0.9.2
+pandoc ==2.3
+docutils ==0.19
 sphinxcontrib-fulltoc >=1.0
 sphinxcontrib-mockautodoc
 pt-lightning-sphinx-theme @ https://github.com/Lightning-AI/lightning_sphinx_theme/archive/master.zip
-sphinx-autodoc-typehints >=1.0
-sphinx-paramlinks >=0.5.1
-sphinx-togglebutton >=0.2
-sphinx-copybutton >=0.3
+sphinx-autodoc-typehints ==1.23.0
+sphinx-paramlinks ==0.5.4
+sphinx-togglebutton ==0.3.2
+sphinx-copybutton ==0.5.2
 
-lightning >=1.8.0, <3.0.0
-lightning-utilities >=0.9.0
-pydantic < 2.0.0
+lightning >=1.8.0, <2.1.0
+lightning-utilities >=0.9.0, <0.10.0
+pydantic >1.0.0, < 2.0.0
 
 # integrations
 -r integrate.txt


### PR DESCRIPTION
## What does this PR do?

after reverting sphinx 6.2 to 5.3 rendering math broke... in fact it was created but saved in the wrong folder... so lets replace it with JS 🦩 

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1973.org.readthedocs.build/en/1973/

<!-- readthedocs-preview torchmetrics end -->