### PR TITLE
Remove noindex for docs

### DIFF
--- a/docs/source/aggregation/cat.rst
+++ b/docs/source/aggregation/cat.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.aggregation.CatMetric
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/max.rst
+++ b/docs/source/aggregation/max.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.aggregation.MaxMetric
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/mean.rst
+++ b/docs/source/aggregation/mean.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.aggregation.MeanMetric
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/min.rst
+++ b/docs/source/aggregation/min.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.aggregation.MinMetric
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/running_mean.rst
+++ b/docs/source/aggregation/running_mean.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.aggregation.RunningMean
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/running_sum.rst
+++ b/docs/source/aggregation/running_sum.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.aggregation.RunningSum
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/aggregation/sum.rst
+++ b/docs/source/aggregation/sum.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.aggregation.SumMetric
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/audio/complex_scale_invariant_signal_noise_ratio.rst
+++ b/docs/source/audio/complex_scale_invariant_signal_noise_ratio.rst
@@ -13,6 +13,7 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.ComplexScaleInvariantSignalNoiseRatio
+
 Functional Interface
 ____________________
 

--- a/docs/source/audio/complex_scale_invariant_signal_noise_ratio.rst
+++ b/docs/source/audio/complex_scale_invariant_signal_noise_ratio.rst
@@ -13,6 +13,7 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.ComplexScaleInvariantSignalNoiseRatio
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/audio/complex_scale_invariant_signal_noise_ratio.rst
+++ b/docs/source/audio/complex_scale_invariant_signal_noise_ratio.rst
@@ -13,11 +13,7 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.ComplexScaleInvariantSignalNoiseRatio
-    :noindex:
-    :exclude-members: update, compute
-
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.complex_scale_invariant_signal_noise_ratio
-    :noindex:

--- a/docs/source/audio/perceptual_evaluation_speech_quality.rst
+++ b/docs/source/audio/perceptual_evaluation_speech_quality.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.pesq.PerceptualEvaluationSpeechQuality
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.pesq.perceptual_evaluation_speech_quality
-    :noindex:

--- a/docs/source/audio/permutation_invariant_training.rst
+++ b/docs/source/audio/permutation_invariant_training.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.PermutationInvariantTraining
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.permutation_invariant_training
-    :noindex:

--- a/docs/source/audio/scale_invariant_signal_distortion_ratio.rst
+++ b/docs/source/audio/scale_invariant_signal_distortion_ratio.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.ScaleInvariantSignalDistortionRatio
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.scale_invariant_signal_distortion_ratio
-    :noindex:

--- a/docs/source/audio/scale_invariant_signal_noise_ratio.rst
+++ b/docs/source/audio/scale_invariant_signal_noise_ratio.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.ScaleInvariantSignalNoiseRatio
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.scale_invariant_signal_noise_ratio
-    :noindex:

--- a/docs/source/audio/short_time_objective_intelligibility.rst
+++ b/docs/source/audio/short_time_objective_intelligibility.rst
@@ -13,11 +13,8 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.stoi.ShortTimeObjectiveIntelligibility
-    :noindex:
-    :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.stoi.short_time_objective_intelligibility
-    :noindex:

--- a/docs/source/audio/signal_distortion_ratio.rst
+++ b/docs/source/audio/signal_distortion_ratio.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.SignalDistortionRatio
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.signal_distortion_ratio
-    :noindex:

--- a/docs/source/audio/signal_noise_ratio.rst
+++ b/docs/source/audio/signal_noise_ratio.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.SignalNoiseRatio
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.signal_noise_ratio
-    :noindex:

--- a/docs/source/audio/source_aggregated_signal_distortion_ratio.rst
+++ b/docs/source/audio/source_aggregated_signal_distortion_ratio.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.sdr.SourceAggregatedSignalDistortionRatio
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.sdr.source_aggregated_signal_distortion_ratio
-    :noindex:

--- a/docs/source/audio/speech_reverberation_modulation_energy_ratio.rst
+++ b/docs/source/audio/speech_reverberation_modulation_energy_ratio.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.audio.srmr.SpeechReverberationModulationEnergyRatio
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.audio.srmr.speech_reverberation_modulation_energy_ratio
-    :noindex:

--- a/docs/source/classification/accuracy.rst
+++ b/docs/source/classification/accuracy.rst
@@ -13,52 +13,33 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.Accuracy
-    :noindex:
-    :exclude-members: update, compute
-    :special-members: __new__
-
-BinaryAccuracy
-^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryAccuracy
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassAccuracy
 ^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: torchmetrics.classification.MulticlassAccuracy
-    :noindex:
-    :exclude-members: update, compute
 
 MultilabelAccuracy
 ^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelAccuracy
-    :noindex:
     :exclude-members: update, compute
-
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.classification.accuracy
-    :noindex:
 
 binary_accuracy
-^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_accuracy
-    :noindex:
 
 multiclass_accuracy
 ^^^^^^^^^^^^^^^^^^^
-
 .. autofunction:: torchmetrics.functional.classification.multiclass_accuracy
-    :noindex:
 
 
 multilabel_accuracy
 ^^^^^^^^^^^^^^^^^^^
-
 .. autofunction:: torchmetrics.functional.classification.multilabel_accuracy
-    :noindex:

--- a/docs/source/classification/accuracy.rst
+++ b/docs/source/classification/accuracy.rst
@@ -13,6 +13,11 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.Accuracy
+    :exclude-members: update, compute
+    :special-members: __new__
+
+BinaryAccuracy
+^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryAccuracy
     :exclude-members: update, compute
