### PR TITLE
fix pesq docs

### DIFF
--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -50,9 +50,9 @@ class PerceptualEvaluationSpeechQuality(Metric):
         installed version of numpy, meaning that if you upgrade numpy at some point in the future you will
         most likely have to reinstall ``pesq``.
 
-    .. note: the ``forward`` and ``compute`` methods in this class return a single (reduced) PESQ value
+    .. note:: the ``forward`` and ``compute`` methods in this class return a single (reduced) PESQ value
         for a batch. To obtain a PESQ value for each sample, you may use the functional counterpart in
-        ``torchmetrics.functional.audio.pesq.perceptual_evaluation_speech_quality()``.
+        :func:`~torchmetrics.functional.audio.pesq.perceptual_evaluation_speech_quality`.
 
     Args:
         fs: sampling frequency, should be 16000 or 8000 (Hz)

--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -30,7 +30,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
     """Calculate `Perceptual Evaluation of Speech Quality`_ (PESQ).
 
     It's a recognized industry standard for audio quality that takes into considerations characteristics such as:
-    audio sharpness, call volume, background noise, clipping, audio interference etc. PESQ returns a score between
+    audio sharpness, call volume, background noise, clipping, audio interference ect. PESQ returns a score between
     -0.5 and 4.5 with the higher scores indicating a better quality.
 
     This metric is a wrapper for the `pesq package`_. Note that input will be moved to ``cpu`` to perform the metric
@@ -43,18 +43,22 @@ class PerceptualEvaluationSpeechQuality(Metric):
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``pesq`` (:class:`~torch.Tensor`): float tensor with shape ``(...,)`` of PESQ value per sample
+    - ``pesq`` (:class:`~torch.Tensor`): float tensor of PESQ value reduced across the batch
 
     .. note:: using this metrics requires you to have ``pesq`` install. Either install as ``pip install
         torchmetrics[audio]`` or ``pip install pesq``. ``pesq`` will compile with your currently
         installed version of numpy, meaning that if you upgrade numpy at some point in the future you will
         most likely have to reinstall ``pesq``.
 
+    .. note: the ``forward`` and ``compute`` methods in this class return a single (reduced) PESQ value 
+        for a batch. To obtain a PESQ value for each sample, you may use the functional counterpart in
+        ``torchmetrics.functional.audio.pesq.perceptual_evaluation_speech_quality()``.
+
     Args:
         fs: sampling frequency, should be 16000 or 8000 (Hz)
         mode: ``'wb'`` (wide-band) or ``'nb'`` (narrow-band)
         keep_same_device: whether to move the pesq value to the device of preds
-        n_processes: integer specifying the number of processes to run in parallel for the metric calculation.
+        n_processes: integer specifiying the number of processes to run in parallel for the metric calculation.
             Only applies to batches of data and if ``multiprocessing`` package is installed.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 

--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -30,7 +30,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
     """Calculate `Perceptual Evaluation of Speech Quality`_ (PESQ).
 
     It's a recognized industry standard for audio quality that takes into considerations characteristics such as:
-    audio sharpness, call volume, background noise, clipping, audio interference ect. PESQ returns a score between
+    audio sharpness, call volume, background noise, clipping, audio interference etc. PESQ returns a score between
     -0.5 and 4.5 with the higher scores indicating a better quality.
 
     This metric is a wrapper for the `pesq package`_. Note that input will be moved to ``cpu`` to perform the metric
@@ -58,7 +58,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
         fs: sampling frequency, should be 16000 or 8000 (Hz)
         mode: ``'wb'`` (wide-band) or ``'nb'`` (narrow-band)
         keep_same_device: whether to move the pesq value to the device of preds
-        n_processes: integer specifiying the number of processes to run in parallel for the metric calculation.
+        n_processes: integer specifying the number of processes to run in parallel for the metric calculation.
             Only applies to batches of data and if ``multiprocessing`` package is installed.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 

--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -50,7 +50,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
         installed version of numpy, meaning that if you upgrade numpy at some point in the future you will
         most likely have to reinstall ``pesq``.
 
-    .. note: the ``forward`` and ``compute`` methods in this class return a single (reduced) PESQ value 
+    .. note: the ``forward`` and ``compute`` methods in this class return a single (reduced) PESQ value
         for a batch. To obtain a PESQ value for each sample, you may use the functional counterpart in
         ``torchmetrics.functional.audio.pesq.perceptual_evaluation_speech_quality()``.
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2095

PESQ ([`torchmetrics.audio.pesq.PerceptualEvaluationSpeechQuality`](https://torchmetrics.readthedocs.io/en/stable/audio/perceptual_evaluation_speech_quality.html#perceptual-evaluation-of-speech-quality-pesq)) docs incorrectly state that a tensor of pesq values is returned. This PR:
- corrects this inconsistency between docs and implementation, namely that `forward` and `compute` return metric value reduced across the batch, instead of a tensor of metrics values for each sample;
- adds a note guiding the user to the functional version of PESQ ([`torchmetrics.functional.audio.pesq.perceptual_evaluation_speech_quality`](https://torchmetrics.readthedocs.io/en/stable/audio/perceptual_evaluation_speech_quality.html#functional-interface)) if a tensor of metrics values for each sample is required;

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>




<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2114.org.readthedocs.build/en/2114/

<!-- readthedocs-preview torchmetrics end -->