### PR TITLE
fix macro when ignore_index is set

### DIFF
--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -416,6 +416,8 @@ def _multiclass_stat_scores_update(
         fp = confmat.sum(0) - tp
         fn = confmat.sum(1) - tp
         tn = confmat.sum() - (fp + fn + tp)
+        if ignore_index is not None:
+            fp[ignore_index] = 0
     return tp, fp, tn, fn
 
 

--- a/tests/unittests/classification/test_accuracy.py
+++ b/tests/unittests/classification/test_accuracy.py
@@ -190,12 +190,9 @@ def _sklearn_accuracy_multiclass(preds, target, ignore_index, multidim_average, 
             return _sklearn_accuracy(target, preds)
         confmat = sk_confusion_matrix(target, preds, labels=list(range(NUM_CLASSES)))
         acc_per_class = confmat.diagonal() / confmat.sum(axis=1)
-        acc_per_class[np.isnan(acc_per_class)] = 0.0
         if average == "macro":
-            acc_per_class = acc_per_class[
-                (np.bincount(preds, minlength=NUM_CLASSES) + np.bincount(target, minlength=NUM_CLASSES)) != 0.0
-            ]
-            return acc_per_class.mean()
+            return np.nanmean(acc_per_class)
+        acc_per_class[np.isnan(acc_per_class)] = 0.0
         if average == "weighted":
             weights = confmat.sum(1)
             return ((weights * acc_per_class) / weights.sum()).sum()


### PR DESCRIPTION
## What does this PR do?

Fixes #1691

Additionally, tests have been updated to exclude the ignored class from the macro accuracy averaging.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