@@ -20,26 +25,31 @@ ________________
 MulticlassAccuracy
 ^^^^^^^^^^^^^^^^^^
 
+.. autoclass:: torchmetrics.classification.MulticlassAccuracy
+    :exclude-members: update, compute
 
 MultilabelAccuracy
 ^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelAccuracy
     :exclude-members: update, compute
+
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.classification.accuracy
 
 binary_accuracy
+^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_accuracy
 
 multiclass_accuracy
 ^^^^^^^^^^^^^^^^^^^
-.. autofunction:: torchmetrics.functional.classification.multiclass_accuracy
 
+.. autofunction:: torchmetrics.functional.classification.multiclass_accuracy
 
 multilabel_accuracy
 ^^^^^^^^^^^^^^^^^^^
+
 .. autofunction:: torchmetrics.functional.classification.multilabel_accuracy

--- a/docs/source/classification/auroc.rst
+++ b/docs/source/classification/auroc.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.AUROC
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,43 +20,36 @@ BinaryAUROC
 ^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryAUROC
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassAUROC
 ^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassAUROC
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelAUROC
 ^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelAUROC
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.auroc
-    :noindex:
 
 binary_auroc
 ^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_auroc
-    :noindex:
 
 multiclass_auroc
 ^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_auroc
-    :noindex:
 
 multilabel_auroc
 ^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_auroc
-    :noindex:

--- a/docs/source/classification/average_precision.rst
+++ b/docs/source/classification/average_precision.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.AveragePrecision
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,43 +20,36 @@ BinaryAveragePrecision
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryAveragePrecision
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassAveragePrecision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassAveragePrecision
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelAveragePrecision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelAveragePrecision
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.average_precision
-    :noindex:
 
 binary_average_precision
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_average_precision
-    :noindex:
 
 multiclass_average_precision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_average_precision
-    :noindex:
 
 multilabel_average_precision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_average_precision
-    :noindex:

--- a/docs/source/classification/calibration_error.rst
+++ b/docs/source/classification/calibration_error.rst
@@ -13,6 +13,7 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.CalibrationError
+    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -26,12 +27,19 @@ MulticlassCalibrationError
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassCalibrationError
+    :exclude-members: update, compute
+
+Functional Interface
+____________________
+
 .. autofunction:: torchmetrics.functional.calibration_error
 
+binary_calibration_error
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-
+.. autofunction:: torchmetrics.functional.classification.binary_calibration_error
 
 multiclass_calibration_error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_calibration_error

--- a/docs/source/classification/calibration_error.rst
+++ b/docs/source/classification/calibration_error.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.CalibrationError
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,30 +20,18 @@ BinaryCalibrationError
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryCalibrationError
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassCalibrationError
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassCalibrationError
-    :noindex:
-    :exclude-members: update, compute
-
-Functional Interface
-____________________
-
 .. autofunction:: torchmetrics.functional.calibration_error
-    :noindex:
 
-binary_calibration_error
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autofunction:: torchmetrics.functional.classification.binary_calibration_error
-    :noindex:
+
 
 multiclass_calibration_error
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_calibration_error
-    :noindex:

--- a/docs/source/classification/cohen_kappa.rst
+++ b/docs/source/classification/cohen_kappa.rst
@@ -13,6 +13,7 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.CohenKappa
+    :exclude-members: update, compute
     :special-members: __new__
 
 BinaryCohenKappa
@@ -25,14 +26,22 @@ MulticlassCohenKappa
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassCohenKappa
+    :exclude-members: update, compute
+
+Functional Interface
+____________________
+
+cohen_kappa
 ^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.cohen_kappa
 
+binary_cohen_kappa
 ^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_cohen_kappa
 
 multiclass_cohen_kappa
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_cohen_kappa

--- a/docs/source/classification/cohen_kappa.rst
+++ b/docs/source/classification/cohen_kappa.rst
@@ -13,41 +13,26 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.CohenKappa
-    :noindex:
-    :exclude-members: update, compute
     :special-members: __new__
 
 BinaryCohenKappa
 ^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryCohenKappa
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassCohenKappa
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassCohenKappa
-    :noindex:
-    :exclude-members: update, compute
-
-Functional Interface
-____________________
-
-cohen_kappa
 ^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.cohen_kappa
-    :noindex:
 
-binary_cohen_kappa
 ^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_cohen_kappa
-    :noindex:
 
 multiclass_cohen_kappa
-^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_cohen_kappa
-    :noindex:

--- a/docs/source/classification/confusion_matrix.rst
+++ b/docs/source/classification/confusion_matrix.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.ConfusionMatrix
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryConfusionMatrix
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryConfusionMatrix
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassConfusionMatrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassConfusionMatrix
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelConfusionMatrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelConfusionMatrix
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,22 +41,18 @@ confusion_matrix
 ^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.confusion_matrix
-    :noindex:
 
 binary_confusion_matrix
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_confusion_matrix
-    :noindex:
 
 multiclass_confusion_matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_confusion_matrix
-    :noindex:
 
 multilabel_confusion_matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_confusion_matrix
-    :noindex:

--- a/docs/source/classification/coverage_error.rst
+++ b/docs/source/classification/coverage_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.classification.MultilabelCoverageError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_coverage_error
-    :noindex:

--- a/docs/source/classification/dice.rst
+++ b/docs/source/classification/dice.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.Dice
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.dice
-    :noindex:

