### PR TITLE
Improve numeric stability of `LPIPS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed numerical stability bug in `LearnedPerceptualImagePatchSimilarity` metric  ([#2144](https://github.com/Lightning-AI/torchmetrics/pull/2144))
 
 
 ## [1.2.0] - 2023-09-22

--- a/src/torchmetrics/functional/image/lpips.py
+++ b/src/torchmetrics/functional/image/lpips.py
@@ -191,10 +191,10 @@ def _upsample(in_tens: Tensor, out_hw: Tuple[int, ...] = (64, 64)) -> Tensor:
     return nn.Upsample(size=out_hw, mode="bilinear", align_corners=False)(in_tens)
 
 
-def _normalize_tensor(in_feat: Tensor, eps: float = 1e-10) -> Tensor:
-    """Normalize tensors."""
-    norm_factor = torch.sqrt(torch.sum(in_feat**2, dim=1, keepdim=True))
-    return in_feat / (norm_factor + eps)
+def _normalize_tensor(in_feat: Tensor, eps: float = 1e-8) -> Tensor:
+    """Normalize input tensor."""
+    norm_factor = torch.sqrt(eps + torch.sum(in_feat**2, dim=1, keepdim=True))
+    return in_feat / norm_factor
 
 
 def _resize_tensor(x: Tensor, size: int = 64) -> Tensor:


### PR DESCRIPTION
## What does this PR do?

Fixes #2139
Instead of doing `sqrt(x) + eps` in one of the operations involved in lpips it will now be `sqrt(x+eps)` which is more numerical stable for small values.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2144.org.readthedocs.build/en/2144/

<!-- readthedocs-preview torchmetrics end -->