### PR TITLE
Clarify language about one-vs-rest for classification metrics

### DIFF
--- a/src/torchmetrics/classification/auroc.py
+++ b/src/torchmetrics/classification/auroc.py
@@ -175,7 +175,7 @@ class MulticlassAUROC(MulticlassPrecisionRecallCurve):
     For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
     classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
     this metric. By default the reported metric is then the average over all classes, but this behavior can be changed
-    by setting the `average` argument.
+    by setting the ``average`` argument.
 
     As input to ``forward`` and ``update`` the metric accepts the following input:
 

--- a/src/torchmetrics/classification/auroc.py
+++ b/src/torchmetrics/classification/auroc.py
@@ -172,6 +172,11 @@ class MulticlassAUROC(MulticlassPrecisionRecallCurve):
     multiple thresholds at the same time. Notably, an AUROC score of 1 is a perfect score and an AUROC score of 0.5
     corresponds to random guessing.
 
+    For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
+    classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
+    this metric. By default the reported metric is then the average over all classes, but this behavior can be changed
+    by setting the `average` argument.
+
     As input to ``forward`` and ``update`` the metric accepts the following input:
 
     - ``preds`` (:class:`~torch.Tensor`): A float tensor of shape ``(N, C, ...)`` containing probabilities or logits

--- a/src/torchmetrics/classification/average_precision.py
+++ b/src/torchmetrics/classification/average_precision.py
@@ -174,7 +174,7 @@ class MulticlassAveragePrecision(MulticlassPrecisionRecallCurve):
     For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
     classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
     this metric. By default the reported metric is then the average over all classes, but this behavior can be changed
-    by setting the `average` argument.
+    by setting the ``average`` argument.
 
     As input to ``forward`` and ``update`` the metric accepts the following input:
 

--- a/src/torchmetrics/classification/average_precision.py
+++ b/src/torchmetrics/classification/average_precision.py
@@ -171,6 +171,11 @@ class MulticlassAveragePrecision(MulticlassPrecisionRecallCurve):
     where :math:`P_n, R_n` is the respective precision and recall at threshold index :math:`n`. This value is
     equivalent to the area under the precision-recall curve (AUPRC).
 
+    For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
+    classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
+    this metric. By default the reported metric is then the average over all classes, but this behavior can be changed
+    by setting the `average` argument.
+
     As input to ``forward`` and ``update`` the metric accepts the following input:
 
     - ``preds`` (:class:`~torch.Tensor`): A float tensor of shape ``(N, C, ...)`` containing probabilities or logits

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -224,6 +224,10 @@ class MulticlassPrecisionRecallCurve(Metric):
     The curve consist of multiple pairs of precision and recall values evaluated at different thresholds, such that the
     tradeoff between the two values can been seen.
 
+    For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
+    classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
+    this metric.
+
     As input to ``forward`` and ``update`` the metric accepts the following input:
 
     - ``preds`` (:class:`~torch.Tensor`): A float tensor of shape ``(N, C, ...)``. Preds should be a tensor containing

--- a/src/torchmetrics/classification/recall_fixed_precision.py
+++ b/src/torchmetrics/classification/recall_fixed_precision.py
@@ -180,6 +180,10 @@ class MulticlassRecallAtFixedPrecision(MulticlassPrecisionRecallCurve):
     This is done by first calculating the precision-recall curve for different thresholds and the find the recall for
     a given precision level.
 
+    For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
+    classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
+    this metric.
+
     As input to ``forward`` and ``update`` the metric accepts the following input:
 
     - ``preds`` (:class:`~torch.Tensor`): A float tensor of shape ``(N, C, ...)``. Preds should be a tensor

--- a/src/torchmetrics/classification/roc.py
+++ b/src/torchmetrics/classification/roc.py
@@ -174,6 +174,10 @@ class MulticlassROC(MulticlassPrecisionRecallCurve):
     The curve consist of multiple pairs of true positive rate (TPR) and false positive rate (FPR) values evaluated at
     different thresholds, such that the tradeoff between the two values can be seen.
 
+    For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
+    classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
+    this metric.
+
     As input to ``forward`` and ``update`` the metric accepts the following input:
 
     - ``preds`` (:class:`~torch.Tensor`): A float tensor of shape ``(N, C, ...)``. Preds should be a tensor

--- a/src/torchmetrics/classification/specificity_sensitivity.py
+++ b/src/torchmetrics/classification/specificity_sensitivity.py
@@ -133,6 +133,10 @@ class MulticlassSpecificityAtSensitivity(MulticlassPrecisionRecallCurve):
     This is done by first calculating the Receiver Operating Characteristic (ROC) curve for different thresholds and the
     find the specificity for a given sensitivity level.
 
+    For multiclass the metric is calculated by iteratively treating each class as the positive class and all other
+    classes as the negative, which is refered to as the one-vs-rest approach. One-vs-one is currently not supported by
+    this metric.
+
     Accepts the following input tensors:
 
     - ``preds`` (float tensor): ``(N, C, ...)``. Preds should be a tensor containing probabilities or logits for each


### PR DESCRIPTION
## What does this PR do?

Fixes #2050
Clarify that for the curve based classification metrics, in the multi class setting we are calculating it in a one-vs-rest approach.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2051.org.readthedocs.build/en/2051/

<!-- readthedocs-preview torchmetrics end -->