### PR TITLE
Fix support for `int` input for samplewise classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix support for int input for when `multidim_average="samplewise"` in classification metrics  ([#1977](https://github.com/Lightning-AI/torchmetrics/pull/1977))
 
 
 ## [1.0.2] - 2023-08-02

--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -374,10 +374,10 @@ def _multiclass_stat_scores_update(
             preds_oh = torch.movedim(select_topk(preds, topk=top_k, dim=1), 1, -1)
         else:
             preds_oh = torch.nn.functional.one_hot(
-                preds, num_classes + 1 if ignore_index is not None and not ignore_in else num_classes
+                preds.long(), num_classes + 1 if ignore_index is not None and not ignore_in else num_classes
             )
         target_oh = torch.nn.functional.one_hot(
-            target, num_classes + 1 if ignore_index is not None and not ignore_in else num_classes
+            target.long(), num_classes + 1 if ignore_index is not None and not ignore_in else num_classes
         )
         if ignore_index is not None:
             if 0 <= ignore_index <= num_classes - 1:

--- a/tests/unittests/classification/test_stat_scores.py
+++ b/tests/unittests/classification/test_stat_scores.py
@@ -542,6 +542,15 @@ class TestMultilabelStatScores(MetricTester):
         )
 
 
+def test_support_for_int():
+    """See issue: https://github.com/Lightning-AI/torchmetrics/issues/1970."""
+    metric = MulticlassStatScores(num_classes=4, average="none", multidim_average="samplewise", ignore_index=0)
+    prediction = torch.randint(low=0, high=4, size=(1, 224, 224)).to(torch.uint8)
+    label = torch.randint(low=0, high=4, size=(1, 224, 224)).to(torch.uint8)
+    score = metric(preds=prediction, target=label)
+    assert score.shape == (1, 4, 5)
+
+
 @pytest.mark.parametrize(
     ("metric", "kwargs"),
     [


### PR DESCRIPTION
## What does this PR do?

Fixes #1970
Missing dtype conversion to make sure that for `multidim_average="samplewise"` works with `int` input.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1977.org.readthedocs.build/en/1977/

<!-- readthedocs-preview torchmetrics end -->