### PR TITLE
Fix external linking in docs

### DIFF
--- a/docs/source/classification/accuracy.rst
+++ b/docs/source/classification/accuracy.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ########
 Accuracy
 ########

--- a/docs/source/classification/average_precision.rst
+++ b/docs/source/classification/average_precision.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 #################
 Average Precision
 #################

--- a/docs/source/classification/exact_match.rst
+++ b/docs/source/classification/exact_match.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ###########
 Exact Match
 ###########

--- a/docs/source/classification/f1_score.rst
+++ b/docs/source/classification/f1_score.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 #########
 F-1 Score
 #########

--- a/docs/source/classification/hamming_distance.rst
+++ b/docs/source/classification/hamming_distance.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ################
 Hamming Distance
 ################

--- a/docs/source/classification/hinge_loss.rst
+++ b/docs/source/classification/hinge_loss.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ##########
 Hinge Loss
 ##########

--- a/docs/source/classification/jaccard_index.rst
+++ b/docs/source/classification/jaccard_index.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 #############
 Jaccard Index
 #############

--- a/docs/source/classification/label_ranking_average_precision.rst
+++ b/docs/source/classification/label_ranking_average_precision.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ###############################
 Label Ranking Average Precision
 ###############################

--- a/docs/source/classification/label_ranking_loss.rst
+++ b/docs/source/classification/label_ranking_loss.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ##################
 Label Ranking Loss
 ##################

--- a/docs/source/classification/precision_at_fixed_recall.rst
+++ b/docs/source/classification/precision_at_fixed_recall.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 #########################
 Precision At Fixed Recall
 #########################

--- a/docs/source/classification/precision_recall_curve.rst
+++ b/docs/source/classification/precision_recall_curve.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ######################
 Precision Recall Curve
 ######################

--- a/docs/source/classification/recall.rst
+++ b/docs/source/classification/recall.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ######
 Recall
 ######

--- a/docs/source/classification/recall_at_fixed_precision.rst
+++ b/docs/source/classification/recall_at_fixed_precision.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 #########################
 Recall At Fixed Precision
 #########################

--- a/docs/source/classification/roc.rst
+++ b/docs/source/classification/roc.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ###
 ROC
 ###

--- a/docs/source/classification/specificity.rst
+++ b/docs/source/classification/specificity.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ###########
 Specificity
 ###########

--- a/docs/source/classification/specificity_at_sensitivity.rst
+++ b/docs/source/classification/specificity_at_sensitivity.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 ##########################
 Specificity At Sensitivity
 ##########################

--- a/docs/source/detection/complete_intersection_over_union.rst
+++ b/docs/source/detection/complete_intersection_over_union.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/object_detection.svg
    :tags: Detection
 
+.. include:: ../links.rst
+
 #######################################
 Complete Intersection Over Union (cIoU)
 #######################################

--- a/docs/source/detection/distance_intersection_over_union.rst
+++ b/docs/source/detection/distance_intersection_over_union.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/object_detection.svg
    :tags: Detection
 
+.. include:: ../links.rst
+
 #######################################
 Distance Intersection Over Union (dIoU)
 #######################################

--- a/docs/source/detection/generalized_intersection_over_union.rst
+++ b/docs/source/detection/generalized_intersection_over_union.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/object_detection.svg
    :tags: Detection
 
+.. include:: ../links.rst
+
 ##########################################
 Generalized Intersection Over Union (gIoU)
 ##########################################

--- a/docs/source/detection/intersection_over_union.rst
+++ b/docs/source/detection/intersection_over_union.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/object_detection.svg
    :tags: Detection
 
+.. include:: ../links.rst
+
 #############################
 Intersection Over Union (IoU)
 #############################

--- a/docs/source/detection/modified_panoptic_quality.rst
+++ b/docs/source/detection/modified_panoptic_quality.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/image_classification.svg
    :tags: Detection
 
+.. include:: ../links.rst
+
 #########################
 Modified Panoptic Quality
 #########################

--- a/docs/source/detection/panoptic_quality.rst
+++ b/docs/source/detection/panoptic_quality.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/image_classification.svg
    :tags: Detection
 
+.. include:: ../links.rst
+
 ################
 Panoptic Quality
 ################

--- a/docs/source/image/learned_perceptual_image_patch_similarity.rst
+++ b/docs/source/image/learned_perceptual_image_patch_similarity.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/image_classification.svg
    :tags: Image
 
+.. include:: ../links.rst
+
 #################################################
 Learned Perceptual Image Patch Similarity (LPIPS)
 #################################################

--- a/docs/source/image/spectral_angle_mapper.rst
+++ b/docs/source/image/spectral_angle_mapper.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/image_classification.svg
    :tags: Image
 
+.. include:: ../links.rst
+
 #####################
 Spectral Angle Mapper
 #####################

