### PR TITLE
ci: patch run with no tests

### DIFF
--- a/.azure/gpu-unittests.yml
+++ b/.azure/gpu-unittests.yml
@@ -146,6 +146,8 @@ jobs:
             --cov=torchmetrics --timeout=240 --durations=100 \
             --reruns 3 --reruns-delay 1
         workingDirectory: tests
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        condition: ne(variables['TEST_DIRS'], '')
         displayName: "UnitTesting common"
 
       - bash: |
@@ -155,6 +157,8 @@ jobs:
         env:
           USE_PYTEST_POOL: "1"
         workingDirectory: tests
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        condition: ne(variables['TEST_DIRS'], '')
         displayName: "UnitTesting DDP"
 
       - bash: |
@@ -164,6 +168,8 @@ jobs:
             --commit=$(Build.SourceVersion) --flags=gpu,unittest --env=linux,azure
           ls -l
         workingDirectory: tests
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        condition: ne(variables['TEST_DIRS'], '')
         displayName: "Statistics"
 
       - bash: |
@@ -175,6 +181,8 @@ jobs:
             python $fn
           done
         workingDirectory: examples
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        condition: ne(variables['TEST_DIRS'], '')
         displayName: "Examples"
 
       - bash: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -144,6 +144,8 @@ jobs:
         run: python -m phmdoctest README.md --outfile tests/unittests/test_readme.py
 
       - name: Unittests common
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        if: ${{ env.TEST_DIRS != '' }}
         working-directory: ./tests
         run: |
           python -m pytest -v \
@@ -158,6 +160,8 @@ jobs:
             ${{ env.UNITTEST_TIMEOUT }}
 
       - name: Unittests DDP
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        if: ${{ env.TEST_DIRS != '' }}
         working-directory: ./tests
         env:
           USE_PYTEST_POOL: "1"
@@ -172,13 +176,16 @@ jobs:
             ${{ env.UNITTEST_TIMEOUT }}
 
       - name: Statistics
-        if: success()
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        if: ${{ env.TEST_DIRS != '' }}
         working-directory: ./tests
         run: |
           coverage xml
           coverage report
 
       - name: Upload coverage to Codecov
+        # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
+        if: ${{ env.TEST_DIRS != '' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Open #2345 revealed we had false positive failing cases when there were only docs changes
https://github.com/Lightning-AI/torchmetrics/blob/dc115fe2bc287dd54b201da05a30b0c749a2d908/.github/assistant.py#L135-L136
The assistant for docs or other no-code changes returns an empty string, but that is interpreted by running all, including integrations which has missing requirements

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2362.org.readthedocs.build/en/2362/

<!-- readthedocs-preview torchmetrics end -->