### PR TITLE
Add support for logging `MultiTaskWrapper` in lightning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for Pytorch v2.1 ([#2142](https://github.com/Lightning-AI/torchmetrics/pull/2142))
 
+- Added support for logging `MultiTaskWrapper` directly with lightnings `log_dict` method ([#2213](https://github.com/Lightning-AI/torchmetrics/pull/2213))
+
 ### Changed
 
 - Change default state of `SpectralAngleMapper` and `UniversalImageQualityIndex` to be tensors ([#2089](https://github.com/Lightning-AI/torchmetrics/pull/2089))

--- a/src/torchmetrics/wrappers/multitask.py
+++ b/src/torchmetrics/wrappers/multitask.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # this is just a bypass for this module name collision with built-in one
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union
 
 from torch import Tensor, nn
 
@@ -101,6 +101,18 @@ class MultitaskWrapper(WrapperMetric):
         self._check_task_metrics_type(task_metrics)
         super().__init__()
         self.task_metrics = nn.ModuleDict(task_metrics)
+
+    def items(self) -> Iterable[Tuple[str, nn.Module]]:
+        """Iterate over task and task metrics."""
+        return self.task_metrics.items()
+
+    def keys(self) -> Iterable[str]:
+        """Iterate over task names."""
+        return self.task_metrics.keys()
+
+    def values(self) -> Iterable[nn.Module]:
+        """Iterate over task metrics."""
+        return self.task_metrics.values()
 
     @staticmethod
     def _check_task_metrics_type(task_metrics: Dict[str, Union[Metric, MetricCollection]]) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes #2193
Will allow this wrapper (which is a specialized version of `MetricCollection`) to be logged directly through `log_dict`.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2213.org.readthedocs.build/en/2213/

<!-- readthedocs-preview torchmetrics end -->