--- a/docs/source/classification/exact_match.rst
+++ b/docs/source/classification/exact_match.rst
@@ -33,9 +33,9 @@ Functional Interface
 ____________________
 
 exact_match
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^
 
-.. autofunction:: torchmetrics.functional.classification.multilabel_exact_match
+.. autofunction:: torchmetrics.functional.classification.exact_match
 
 multiclass_exact_match
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/classification/exact_match.rst
+++ b/docs/source/classification/exact_match.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.ExactMatch
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,14 +20,12 @@ MulticlassExactMatch
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassExactMatch
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelExactMatch
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelExactMatch
-    :noindex:
     :exclude-members: update, compute
 
 
@@ -39,16 +36,13 @@ exact_match
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_exact_match
-    :noindex:
 
 multiclass_exact_match
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_exact_match
-    :noindex:
 
 multilabel_exact_match
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_exact_match
-    :noindex:

--- a/docs/source/classification/f1_score.rst
+++ b/docs/source/classification/f1_score.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.F1Score
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryF1Score
 ^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryF1Score
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassF1Score
 ^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassF1Score
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelF1Score
 ^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelF1Score
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,22 +41,18 @@ f1_score
 ^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.f1_score
-    :noindex:
 
 binary_f1_score
 ^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_f1_score
-    :noindex:
 
 multiclass_f1_score
 ^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_f1_score
-    :noindex:
 
 multilabel_f1_score
 ^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_f1_score
-    :noindex:

--- a/docs/source/classification/fbeta_score.rst
+++ b/docs/source/classification/fbeta_score.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.FBetaScore
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryFBetaScore
 ^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryFBetaScore
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassFBetaScore
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassFBetaScore
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelFBetaScore
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelFBetaScore
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,22 +41,18 @@ fbeta_score
 ^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.fbeta_score
-    :noindex:
 
 binary_fbeta_score
 ^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_fbeta_score
-    :noindex:
 
 multiclass_fbeta_score
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_fbeta_score
-    :noindex:
 
 multilabel_fbeta_score
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_fbeta_score
-    :noindex:

--- a/docs/source/classification/group_fairness.rst
+++ b/docs/source/classification/group_fairness.rst
@@ -16,14 +16,12 @@ BinaryFairness
 ^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryFairness
-    :noindex:
     :exclude-members: update, compute
 
 BinaryGroupStatRates
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryGroupStatRates
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -33,22 +31,18 @@ binary_fairness
 ^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_fairness
-    :noindex:
 
 demographic_parity
 ^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.demographic_parity
-    :noindex:
 
 equal_opportunity
 ^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.equal_opportunity
-    :noindex:
 
 binary_groups_stat_rates
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_groups_stat_rates
-    :noindex:

--- a/docs/source/classification/hamming_distance.rst
+++ b/docs/source/classification/hamming_distance.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.HammingDistance
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryHammingDistance
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryHammingDistance
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassHammingDistance
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassHammingDistance
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelHammingDistance
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelHammingDistance
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,22 +41,18 @@ hamming_distance
 ^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.hamming_distance
-    :noindex:
 
 binary_hamming_distance
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_hamming_distance
-    :noindex:
 
 multiclass_hamming_distance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_hamming_distance
-    :noindex:
 
 multilabel_hamming_distance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_hamming_distance
-    :noindex:

--- a/docs/source/classification/hinge_loss.rst
+++ b/docs/source/classification/hinge_loss.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.HingeLoss
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,30 +20,25 @@ BinaryHingeLoss
 ^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryHingeLoss
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassHingeLoss
 ^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassHingeLoss
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.hinge_loss
-    :noindex:
 
 binary_hinge_loss
 ^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_hinge_loss
-    :noindex:
 
 multiclass_hinge_loss
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_hinge_loss
-    :noindex:

--- a/docs/source/classification/jaccard_index.rst
+++ b/docs/source/classification/jaccard_index.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.JaccardIndex
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryJaccardIndex
 ^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryJaccardIndex
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassJaccardIndex
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassJaccardIndex
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelJaccardIndex
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelJaccardIndex
-    :noindex:
     :exclude-members: update, compute
 
 
@@ -46,22 +42,18 @@ jaccard_index
 ^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.jaccard_index
-    :noindex:
 
 binary_jaccard_index
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_jaccard_index
-    :noindex:
 
 multiclass_jaccard_index
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_jaccard_index
-    :noindex:
 
 multilabel_jaccard_index
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_jaccard_index
-    :noindex:

--- a/docs/source/classification/label_ranking_average_precision.rst
+++ b/docs/source/classification/label_ranking_average_precision.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.classification.MultilabelRankingAveragePrecision
-    :noindex:
     :exclude-members: update, compute
 
 
@@ -21,4 +20,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_ranking_average_precision
-    :noindex:

--- a/docs/source/classification/label_ranking_loss.rst
+++ b/docs/source/classification/label_ranking_loss.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.classification.MultilabelRankingLoss
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_ranking_loss
-    :noindex:

--- a/docs/source/classification/matthews_corr_coef.rst
+++ b/docs/source/classification/matthews_corr_coef.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.MatthewsCorrCoef
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryMatthewsCorrCoef
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryMatthewsCorrCoef
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassMatthewsCorrCoef
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassMatthewsCorrCoef
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelMatthewsCorrCoef
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelMatthewsCorrCoef
-    :noindex:
     :exclude-members: update, compute
 
 
@@ -46,22 +42,18 @@ matthews_corrcoef
 ^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.matthews_corrcoef
