### PR TITLE
replace setuptools' `find_packages` by `find_namespace_packages`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
 
 from pkg_resources import Requirement, yield_lines
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 _PATH_ROOT = os.path.realpath(os.path.dirname(__file__))
 _PATH_SOURCE = os.path.join(_PATH_ROOT, "src")
@@ -200,7 +200,7 @@ if __name__ == "__main__":
         url=ABOUT.__homepage__,
         download_url=os.path.join(ABOUT.__homepage__, "archive", "master.zip"),
         license=ABOUT.__license__,
-        packages=find_packages(where="src"),
+        packages=find_namespace_packages(where="src"),
         package_dir={"": "src"},
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
## What does this PR do?

following suggestion in https://github.com/Lightning-AI/lightning/issues/16756#issuecomment-1751509467
tested even with the legacy version `setuptools==41.0.0` released in [2019](https://pypi.org/project/setuptools/41.0.0/)

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2153.org.readthedocs.build/en/2153/

<!-- readthedocs-preview torchmetrics end -->