### PR TITLE
ci/docs: run docs make in parallel

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ matrix.check == 'doctest' }}
         working-directory: ./docs
         run: |
-          make doctest
+          make doctest --debug --jobs $(nproc)
           make coverage
 
       - name: Check External Links
@@ -80,15 +80,15 @@ jobs:
         working-directory: ./docs
         env:
           SPHINX_MOCK_REQUIREMENTS: 1
-        run: make --jobs $(nproc) linkcheck SPHINXOPTS="--keep-going"
+        run: make linkcheck --jobs $(nproc) SPHINXOPTS="--keep-going"
 
       - name: Full build for deployment
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: echo "SPHINX_FETCH_ASSETS=1" >> $GITHUB_ENV
       - name: Make Documentation
         if: ${{ matrix.check == 'html' }}
         working-directory: ./docs
-        run: make html --debug SPHINXOPTS="-W --keep-going"
+        run: make html --debug --jobs $(nproc) SPHINXOPTS="-W --keep-going"
 
       - name: Upload built docs
         if: ${{ matrix.check == 'html' && github.event_name == 'push' }}


### PR DESCRIPTION
## What does this PR do?

attempt to speed up some docs by run them in multiple jobs

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2160.org.readthedocs.build/en/2160/

<!-- readthedocs-preview torchmetrics end -->