### PR TITLE
lint/ruff: replace `pyupgrade` with rule "UP"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,13 +37,6 @@ repos:
         args: ["--maxkb=100", "--enforce-all"]
       - id: detect-private-key
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py38-plus"]
-        name: Upgrade code
-
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ lint.select = [
     "D", # see: https://pypi.org/project/pydocstyle
     "N", # see: https://pypi.org/project/pep8-naming
     "S", # see: https://pypi.org/project/flake8-bandit
+    "UP", # see: https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
 lint.extend-select = [
     "A",    # see: https://pypi.org/project/flake8-builtins


### PR DESCRIPTION
## What does this PR do?

see: https://docs.astral.sh/ruff/rules/#pyupgrade-up

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2432.org.readthedocs.build/en/2432/

<!-- readthedocs-preview torchmetrics end -->