-    :noindex:
 
 binary_matthews_corrcoef
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_matthews_corrcoef
-    :noindex:
 
 multiclass_matthews_corrcoef
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_matthews_corrcoef
-    :noindex:
 
 multilabel_matthews_corrcoef
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_matthews_corrcoef
-    :noindex:

--- a/docs/source/classification/precision.rst
+++ b/docs/source/classification/precision.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.Precision
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,43 +20,36 @@ BinaryPrecision
 ^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryPrecision
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassPrecision
 ^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassPrecision
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelPrecision
 ^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelPrecision
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.precision
-    :noindex:
 
 binary_precision
 ^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_precision
-    :noindex:
 
 multiclass_precision
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_precision
-    :noindex:
 
 multilabel_precision
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_precision
-    :noindex:

--- a/docs/source/classification/precision_at_fixed_recall.rst
+++ b/docs/source/classification/precision_at_fixed_recall.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.PrecisionAtFixedRecall
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryPrecisionAtFixedRecall
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryPrecisionAtFixedRecall
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassPrecisionAtFixedRecall
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassPrecisionAtFixedRecall
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelPrecisionAtFixedRecall
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelPrecisionAtFixedRecall
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,16 +41,13 @@ binary_precision_at_fixed_recall
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_precision_at_fixed_recall
-    :noindex:
 
 multiclass_precision_at_fixed_recall
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_precision_at_fixed_recall
-    :noindex:
 
 multilabel_precision_at_fixed_recall
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_precision_at_fixed_recall
-    :noindex:

--- a/docs/source/classification/precision_recall_curve.rst
+++ b/docs/source/classification/precision_recall_curve.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.PrecisionRecallCurve
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,43 +20,36 @@ BinaryPrecisionRecallCurve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryPrecisionRecallCurve
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassPrecisionRecallCurve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassPrecisionRecallCurve
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelPrecisionRecallCurve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelPrecisionRecallCurve
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.precision_recall_curve
-    :noindex:
 
 binary_precision_recall_curve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_precision_recall_curve
-    :noindex:
 
 multiclass_precision_recall_curve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_precision_recall_curve
-    :noindex:
 
 multilabel_precision_recall_curve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_precision_recall_curve
-    :noindex:

--- a/docs/source/classification/recall.rst
+++ b/docs/source/classification/recall.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.Recall
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,43 +20,36 @@ BinaryRecall
 ^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryRecall
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassRecall
 ^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassRecall
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelRecall
 ^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelRecall
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.recall
-    :noindex:
 
 binary_recall
 ^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_recall
-    :noindex:
 
 multiclass_recall
 ^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_recall
-    :noindex:
 
 multilabel_recall
 ^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_recall
-    :noindex:

--- a/docs/source/classification/recall_at_fixed_precision.rst
+++ b/docs/source/classification/recall_at_fixed_precision.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.RecallAtFixedPrecision
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryRecallAtFixedPrecision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryRecallAtFixedPrecision
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassRecallAtFixedPrecision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassRecallAtFixedPrecision
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelRecallAtFixedPrecision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelRecallAtFixedPrecision
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,16 +41,13 @@ binary_recall_at_fixed_precision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_recall_at_fixed_precision
-    :noindex:
 
 multiclass_recall_at_fixed_precision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_recall_at_fixed_precision
-    :noindex:
 
 multilabel_recall_at_fixed_precision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_recall_at_fixed_precision
-    :noindex:

--- a/docs/source/classification/roc.rst
+++ b/docs/source/classification/roc.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.ROC
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,43 +20,36 @@ BinaryROC
 ^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryROC
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassROC
 ^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassROC
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelROC
 ^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelROC
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.roc
-    :noindex:
 
 binary_roc
 ^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_roc
-    :noindex:
 
 multiclass_roc
 ^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_roc
-    :noindex:
 
 multilabel_roc
 ^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_roc
-    :noindex:

--- a/docs/source/classification/specificity.rst
+++ b/docs/source/classification/specificity.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.Specificity
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinarySpecificity
 ^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinarySpecificity
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassSpecificity
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassSpecificity
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelSpecificity
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelSpecificity
-    :noindex:
     :exclude-members: update, compute
 
 
@@ -43,22 +39,18 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.specificity
-    :noindex:
 
 binary_specificity
 ^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_specificity
-    :noindex:
 
 multiclass_specificity
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_specificity
-    :noindex:
 
 multilabel_specificity
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_specificity
-    :noindex:

--- a/docs/source/classification/specificity_at_sensitivity.rst
+++ b/docs/source/classification/specificity_at_sensitivity.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.SpecificityAtSensitivity
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinarySpecificityAtSensitivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinarySpecificityAtSensitivity
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassSpecificityAtSensitivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassSpecificityAtSensitivity
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelSpecificityAtSensitivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelSpecificityAtSensitivity
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,16 +41,13 @@ binary_specificity_at_sensitivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_specificity_at_sensitivity
-    :noindex:
 
 multiclass_specificity_at_sensitivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_specificity_at_sensitivity
-    :noindex:
 
 multilabel_specificity_at_sensitivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_specificity_at_sensitivity
-    :noindex:

--- a/docs/source/classification/stat_scores.rst
+++ b/docs/source/classification/stat_scores.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.StatScores
-    :noindex:
     :exclude-members: update, compute
     :special-members: __new__
 
@@ -21,21 +20,18 @@ BinaryStatScores
 ^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.BinaryStatScores
