### PR TITLE
Supress warning for running metric wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed warning incorrectly being raised in `Running` metrics ([#2256](https://github.com/Lightning-AI/torchmetrics/pull/2265))
 
 
 ## [1.2.1] - 2023-11-30

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -592,7 +592,7 @@ class Metric(Module, ABC):
     def _wrap_compute(self, compute: Callable) -> Callable:
         @functools.wraps(compute)
         def wrapped_func(*args: Any, **kwargs: Any) -> Any:
-            if self._update_count == 0:
+            if not self.update_called:
                 rank_zero_warn(
                     f"The ``compute`` method of metric {self.__class__.__name__}"
                     " was called before the ``update`` method which may lead to errors,"

--- a/src/torchmetrics/wrappers/running.py
+++ b/src/torchmetrics/wrappers/running.py
@@ -127,6 +127,7 @@ class Running(WrapperMetric):
         """Compute the metric over the running window."""
         for i in range(self.window):
             self.base_metric._reduce_states({key: getattr(self, key + f"_{i}") for key in self.base_metric._defaults})
+        self.base_metric._update_count = self._num_vals_seen
         val = self.base_metric.compute()
         self.base_metric.reset()
         return val

--- a/tests/unittests/wrappers/test_running.py
+++ b/tests/unittests/wrappers/test_running.py
@@ -23,6 +23,7 @@ from torchmetrics.regression import MeanAbsoluteError, MeanSquaredError, Pearson
 from torchmetrics.wrappers import Running
 
 from unittests import NUM_PROCESSES
+from unittests.helpers.utilities import no_warning_call
 
 
 def test_errors_on_wrong_input():
@@ -150,3 +151,11 @@ def test_ddp_running(dist_sync_on_step, expected):
     pytest.pool.map(
         partial(_test_ddp_running, dist_sync_on_step=dist_sync_on_step, expected=expected), range(NUM_PROCESSES)
     )
+
+
+def test_no_warning_due_to_reset():
+    """Internally we call .reset() which would normally raise a warning, but it should not happen in Runner."""
+    metric = Running(SumMetric(), window=3)
+    metric.update(torch.tensor(2.0))
+    with no_warning_call(UserWarning):
+        metric.compute()


### PR DESCRIPTION
## What does this PR do?

Fixes #2264
Because we make use of `.reset` in the runner wrapper it leads to a warning being raised, but everything is completely fine.
PR fixes this.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
:books: Documentation preview :books:: https://torchmetrics--2265.org.readthedocs.build/en/2265/

<!-- readthedocs-preview torchmetrics end -->