### PR TITLE
ci: set PT 2.2 as stable latest

### DIFF
--- a/.azure/gpu-integrations.yml
+++ b/.azure/gpu-integrations.yml
@@ -22,8 +22,8 @@ jobs:
           torch-ver: "1.13.1"
           requires: "oldest"
         "torch | 2.x":
-          docker-image: "pytorch/pytorch:2.1.2-cuda12.1-cudnn8-runtime"
-          torch-ver: "2.1.2"
+          docker-image: "pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime"
+          torch-ver: "2.2.0"
     # how long to run the job before automatically cancelling
     timeoutInMinutes: "40"
     # how much time to give 'run always even if cancelled tasks' before stopping them

--- a/.azure/gpu-unittests.yml
+++ b/.azure/gpu-unittests.yml
@@ -25,9 +25,6 @@ jobs:
           docker-image: "pytorchlightning/torchmetrics:ubuntu22.04-cuda11.8.0-py3.9-torch1.13"
           torch-ver: "1.13.1"
         "PyTorch | 2.X":
-          docker-image: "pytorchlightning/torchmetrics:ubuntu22.04-cuda12.1.1-py3.10-torch2.1"
-          torch-ver: "2.1.2"
-        "PyTorch | RC":
           docker-image: "pytorchlightning/torchmetrics:ubuntu22.04-cuda12.1.1-py3.11-torch2.2"
           torch-ver: "2.2.0"
     # how long to run the job before automatically cancelling

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,23 +33,25 @@ jobs:
       matrix:
         os: ["ubuntu-20.04"]
         python-version: ["3.9"]
-        pytorch-version: ["1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2"]
+        pytorch-version:
+          - "1.10.2"
+          - "1.11.0"
+          - "1.12.1"
+          - "1.13.1"
+          - "2.0.1"
+          - "2.1.2"
+          - "2.2.0"
         include:
           - { os: "ubuntu-22.04", python-version: "3.8", pytorch-version: "1.13.1" }
-          - { os: "ubuntu-22.04", python-version: "3.10", pytorch-version: "1.13.1" }
           - { os: "ubuntu-22.04", python-version: "3.10", pytorch-version: "2.0.1" }
-          - { os: "ubuntu-22.04", python-version: "3.10", pytorch-version: "2.1.2" }
-          - { os: "ubuntu-22.04", python-version: "3.11", pytorch-version: "2.1.2" }
           - { os: "ubuntu-22.04", python-version: "3.10", pytorch-version: "2.2.0" }
           - { os: "ubuntu-22.04", python-version: "3.11", pytorch-version: "2.2.0" }
           - { os: "macOS-12", python-version: "3.8", pytorch-version: "1.13.1" }
-          - { os: "macOS-12", python-version: "3.9", pytorch-version: "1.13.1" }
           - { os: "macOS-12", python-version: "3.10", pytorch-version: "2.0.1" }
-          - { os: "macOS-12", python-version: "3.11", pytorch-version: "2.1.2" }
+          - { os: "macOS-12", python-version: "3.11", pytorch-version: "2.2.0" }
           - { os: "windows-2022", python-version: "3.8", pytorch-version: "1.13.1" }
-          - { os: "windows-2022", python-version: "3.9", pytorch-version: "1.13.1" }
           - { os: "windows-2022", python-version: "3.10", pytorch-version: "2.0.1" }
-          # - { os: "windows-2022", python-version: "3.11", pytorch-version: "2.1.2" }  # TODO
+          - { os: "windows-2022", python-version: "3.11", pytorch-version: "2.2.0" }
     env:
       PYTORCH_URL: "https://download.pytorch.org/whl/cpu/torch_stable.html"
       FREEZE_REQUIREMENTS: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
@@ -91,9 +93,9 @@ jobs:
           pytorch-version: ${{ matrix.pytorch-version }}
           pypi-dir: ${{ env.PYPI_CACHE }}
 
-      - name: Switch to PT test URL
-        if: ${{ matrix.pytorch-version == '2.2.0' }}
-        run: echo 'PYTORCH_URL=https://download.pytorch.org/whl/test/cpu/torch_test.html' >> $GITHUB_ENV
+      #- name: Switch to PT test URL
+      #  if: ${{ matrix.pytorch-version == '2.3.0' }}
+      #  run: echo 'PYTORCH_URL=https://download.pytorch.org/whl/test/cpu/torch_test.html' >> $GITHUB_ENV
       - name: Install pkg
         timeout-minutes: 25
         run: |


### PR DESCRIPTION
## What does this PR do?

Follow the final PT 2.2 release, not using RC any more...

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2352.org.readthedocs.build/en/2352/

<!-- readthedocs-preview torchmetrics end -->