### PR TITLE
Fix Perplexity docs

### DIFF
--- a/src/torchmetrics/text/perplexity.py
+++ b/src/torchmetrics/text/perplexity.py
@@ -33,8 +33,8 @@ class Perplexity(Metric):
     As input to ``forward`` and ``update`` the metric accepts the following input:
 
     - ``preds`` (:class:`~torch.Tensor`): Logits or a unnormalized score assigned to each token in a sequence with shape
-        [batch_size, seq_len, vocab_size], which is the output of a language model. Scores will be normalized internally
-        using softmax.
+      [batch_size, seq_len, vocab_size], which is the output of a language model. Scores will be normalized internally
+      using softmax.
     - ``target`` (:class:`~torch.Tensor`): Ground truth values with a shape [batch_size, seq_len]
 
     As output of ``forward`` and ``compute`` the metric returns the following output:


### PR DESCRIPTION
## What does this PR do?

Fixes the docs of [Perplexity](https://lightning.ai/docs/torchmetrics/stable/text/perplexity.html): it has incorrect indentation so it's not rendered right.

Before the fix:

![before](https://github.com/Lightning-AI/torchmetrics/assets/22856433/f9f77cae-f97b-42c0-a7ef-1fadb1c80bf5)

After the fix:

![after](https://github.com/Lightning-AI/torchmetrics/assets/22856433/a4058793-a2d9-4b4d-ab53-a79b6772cd08)


<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

No. Building the docs is hard for me. I cannot install the `lai-sphinx-theme` package easily. I refered to [pytorch-lightning](https://github.com/Lightning-AI/pytorch-lightning)'s Makefile to figure out that it can be installed using AWS S3 CLI.


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2391.org.readthedocs.build/en/2391/

<!-- readthedocs-preview torchmetrics end -->