### PR TITLE
ci/docs: split links testing and build

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,9 +23,15 @@ env:
   TOKENIZERS_PARALLELISM: false
 
 jobs:
-  make-doctest:
+  make-check:
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        check: [doctest, linkcheck]
+    env:
+      SPHINX_MOCK_REQUIREMENTS: 0
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -46,13 +52,19 @@ jobs:
           pip install . -U -r requirements/docs.txt --find-links $PYPI_CACHE -f $TORCH_URL
           pip list
 
-      - name: Test Documentation
-        env:
-          SPHINX_MOCK_REQUIREMENTS: 0
+      - name: Test Examples in Documentation
+        if: ${{ matrix.check == 'doctest' }}
         working-directory: ./docs
         run: |
           make doctest
           make coverage
+
+      - name: Check External Links
+        if: ${{ matrix.check == 'linkcheck' }}
+        working-directory: ./docs
+        run: make --jobs $(nproc) linkcheck
+        # ToDO: comment on PR if any link failed
+        #continue-on-error: true
 
 
   make-html:
@@ -93,12 +105,6 @@ jobs:
       - name: Make Documentation
         working-directory: ./docs
         run: make html --debug SPHINXOPTS="-W --keep-going"
-
-      - name: Check External Links (Optional)
-        working-directory: ./docs
-        run: make --jobs $(nproc) linkcheck
-        # ToDO: comment on PR if any link failed
-        continue-on-error: true
 
       - name: Upload built docs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## What does this PR do?

with parallelization over links check shall boost build time

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
