### PR TITLE
enable pygrep-hooks with precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,10 +71,21 @@ repos:
               docs/paper_JOSS/paper.md
           )$
 
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.5.0
+    hooks:
+      - id: yesqa
+        additional_dependencies:
+          - pep8-naming
+          - flake8-pytest-style
+          - flake8-bandit
+          - flake8-builtins
+          - flake8-bugbear
+
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-      # Enforce that # type: ignore annotations always occur with specific codes. Sample annotations: # type: ignore[attr-defined], # type: ignore[attr-defined, name-def
+      # Enforce that noqa annotations always occur with specific codes. Sample annotations: # noqa: F401, # noqa: F401,W203
       - id: python-check-blanket-noqa
       # Enforce that # type: ignore annotations always occur with specific codes. Sample annotations: # type: ignore[attr-defined], # type: ignore[attr-defined, name-defined]
       #- id: python-check-blanket-type-ignore  # TODO

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,16 +71,29 @@ repos:
               docs/paper_JOSS/paper.md
           )$
 
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.5.0
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
     hooks:
-      - id: yesqa
-        additional_dependencies:
-          - pep8-naming
-          - flake8-pytest-style
-          - flake8-bandit
-          - flake8-builtins
-          - flake8-bugbear
+      # Enforce that # type: ignore annotations always occur with specific codes. Sample annotations: # type: ignore[attr-defined], # type: ignore[attr-defined, name-def
+      - id: python-check-blanket-noqa
+      # Enforce that # type: ignore annotations always occur with specific codes. Sample annotations: # type: ignore[attr-defined], # type: ignore[attr-defined, name-defined]
+      #- id: python-check-blanket-type-ignore  # TODO
+      # Prevent common mistakes of assert mck.not_called(), assert mck.called_once_with(...) and mck.assert_called.
+      - id: python-check-mock-methods
+      # A quick check for the eval() built-in function
+      #- id: python-no-eval broken check - https://github.com/pre-commit/pygrep-hooks/issues/135
+      # A quick check for the deprecated .warn() method of python loggers
+      - id: python-no-log-warn
+      # Enforce that python3.6+ type annotations are used instead of type comments
+      #- id: python-use-type-annotations # false positive - https://github.com/pre-commit/pygrep-hooks/issues/154
+      # Detect common mistake of using single backticks when writing rst
+      #- id: rst-backticks  # todo
+      # Detect mistake of rst directive not ending with double colon or space before the double colon
+      - id: rst-directive-colons
+      # Detect mistake of inline code touching normal text in rst
+      - id: rst-inline-touching-normal
+      # Forbid files which have a UTF-8 Unicode replacement character
+      - id: text-unicode-replacement-char
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.277

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -868,7 +868,7 @@ class Metric(Module, ABC):
     def _filter_kwargs(self, **kwargs: Any) -> Dict[str, Any]:
         """Filter kwargs such that they match the update signature of the metric."""
         # filter all parameters based on update signature except those of
-        # type VAR_POSITIONAL (*args) and VAR_KEYWORD (**kwargs)
+        # types `VAR_POSITIONAL` for `* args` and `VAR_KEYWORD` for `** kwargs`
         _params = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
         _sign_params = self._update_signature.parameters
         filtered_kwargs = {


### PR DESCRIPTION
## What does this PR do?

it may improve our codebase, but:
- can't use `eval` check because false positive https://github.com/pre-commit/pygrep-hooks/issues/135
- not sure how to satisfy `use-type-annotations` because of https://github.com/pre-commit/pygrep-hooks/issues/154
- [ ] need to fix to broad ignore statement
- the `rst-backticks` shall be addressed together with #1916 

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1992.org.readthedocs.build/en/1992/

<!-- readthedocs-preview torchmetrics end -->