### PR TITLE
Docs: fix typo in wip

### DIFF
--- a/src/torchmetrics/text/wip.py
+++ b/src/torchmetrics/text/wip.py
@@ -33,7 +33,7 @@ class WordInfoPreserved(Metric):
     computed as:
 
     .. math::
-        wip = \frac{C}{N} + \frac{C}{P}
+        wip = \frac{C}{N} * \frac{C}{P}
 
     where:
 


### PR DESCRIPTION
s/+/*/

## What does this PR do?

Fixes a typo in the documentation
