### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/src/torchmetrics/detection/_mean_ap.py
+++ b/src/torchmetrics/detection/_mean_ap.py
@@ -542,7 +542,7 @@ class MeanAveragePrecision(Metric):
             return self.__evaluate_image_gt_no_preds(gt, gt_label_mask, area_range, nb_iou_thrs)
 
         # Some predictions but no GT
-        if len(gt_label_mask) == 0 and len(det_label_mask) >= 0:
+        if len(gt_label_mask) == 0 and len(det_label_mask) > 0:
             return self.__evaluate_image_preds_no_gt(det, idx, det_label_mask, max_det, area_range, nb_iou_thrs)
 
         gt = [gt[i] for i in gt_label_mask]


### PR DESCRIPTION
In file: _mean_ap.py, the comparison of Collection length creates a logical short circuit. I suggested that the Collection length comparison should be done without creating a logical short circuit. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2082.org.readthedocs.build/en/2082/

<!-- readthedocs-preview torchmetrics end -->