### PR TITLE
ci: split publishing to small steps/jobs

### DIFF
--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -32,7 +32,7 @@ jobs:
           name: pypi-packages-${{ github.sha }}
           path: dist
 
-  upload-package:
+  release-upload:
     needs: build-package
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     runs-on: ubuntu-latest
@@ -50,18 +50,17 @@ jobs:
           files: "dist/*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-  publish-package:
+  publish-pypi-test:
     needs: build-package
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
       - run: ls -lh dist/
-
       # We do this, since failures on test.pypi aren't that bad
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
@@ -71,11 +70,25 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           verbose: true
 
-      - name: Delay releasing
-        uses: juliangruber/sleep-action@v1
+  publish-delayed:
+    needs: publish-pypi-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: juliangruber/sleep-action@v1
         with:
           time: 5m
 
+  publish-pypi-main:
+    needs: [build-package, publish-delayed]
+    if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+      - run: ls -lh dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -4,6 +4,10 @@ name: PyPI Release
 on: # Trigger the workflow on push or pull request, but only for the master branch
   push:
     branches: [master, "release/*"]
+  pull_request:
+    branches: [master, "release/*"]
+    paths:
+      - ".github/workflows/publish-pkg.yml"
   release:
     types: [published]
 


### PR DESCRIPTION
## What does this PR do?

make cleaner the workflow from top level
![image](https://github.com/Lightning-AI/torchmetrics/assets/6035284/85c4f63f-d607-42f1-a540-7e2c64a5abef)


<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2313.org.readthedocs.build/en/2313/

<!-- readthedocs-preview torchmetrics end -->