### PR TITLE
ci: fix PR's file changed limit

### DIFF
--- a/.azure/gpu-integrations.yml
+++ b/.azure/gpu-integrations.yml
@@ -50,7 +50,7 @@ jobs:
           echo "##vso[task.setvariable variable=CUDA_VERSION_MM]$CUDA_version_mm"
           echo "##vso[task.setvariable variable=TORCH_URL]https://download.pytorch.org/whl/cu${CUDA_version_mm}/torch_stable.html"
           # packages for running assistant
-          pip install -q packaging fire requests wget
+          pip install -q fire wget
         displayName: "set Env. vars"
 
       - bash: |

--- a/.azure/gpu-unittests.yml
+++ b/.azure/gpu-unittests.yml
@@ -73,6 +73,7 @@ jobs:
         displayName: "set Env. vars for PRs"
 
       - bash: |
+          pip install -q fire pyGithub
           printf "PR: $PR_NUMBER \n"
           focus=$(python .github/assistant.py changed-domains $PR_NUMBER)
           printf "focus: $focus \n"

--- a/.github/actions/pull-caches/action.yml
+++ b/.github/actions/pull-caches/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: install assistant's deps
-      run: pip install -q fire requests packaging wget
+      run: pip install -q fire wget
       shell: bash
 
     - name: Set PyTorch version

--- a/.github/workflows/_focus-diff.yml
+++ b/.github/workflows/_focus-diff.yml
@@ -27,7 +27,7 @@ jobs:
           PR_NUMBER: "${{ github.event.pull_request.number }}"
         run: |
           echo $PR_NUMBER
-          pip install fire requests
+          pip install fire pyGithub
           # python .github/assistant.py changed-domains $PR_NUMBER
           echo "focus=$(python .github/assistant.py changed-domains $PR_NUMBER)" >> $GITHUB_OUTPUT
 

--- a/requirements/_tests.txt
+++ b/requirements/_tests.txt
@@ -11,7 +11,7 @@ pytest-xdist ==3.5.0
 phmdoctest ==1.4.0
 
 psutil <5.10.0
-requests <=2.31.0
+pyGithub ==2.2.0
 fire <=0.5.0
 
 cloudpickle >1.3, <=3.0.0


### PR DESCRIPTION
## What does this PR do?

seems that using simple request limited nb files to 30, so if PR was larger other files were ignored, see test against #2335
`master` response:
```
unittests/bases unittests/audio unittests/classification
```
This fix response:
```
unittests/bases unittests/image unittests/clustering unittests/nominal unittests/detection unittests/regression unittests/text unittests/audio unittests/classification unittests/multimodal
```

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