-    :noindex:
     :exclude-members: update, compute
 
 MulticlassStatScores
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MulticlassStatScores
-    :noindex:
     :exclude-members: update, compute
 
 MultilabelStatScores
 ^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.classification.MultilabelStatScores
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
@@ -45,22 +41,18 @@ stat_scores
 ^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.stat_scores
-    :noindex:
 
 binary_stat_scores
 ^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.binary_stat_scores
-    :noindex:
 
 multiclass_stat_scores
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multiclass_stat_scores
-    :noindex:
 
 multilabel_stat_scores
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.classification.multilabel_stat_scores
-    :noindex:

--- a/docs/source/detection/complete_intersection_over_union.rst
+++ b/docs/source/detection/complete_intersection_over_union.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.detection.ciou.CompleteIntersectionOverUnion
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.detection.ciou.complete_intersection_over_union
-    :noindex:

--- a/docs/source/detection/distance_intersection_over_union.rst
+++ b/docs/source/detection/distance_intersection_over_union.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.detection.diou.DistanceIntersectionOverUnion
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.detection.diou.distance_intersection_over_union
-    :noindex:

--- a/docs/source/detection/generalized_intersection_over_union.rst
+++ b/docs/source/detection/generalized_intersection_over_union.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.detection.giou.GeneralizedIntersectionOverUnion
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.detection.giou.generalized_intersection_over_union
-    :noindex:

--- a/docs/source/detection/intersection_over_union.rst
+++ b/docs/source/detection/intersection_over_union.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.detection.iou.IntersectionOverUnion
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.detection.iou.intersection_over_union
-    :noindex:

--- a/docs/source/detection/mean_average_precision.rst
+++ b/docs/source/detection/mean_average_precision.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.detection.mean_ap.MeanAveragePrecision
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/detection/modified_panoptic_quality.rst
+++ b/docs/source/detection/modified_panoptic_quality.rst
@@ -15,11 +15,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.detection.ModifiedPanopticQuality
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.detection.modified_panoptic_quality
-    :noindex:

--- a/docs/source/detection/panoptic_quality.rst
+++ b/docs/source/detection/panoptic_quality.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.detection.PanopticQuality
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.detection.panoptic_quality
-    :noindex:

--- a/docs/source/image/error_relative_global_dimensionless_synthesis.rst
+++ b/docs/source/image/error_relative_global_dimensionless_synthesis.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.ErrorRelativeGlobalDimensionlessSynthesis
-    :noindex:
     :exclude-members: update, compute
 
 
@@ -21,4 +20,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.error_relative_global_dimensionless_synthesis
-    :noindex:

--- a/docs/source/image/frechet_inception_distance.rst
+++ b/docs/source/image/frechet_inception_distance.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.fid.FrechetInceptionDistance
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/image/image_gradients.rst
+++ b/docs/source/image/image_gradients.rst
@@ -13,4 +13,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.image_gradients
-    :noindex:

--- a/docs/source/image/inception_score.rst
+++ b/docs/source/image/inception_score.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.inception.InceptionScore
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/image/kernel_inception_distance.rst
+++ b/docs/source/image/kernel_inception_distance.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.kid.KernelInceptionDistance
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/image/learned_perceptual_image_patch_similarity.rst
+++ b/docs/source/image/learned_perceptual_image_patch_similarity.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.lpip.LearnedPerceptualImagePatchSimilarity
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.learned_perceptual_image_patch_similarity
-    :noindex:

--- a/docs/source/image/mifid.rst
+++ b/docs/source/image/mifid.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.mifid.MemorizationInformedFrechetInceptionDistance
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/image/multi_scale_structural_similarity.rst
+++ b/docs/source/image/multi_scale_structural_similarity.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.MultiScaleStructuralSimilarityIndexMeasure
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.multiscale_structural_similarity_index_measure
-    :noindex:

--- a/docs/source/image/peak_signal_noise_ratio.rst
+++ b/docs/source/image/peak_signal_noise_ratio.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.PeakSignalNoiseRatio
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.peak_signal_noise_ratio
-    :noindex:

--- a/docs/source/image/peak_signal_to_noise_with_block.rst
+++ b/docs/source/image/peak_signal_to_noise_with_block.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.PeakSignalNoiseRatioWithBlockedEffect
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.peak_signal_noise_ratio_with_blocked_effect
-    :noindex:

--- a/docs/source/image/perceptual_path_length.rst
+++ b/docs/source/image/perceptual_path_length.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.perceptual_path_length.PerceptualPathLength
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.perceptual_path_length.perceptual_path_length
-    :noindex:

--- a/docs/source/image/relative_average_spectral_error.rst
+++ b/docs/source/image/relative_average_spectral_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.RelativeAverageSpectralError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.relative_average_spectral_error
-    :noindex:

--- a/docs/source/image/root_mean_squared_error_using_sliding_window.rst
+++ b/docs/source/image/root_mean_squared_error_using_sliding_window.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.RootMeanSquaredErrorUsingSlidingWindow
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.root_mean_squared_error_using_sliding_window
-    :noindex:

--- a/docs/source/image/spectral_angle_mapper.rst
+++ b/docs/source/image/spectral_angle_mapper.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.SpectralAngleMapper
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.spectral_angle_mapper
-    :noindex:

--- a/docs/source/image/spectral_distortion_index.rst
+++ b/docs/source/image/spectral_distortion_index.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.SpectralDistortionIndex
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface

