### PR TITLE
CI: Fix flaky test using stable sort

### DIFF
--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -19,7 +19,7 @@ from lightning_utilities import apply_to_collection
 from torch import Tensor
 
 from torchmetrics.utilities.exceptions import TorchMetricsUserWarning
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_12, _XLA_AVAILABLE
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_12, _TORCH_GREATER_EQUAL_1_13, _XLA_AVAILABLE
 from torchmetrics.utilities.prints import rank_zero_warn
 
 METRIC_EPS = 1e-6
@@ -115,6 +115,8 @@ def to_onehot(
 def _top_k_with_half_precision_support(x: Tensor, k: int = 1, dim: int = 1) -> Tensor:
     """torch.top_k does not support half precision on CPU."""
     if x.dtype == torch.half and not x.is_cuda:
+        if not _TORCH_GREATER_EQUAL_1_13:
+            raise RuntimeError("Half precision (torch.float16) is not supported on CPU for PyTorch < 1.13.")
         idx = torch.argsort(x, dim=dim, stable=True).flip(dim)
         return idx.narrow(dim, 0, k)
     return x.topk(k=k, dim=dim).indices

--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -115,7 +115,7 @@ def to_onehot(
 def _top_k_with_half_precision_support(x: Tensor, k: int = 1, dim: int = 1) -> Tensor:
     """torch.top_k does not support half precision on CPU."""
     if x.dtype == torch.half and not x.is_cuda:
-        idx = torch.argsort(x, dim=dim, descending=True)
+        idx = torch.argsort(x, dim=dim, stable=True).flip(dim)
         return idx.narrow(dim, 0, k)
     return x.topk(k=k, dim=dim).indices
 
@@ -139,11 +139,11 @@ def select_topk(prob_tensor: Tensor, topk: int = 1, dim: int = 1) -> Tensor:
                 [1, 1, 0]], dtype=torch.int32)
 
     """
-    zeros = torch.zeros_like(prob_tensor)
+    topk_tensor = torch.zeros_like(prob_tensor, dtype=torch.int)
     if topk == 1:  # argmax has better performance than topk
-        topk_tensor = zeros.scatter(dim, prob_tensor.argmax(dim=dim, keepdim=True), 1.0)
+        topk_tensor.scatter_(dim, prob_tensor.argmax(dim=dim, keepdim=True), 1.0)
     else:
-        topk_tensor = zeros.scatter(dim, _top_k_with_half_precision_support(prob_tensor, k=topk, dim=dim), 1.0)
+        topk_tensor.scatter_(dim, _top_k_with_half_precision_support(prob_tensor, k=topk, dim=dim), 1.0)
     return topk_tensor.int()
 
 

--- a/tests/unittests/utilities/test_utilities.py
+++ b/tests/unittests/utilities/test_utilities.py
@@ -216,9 +216,10 @@ def _reference_topk(x, dim, k):
     one_hot = np.zeros((x.shape[0], x.shape[1]), dtype=int)
     if dim == 1:
         for i in range(x.shape[0]):
-            one_hot[i, np.argsort(x[i, :])[::-1][:k]] = 1
+            one_hot[i, np.argsort(x[i, :], kind="stable")[::-1][:k]] = 1
+        return one_hot
     for i in range(x.shape[1]):
-        one_hot[np.argsort(x[:, i])[::-1][:k], i] = 1
+        one_hot[np.argsort(x[:, i], kind="stable")[::-1][:k], i] = 1
     return one_hot
 
 

--- a/tests/unittests/utilities/test_utilities.py
+++ b/tests/unittests/utilities/test_utilities.py
@@ -228,6 +228,8 @@ def _reference_topk(x, dim, k):
 @pytest.mark.parametrize("dim", [0, 1])
 def test_custom_topk(dtype, k, dim):
     """Test custom topk implementation."""
+    if dtype == torch.half and not _TORCH_GREATER_EQUAL_1_13:
+        pytest.skip("half precision topk not supported in Pytorch < 1.13")
     x = torch.randn(100, 10, dtype=dtype)
     top_k = select_topk(x, dim=dim, topk=k)
     assert top_k.shape == (100, 10)


### PR DESCRIPTION
## What does this PR do?

Fixes bug introduced in https://github.com/Lightning-AI/torchmetrics/pull/2252
Essentially the comparison can fail at random due to difference in sorting algorithm.
Change sorting to use the stable version.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2278.org.readthedocs.build/en/2278/

<!-- readthedocs-preview torchmetrics end -->