--- a/docs/source/multimodal/clip_score.rst
+++ b/docs/source/multimodal/clip_score.rst
@@ -3,9 +3,11 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/image_classification.svg
    :tags: Image
 
-############################################
+.. include:: ../links.rst
+
+##########
 CLIP Score
-############################################
+##########
 
 Module Interface
 ________________

--- a/docs/source/nominal/cramers_v.rst
+++ b/docs/source/nominal/cramers_v.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Nominal
 
+.. include:: ../links.rst
+
 ##########
 Cramer's V
 ##########

--- a/docs/source/nominal/fleiss_kappa.rst
+++ b/docs/source/nominal/fleiss_kappa.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Nominal
 
+.. include:: ../links.rst
+
 ############
 Fleiss Kappa
 ############

--- a/docs/source/nominal/pearsons_contingency_coefficient.rst
+++ b/docs/source/nominal/pearsons_contingency_coefficient.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Nominal
 
+.. include:: ../links.rst
+
 #################################
 Pearson's Contingency Coefficient
 #################################

--- a/docs/source/nominal/theils_u.rst
+++ b/docs/source/nominal/theils_u.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Nominal
 
+.. include:: ../links.rst
+
 #########
 Theil's U
 #########

--- a/docs/source/nominal/tschuprows_t.rst
+++ b/docs/source/nominal/tschuprows_t.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Nominal
 
+.. include:: ../links.rst
+
 #############
 Tschuprow's T
 #############

--- a/docs/source/pairwise/cosine_similarity.rst
+++ b/docs/source/pairwise/cosine_similarity.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/translation.svg
    :tags: Pairwise
 
+.. include:: ../links.rst
+
 #################
 Cosine Similarity
 #################

--- a/docs/source/pairwise/euclidean_distance.rst
+++ b/docs/source/pairwise/euclidean_distance.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/translation.svg
    :tags: Pairwise
 
+.. include:: ../links.rst
+
 ##################
 Euclidean Distance
 ##################

--- a/docs/source/pairwise/linear_similarity.rst
+++ b/docs/source/pairwise/linear_similarity.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/translation.svg
    :tags: Pairwise
 
+.. include:: ../links.rst
+
 #################
 Linear Similarity
 #################

--- a/docs/source/pairwise/manhattan_distance.rst
+++ b/docs/source/pairwise/manhattan_distance.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/translation.svg
    :tags: Pairwise
 
+.. include:: ../links.rst
+
 ##################
 Manhattan Distance
 ##################

--- a/docs/source/pairwise/minkowski_distance.rst
+++ b/docs/source/pairwise/minkowski_distance.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/translation.svg
    :tags: Pairwise
 
+.. include:: ../links.rst
+
 ##################
 Minkowski Distance
 ##################

--- a/docs/source/regression/cosine_similarity.rst
+++ b/docs/source/regression/cosine_similarity.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Regression
 
+.. include:: ../links.rst
+
 #################
 Cosine Similarity
 #################

--- a/docs/source/regression/explained_variance.rst
+++ b/docs/source/regression/explained_variance.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Regression
 
+.. include:: ../links.rst
+
 ##################
 Explained Variance
 ##################

--- a/docs/source/regression/kl_divergence.rst
+++ b/docs/source/regression/kl_divergence.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Classification
 
+.. include:: ../links.rst
+
 #############
 KL Divergence
 #############

--- a/docs/source/regression/tweedie_deviance_score.rst
+++ b/docs/source/regression/tweedie_deviance_score.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/tabular_classification.svg
    :tags: Regression
 
+.. include:: ../links.rst
+
 ######################
 Tweedie Deviance Score
 ######################

--- a/docs/source/retrieval/hit_rate.rst
+++ b/docs/source/retrieval/hit_rate.rst
@@ -3,6 +3,8 @@
    :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/text_classification.svg
    :tags: Retrieval
 
+.. include:: ../links.rst
+
 ##################
 Retrieval Hit Rate
 ##################


### PR DESCRIPTION
## What does this PR do?

Fixes part of #1962

Many pages that have external links does currently not work, and they are just self-referential.
Take accuracy as an example:
https://torchmetrics.readthedocs.io/en/stable/classification/accuracy.html
when clicking on the the external link that should redirect to wikipedia, it just refers to the page.
They are simply missing linking to the `links.rst` file.

The reason docs builds are not failing is when we have a link in `links.rst` like:
```
.. _Accuracy: https://en.wikipedia.org/wiki/Accuracy_and_precision
```
that share the exact same name as one of the headers on the given page (which often happens because it is the same metric), thus sphinx just thinks we are referring to the header.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1980.org.readthedocs.build/en/1980/

<!-- readthedocs-preview torchmetrics end -->