--- a/docs/source/image/structural_similarity.rst
+++ b/docs/source/image/structural_similarity.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.StructuralSimilarityIndexMeasure
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.structural_similarity_index_measure
-    :noindex:

--- a/docs/source/image/total_variation.rst
+++ b/docs/source/image/total_variation.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.TotalVariation
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.total_variation
-    :noindex:

--- a/docs/source/image/universal_image_quality_index.rst
+++ b/docs/source/image/universal_image_quality_index.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.UniversalImageQualityIndex
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.universal_image_quality_index
-    :noindex:

--- a/docs/source/image/visual_information_fidelity.rst
+++ b/docs/source/image/visual_information_fidelity.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.image.VisualInformationFidelity
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.image.visual_information_fidelity
-    :noindex:

--- a/docs/source/multimodal/clip_score.rst
+++ b/docs/source/multimodal/clip_score.rst
@@ -13,10 +13,8 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.multimodal.clip_score.CLIPScore
-    :noindex:
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.multimodal.clip_score.clip_score
-    :noindex:

--- a/docs/source/nominal/cramers_v.rst
+++ b/docs/source/nominal/cramers_v.rst
@@ -13,17 +13,14 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.nominal.CramersV
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.nominal.cramers_v
-    :noindex:
 
 cramers_v_matrix
 ^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.nominal.cramers_v_matrix
-    :noindex:

--- a/docs/source/nominal/fleiss_kappa.rst
+++ b/docs/source/nominal/fleiss_kappa.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.nominal.FleissKappa
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.nominal.fleiss_kappa
-    :noindex:

--- a/docs/source/nominal/pearsons_contingency_coefficient.rst
+++ b/docs/source/nominal/pearsons_contingency_coefficient.rst
@@ -13,17 +13,14 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.nominal.PearsonsContingencyCoefficient
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.nominal.pearsons_contingency_coefficient
-    :noindex:
 
 pearsons_contingency_coefficient_matrix
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.nominal.pearsons_contingency_coefficient_matrix
-    :noindex:

--- a/docs/source/nominal/theils_u.rst
+++ b/docs/source/nominal/theils_u.rst
@@ -13,17 +13,14 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.nominal.TheilsU
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.nominal.theils_u
-    :noindex:
 
 theils_u_matrix
 ^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.nominal.theils_u_matrix
-    :noindex:

--- a/docs/source/nominal/tschuprows_t.rst
+++ b/docs/source/nominal/tschuprows_t.rst
@@ -13,17 +13,14 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.nominal.TschuprowsT
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.nominal.tschuprows_t
-    :noindex:
 
 tschuprows_t_matrix
 ^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: torchmetrics.functional.nominal.tschuprows_t_matrix
-    :noindex:

--- a/docs/source/pages/implement.rst
+++ b/docs/source/pages/implement.rst
@@ -138,6 +138,7 @@ both ``True`` and ``False``. If the results are equal, then setting it to ``Fals
 ---------
 
 .. autoclass:: torchmetrics.Metric
+    :noindex:
     :members:
 
 Contributing your metric to TorchMetrics

--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -305,7 +305,6 @@ dynamic search. See the *compute_groups* argument in the class docs below for mo
 information on this topic.
 
 .. autoclass:: torchmetrics.MetricCollection
-    :noindex:
     :exclude-members: update, compute, forward
 
 

--- a/docs/source/pairwise/cosine_similarity.rst
+++ b/docs/source/pairwise/cosine_similarity.rst
@@ -13,4 +13,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.pairwise_cosine_similarity
-    :noindex:

--- a/docs/source/pairwise/euclidean_distance.rst
+++ b/docs/source/pairwise/euclidean_distance.rst
@@ -13,4 +13,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.pairwise_euclidean_distance
-    :noindex:

--- a/docs/source/pairwise/linear_similarity.rst
+++ b/docs/source/pairwise/linear_similarity.rst
@@ -13,4 +13,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.pairwise_linear_similarity
-    :noindex:

--- a/docs/source/pairwise/manhattan_distance.rst
+++ b/docs/source/pairwise/manhattan_distance.rst
@@ -13,4 +13,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.pairwise_manhattan_distance
-    :noindex:

--- a/docs/source/pairwise/minkowski_distance.rst
+++ b/docs/source/pairwise/minkowski_distance.rst
@@ -13,4 +13,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.pairwise_minkowski_distance
-    :noindex:

--- a/docs/source/references/metric.rst
+++ b/docs/source/references/metric.rst
@@ -9,4 +9,3 @@ The base ``Metric`` class is an abstract base class that are used as the buildin
 metrics.
 
 .. autoclass:: torchmetrics.Metric
-    :noindex:

--- a/docs/source/references/utilities.rst
+++ b/docs/source/references/utilities.rst
@@ -9,16 +9,13 @@ select_topk
 ~~~~~~~~~~~
 
 .. autofunction:: torchmetrics.utilities.data.select_topk
-    :noindex:
 
 to_categorical
 ~~~~~~~~~~~~~~
 
 .. autofunction:: torchmetrics.utilities.data.to_categorical
-    :noindex:
 
 to_onehot
 ~~~~~~~~~
 
 .. autofunction:: torchmetrics.utilities.data.to_onehot
-    :noindex:

--- a/docs/source/regression/concordance_corr_coef.rst
+++ b/docs/source/regression/concordance_corr_coef.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.ConcordanceCorrCoef
-    :noindex:
     :exclude-members: update, compute
 
 
@@ -21,4 +20,3 @@ Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.concordance_corrcoef
-    :noindex:

