### PR TITLE
ci: set oldest versions also for GPU tests

### DIFF
--- a/.azure/gpu-unittests.yml
+++ b/.azure/gpu-unittests.yml
@@ -85,6 +85,11 @@ jobs:
         displayName: "Adjust versions"
 
       - bash: |
+          python .github/assistant.py set-oldest-versions
+        condition: eq(variables['torch-ver'], '1.10.2')
+        displayName: "Setting oldest versions"
+
+      - bash: |
           pip install . -U -r ./requirements/_devel.txt --prefer-binary --find-links=${TORCH_URL}
         displayName: "Install environment"
 


### PR DESCRIPTION
## What does this PR do?

Not sure why we have this configuration missing

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
