### PR TITLE
Bugfix for custom prefix/postfix and metric collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed performance issues in `RecallAtFixedPrecision` for large batch sizes ([#2042](https://github.com/Lightning-AI/torchmetrics/pull/2042))
 
 
+- Fixed bug related to `MetricCollection` used with custom metrics have `prefix`/`postfix` attributes ([#2070](https://github.com/Lightning-AI/torchmetrics/pull/2070))
+
 ## [1.1.1] - 2023-08-29
 
 ### Added

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -348,9 +348,9 @@ class MetricCollection(ModuleDict):
                         stripped_k = k.replace(getattr(m, "prefix", ""), "")
                         stripped_k = stripped_k.replace(getattr(m, "postfix", ""), "")
                         key = f"{stripped_k}_{key}"
-                    if hasattr(m, "_from_collection") and m._from_collection and m.prefix is not None:
+                    if getattr(m, "_from_collection") and m.prefix is not None:
                         key = f"{m.prefix}{key}"
-                    if hasattr(m, "_from_collection") and m._from_collection and m.postfix is not None:
+                    if getattr(m, "_from_collection") and m.postfix is not None:
                         key = f"{key}{m.postfix}"
                     flattened_results[key] = v
             else:

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -339,7 +339,8 @@ class MetricCollection(ModuleDict):
         _, duplicates = _flatten_dict(result)
 
         flattened_results = {}
-        for k, res in result.items():
+        for k, m in self.items(keep_base=True, copy_state=False):
+            res = result[k]
             if isinstance(res, dict):
                 for key, v in res.items():
                     # if duplicates of keys we need to add unique prefix to each key
@@ -347,9 +348,9 @@ class MetricCollection(ModuleDict):
                         stripped_k = k.replace(getattr(m, "prefix", ""), "")
                         stripped_k = stripped_k.replace(getattr(m, "postfix", ""), "")
                         key = f"{stripped_k}_{key}"
-                    if hasattr(m, "prefix") and m.prefix is not None:
+                    if hasattr(m, "_from_collection") and m._from_collection and m.prefix is not None:
                         key = f"{m.prefix}{key}"
-                    if hasattr(m, "postfix") and m.postfix is not None:
+                    if hasattr(m, "_from_collection") and m._from_collection and m.postfix is not None:
                         key = f"{key}{m.postfix}"
                     flattened_results[key] = v
             else:
@@ -425,6 +426,7 @@ class MetricCollection(ModuleDict):
                     for k, v in metric.items(keep_base=False):
                         v.postfix = metric.postfix
                         v.prefix = metric.prefix
+                        v._from_collection = True
                         self[f"{name}_{k}"] = v
         elif isinstance(metrics, Sequence):
             for metric in metrics:
@@ -442,6 +444,7 @@ class MetricCollection(ModuleDict):
                     for k, v in metric.items(keep_base=False):
                         v.postfix = metric.postfix
                         v.prefix = metric.prefix
+                        v._from_collection = True
                         self[k] = v
         else:
             raise ValueError(

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -348,9 +348,9 @@ class MetricCollection(ModuleDict):
                         stripped_k = k.replace(getattr(m, "prefix", ""), "")
                         stripped_k = stripped_k.replace(getattr(m, "postfix", ""), "")
                         key = f"{stripped_k}_{key}"
-                    if getattr(m, "_from_collection") and m.prefix is not None:
+                    if m._from_collection and m.prefix is not None:
                         key = f"{m.prefix}{key}"
-                    if getattr(m, "_from_collection") and m.postfix is not None:
+                    if m._from_collection and m.postfix is not None:
                         key = f"{key}{m.postfix}"
                     flattened_results[key] = v
             else:

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -348,9 +348,9 @@ class MetricCollection(ModuleDict):
                         stripped_k = k.replace(getattr(m, "prefix", ""), "")
                         stripped_k = stripped_k.replace(getattr(m, "postfix", ""), "")
                         key = f"{stripped_k}_{key}"
-                    if m._from_collection and m.prefix is not None:
+                    if getattr(m, "_from_collection", None) and m.prefix is not None:
                         key = f"{m.prefix}{key}"
-                    if m._from_collection and m.postfix is not None:
+                    if getattr(m, "_from_collection", None) and m.postfix is not None:
                         key = f"{key}{m.postfix}"
                     flattened_results[key] = v
             else:


### PR DESCRIPTION
## What does this PR do?

Fixes #2065
Make sure that metric collection does not conflict with user attributes `prefix`/`postfix`

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2070.org.readthedocs.build/en/2070/

<!-- readthedocs-preview torchmetrics end -->