--- a/docs/source/regression/cosine_similarity.rst
+++ b/docs/source/regression/cosine_similarity.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.CosineSimilarity
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.cosine_similarity
-    :noindex:

--- a/docs/source/regression/explained_variance.rst
+++ b/docs/source/regression/explained_variance.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.ExplainedVariance
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.explained_variance
-    :noindex:

--- a/docs/source/regression/kendall_rank_corr_coef.rst
+++ b/docs/source/regression/kendall_rank_corr_coef.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.KendallRankCorrCoef
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.kendall_rank_corrcoef
-    :noindex:

--- a/docs/source/regression/kl_divergence.rst
+++ b/docs/source/regression/kl_divergence.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.KLDivergence
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.kl_divergence
-    :noindex:

--- a/docs/source/regression/log_cosh_error.rst
+++ b/docs/source/regression/log_cosh_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.LogCoshError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.log_cosh_error
-    :noindex:

--- a/docs/source/regression/mean_absolute_error.rst
+++ b/docs/source/regression/mean_absolute_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.MeanAbsoluteError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.mean_absolute_error
-    :noindex:

--- a/docs/source/regression/mean_absolute_percentage_error.rst
+++ b/docs/source/regression/mean_absolute_percentage_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.MeanAbsolutePercentageError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.mean_absolute_percentage_error
-    :noindex:

--- a/docs/source/regression/mean_squared_error.rst
+++ b/docs/source/regression/mean_squared_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.MeanSquaredError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.mean_squared_error
-    :noindex:

--- a/docs/source/regression/mean_squared_log_error.rst
+++ b/docs/source/regression/mean_squared_log_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.MeanSquaredLogError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.mean_squared_log_error
-    :noindex:

--- a/docs/source/regression/minkowski_distance.rst
+++ b/docs/source/regression/minkowski_distance.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.MinkowskiDistance
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.minkowski_distance
-    :noindex:

--- a/docs/source/regression/pearson_corr_coef.rst
+++ b/docs/source/regression/pearson_corr_coef.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.PearsonCorrCoef
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.pearson_corrcoef
-    :noindex:

--- a/docs/source/regression/r2_score.rst
+++ b/docs/source/regression/r2_score.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.R2Score
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.r2_score
-    :noindex:

--- a/docs/source/regression/rse.rst
+++ b/docs/source/regression/rse.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.RelativeSquaredError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.relative_squared_error
-    :noindex:

--- a/docs/source/regression/spearman_corr_coef.rst
+++ b/docs/source/regression/spearman_corr_coef.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.SpearmanCorrCoef
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.spearman_corrcoef
-    :noindex:

--- a/docs/source/regression/symmetric_mean_absolute_percentage_error.rst
+++ b/docs/source/regression/symmetric_mean_absolute_percentage_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.SymmetricMeanAbsolutePercentageError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.symmetric_mean_absolute_percentage_error
-    :noindex:

--- a/docs/source/regression/tweedie_deviance_score.rst
+++ b/docs/source/regression/tweedie_deviance_score.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.TweedieDevianceScore
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.tweedie_deviance_score
-    :noindex:

--- a/docs/source/regression/weighted_mean_absolute_percentage_error.rst
+++ b/docs/source/regression/weighted_mean_absolute_percentage_error.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.WeightedMeanAbsolutePercentageError
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.weighted_mean_absolute_percentage_error
-    :noindex:

--- a/docs/source/retrieval/fall_out.rst
+++ b/docs/source/retrieval/fall_out.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalFallOut
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_fall_out
-    :noindex:

--- a/docs/source/retrieval/hit_rate.rst
+++ b/docs/source/retrieval/hit_rate.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalHitRate
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_hit_rate
-    :noindex:

--- a/docs/source/retrieval/map.rst
+++ b/docs/source/retrieval/map.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalMAP
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_average_precision
-    :noindex:

--- a/docs/source/retrieval/mrr.rst
+++ b/docs/source/retrieval/mrr.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalMRR
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_reciprocal_rank
-    :noindex:

--- a/docs/source/retrieval/normalized_dcg.rst
+++ b/docs/source/retrieval/normalized_dcg.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalNormalizedDCG
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_normalized_dcg
-    :noindex:

--- a/docs/source/retrieval/precision.rst
+++ b/docs/source/retrieval/precision.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalPrecision
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_precision
-    :noindex:

--- a/docs/source/retrieval/precision_recall_curve.rst
+++ b/docs/source/retrieval/precision_recall_curve.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalPrecisionRecallCurve
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_precision_recall_curve
-    :noindex:

--- a/docs/source/retrieval/r_precision.rst
+++ b/docs/source/retrieval/r_precision.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalRPrecision
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_r_precision
-    :noindex:

--- a/docs/source/retrieval/recall.rst
+++ b/docs/source/retrieval/recall.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.retrieval.RetrievalRecall
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.retrieval.retrieval_recall
-    :noindex:

--- a/docs/source/text/bert_score.rst
+++ b/docs/source/text/bert_score.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.bert.BERTScore
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface

--- a/docs/source/text/bleu_score.rst
+++ b/docs/source/text/bleu_score.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.BLEUScore
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.bleu_score
-    :noindex:

--- a/docs/source/text/char_error_rate.rst
+++ b/docs/source/text/char_error_rate.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.CharErrorRate
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.char_error_rate
-    :noindex:

--- a/docs/source/text/chrf_score.rst
+++ b/docs/source/text/chrf_score.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.CHRFScore
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.chrf_score
-    :noindex:

