### PR TITLE
Update examples in running

### DIFF
--- a/src/torchmetrics/wrappers/running.py
+++ b/src/torchmetrics/wrappers/running.py
@@ -43,8 +43,7 @@ class Running(WrapperMetric):
         base_metric: The metric to wrap.
         window: The size of the running window.
 
-    Example:
-        # Single metric
+    Example (single metric):
         >>> from torch import tensor
         >>> from torchmetrics.wrappers import Running
         >>> from torchmetrics.aggregation import SumMetric
@@ -61,8 +60,7 @@ class Running(WrapperMetric):
         current_val=tensor(4.), running_val=tensor(9.), total_val=tensor(10)
         current_val=tensor(5.), running_val=tensor(12.), total_val=tensor(15)
 
-    Example:
-        # Metric collection
+    Example (metric collection):
         >>> from torch import tensor
         >>> from torchmetrics.wrappers import Running
         >>> from torchmetrics import MetricCollection


### PR DESCRIPTION
Remove the first two lines after the `Example:`, to fix rendering of the code in the running wrapper documentation. 
Similar to [Metric tracker docs](https://torchmetrics.readthedocs.io/en/stable/wrappers/metric_tracker.html), add the example name in the title.

## What does this PR do?

Fixes #2080 

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2081.org.readthedocs.build/en/2081/

<!-- readthedocs-preview torchmetrics end -->