### PR TITLE
Fix input types for `MultitaskWrapper`

### DIFF
--- a/src/torchmetrics/wrappers/multitask.py
+++ b/src/torchmetrics/wrappers/multitask.py
@@ -159,7 +159,7 @@ class MultitaskWrapper(WrapperMetric):
                     f"Found a metric of type {type(metric)}"
                 )
 
-    def update(self, task_preds: Dict[str, Tensor], task_targets: Dict[str, Tensor]) -> None:
+    def update(self, task_preds: Dict[str, Any], task_targets: Dict[str, Any]) -> None:
         """Update each task's metric with its corresponding pred and target.
 
         Args:


### PR DESCRIPTION
## What does this PR do?

Fixes #2398
Since the base metric in `MultitaskWrapper` can be any metric, by consequence the input to `MultitaskWrapper` needs to support all possible combinations of input that any metric case take. Therefore changing `Tensor` to `Any` in this case.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