--- a/docs/source/text/edit.rst
+++ b/docs/source/text/edit.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.EditDistance
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.edit_distance
-    :noindex:

--- a/docs/source/text/extended_edit_distance.rst
+++ b/docs/source/text/extended_edit_distance.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.ExtendedEditDistance
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.extended_edit_distance
-    :noindex:

--- a/docs/source/text/infolm.rst
+++ b/docs/source/text/infolm.rst
@@ -13,7 +13,6 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.infolm.InfoLM
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface

--- a/docs/source/text/match_error_rate.rst
+++ b/docs/source/text/match_error_rate.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.MatchErrorRate
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.match_error_rate
-    :noindex:

--- a/docs/source/text/perplexity.rst
+++ b/docs/source/text/perplexity.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.perplexity.Perplexity
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.perplexity.perplexity
-    :noindex:

--- a/docs/source/text/rouge_score.rst
+++ b/docs/source/text/rouge_score.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.rouge.ROUGEScore
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.rouge.rouge_score
-    :noindex:

--- a/docs/source/text/sacre_bleu_score.rst
+++ b/docs/source/text/sacre_bleu_score.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.SacreBLEUScore
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.sacre_bleu_score
-    :noindex:

--- a/docs/source/text/squad.rst
+++ b/docs/source/text/squad.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.SQuAD
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.squad
-    :noindex:

--- a/docs/source/text/translation_edit_rate.rst
+++ b/docs/source/text/translation_edit_rate.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.TranslationEditRate
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.translation_edit_rate
-    :noindex:

--- a/docs/source/text/word_error_rate.rst
+++ b/docs/source/text/word_error_rate.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.WordErrorRate
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.word_error_rate
-    :noindex:

--- a/docs/source/text/word_info_lost.rst
+++ b/docs/source/text/word_info_lost.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.WordInfoLost
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.word_information_lost
-    :noindex:

--- a/docs/source/text/word_info_preserved.rst
+++ b/docs/source/text/word_info_preserved.rst
@@ -13,11 +13,9 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.text.WordInfoPreserved
-    :noindex:
     :exclude-members: update, compute
 
 Functional Interface
 ____________________
 
 .. autofunction:: torchmetrics.functional.text.word_information_preserved
-    :noindex:

--- a/docs/source/wrappers/bootstrapper.rst
+++ b/docs/source/wrappers/bootstrapper.rst
@@ -13,4 +13,3 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.wrappers.BootStrapper
-    :noindex:

--- a/docs/source/wrappers/classwise_wrapper.rst
+++ b/docs/source/wrappers/classwise_wrapper.rst
@@ -13,4 +13,3 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.wrappers.ClasswiseWrapper
-    :noindex:

--- a/docs/source/wrappers/metric_tracker.rst
+++ b/docs/source/wrappers/metric_tracker.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.wrappers.MetricTracker
-    :noindex:
     :exclude-members: update, compute

--- a/docs/source/wrappers/min_max.rst
+++ b/docs/source/wrappers/min_max.rst
@@ -13,4 +13,3 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.wrappers.MinMaxMetric
-    :noindex:

--- a/docs/source/wrappers/multi_output_wrapper.rst
+++ b/docs/source/wrappers/multi_output_wrapper.rst
@@ -13,4 +13,3 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.wrappers.MultioutputWrapper
-    :noindex:

--- a/docs/source/wrappers/multi_task_wrapper.rst
+++ b/docs/source/wrappers/multi_task_wrapper.rst
@@ -13,4 +13,3 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.wrappers.MultitaskWrapper
-    :noindex:

--- a/docs/source/wrappers/running.rst
+++ b/docs/source/wrappers/running.rst
@@ -13,5 +13,4 @@ Module Interface
 ________________
 
 .. autoclass:: torchmetrics.wrappers.Running
-    :noindex:
     :exclude-members: update, compute

--- a/src/torchmetrics/functional/classification/exact_match.py
+++ b/src/torchmetrics/functional/classification/exact_match.py
@@ -231,6 +231,7 @@ def exact_match(
     ``task`` argument to either ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`multiclass_exact_match` and :func:`multilabel_exact_match` for the specific details of
     each argument influence and examples.
+
     Legacy Example:
         >>> from torch import tensor
         >>> target = tensor([[[0, 1], [2, 1], [0, 2]], [[1, 1], [2, 0], [1, 2]]])


### PR DESCRIPTION
## What does this PR do?

Fixes #865
Currently https://github.com/Lightning-AI/torchmetrics/pull/1916 is blocked because we currently cannot reference our own metrics in our own docs due to the use of `:noindex:`. I propose that we remove the `:noindex:` from docs. The reason it is there as far as I am aware is to not have double entries when searching for something.

This is also true. Currently with `:noindex:` a search for `BinaryAccuracy` looks like
![docs2](https://github.com/Lightning-AI/torchmetrics/assets/24896311/85eb1d96-f0c9-4932-879d-22413b821eab)
without `:noindex:` it would look like:
![docs1](https://github.com/Lightning-AI/torchmetrics/assets/24896311/6a85f769-484c-4119-9381-d74aba99d2a0)

I think it would not be too destructive to have multiple of the same search results if we compare with the benefit that we can begin to actually reference our own metrics in the docs. This change also solves the linked issue, such that others can cross-reference torchmetrics in their own documentation.


<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--1998.org.readthedocs.build/en/1998/

<!-- readthedocs-preview torchmetrics end -->