### PR TITLE
iou compute in cuda fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed IOU compute in cuda ([#1982](https://github.com/Lightning-AI/torchmetrics/pull/1982))
 
 
 ## [1.0.2] - 2023-08-02

--- a/src/torchmetrics/functional/detection/iou.py
+++ b/src/torchmetrics/functional/detection/iou.py
@@ -38,7 +38,7 @@ def _iou_update(
 def _iou_compute(iou: torch.Tensor, labels_eq: bool = True) -> torch.Tensor:
     if labels_eq:
         return iou.diag().mean()
-    return iou.mean() if iou.numel() > 0 else torch.tensor(0.0)
+    return iou.mean() if iou.numel() > 0 else torch.tensor(0.0).to(iou.device)
 
 
 def intersection_over_union(


### PR DESCRIPTION
the `_iou_compute` function does not adhere to the device of the original tensor in the case of when it is returning `0.0`.

So, by adding `.to(iou.device)` to `torch.tensor(0.0)`, this can be fixed.

<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1982.org.readthedocs.build/en/1982/

<!-- readthedocs-preview torchmetrics end -->