### PR TITLE
Fix return type documentation of inception score

### DIFF
--- a/src/torchmetrics/image/inception.py
+++ b/src/torchmetrics/image/inception.py
@@ -38,7 +38,7 @@ class InceptionScore(Metric):
         IS = exp(\mathbb{E}_x KL(p(y | x ) || p(y)))
 
     where :math:`KL(p(y | x) || p(y))` is the KL divergence between the conditional distribution :math:`p(y|x)`
-    and the margianl distribution :math:`p(y)`. Both the conditional and marginal distribution is calculated
+    and the marginal distribution :math:`p(y)`. Both the conditional and marginal distribution is calculated
     from features extracted from the images. The score is calculated on random splits of the images such that
     both a mean and standard deviation of the score are returned. The metric was originally proposed in
     `inception ref1`_.
@@ -59,7 +59,8 @@ class InceptionScore(Metric):
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``fid`` (:class:`~torch.Tensor`): float scalar tensor with mean FID value over samples
+    - ``inception_mean`` (:class:`~torch.Tensor`): float scalar tensor with mean inception score over subsets
+    - ``inception_std`` (:class:`~torch.Tensor`): float scalar tensor with standard deviation of inception score over subsets
 
     Args:
         feature:

--- a/src/torchmetrics/image/inception.py
+++ b/src/torchmetrics/image/inception.py
@@ -60,7 +60,8 @@ class InceptionScore(Metric):
     As output of `forward` and `compute` the metric returns the following output
 
     - ``inception_mean`` (:class:`~torch.Tensor`): float scalar tensor with mean inception score over subsets
-    - ``inception_std`` (:class:`~torch.Tensor`): float scalar tensor with standard deviation of inception score over subsets
+    - ``inception_std`` (:class:`~torch.Tensor`): float scalar tensor with standard deviation of inception score
+      over subsets
 
     Args:
         feature:


### PR DESCRIPTION
## What does this PR do?

Fixes some typo on the documentation of InceptionScore. Return type mentioned on the documentation is wrong and misleading in it's current state.

<details>
  <summary>Before submitting</summary>

- [X Typo fix] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [+] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [+] Did you make sure to **update the docs**?
- [+ Typo fix so no need for tests] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2467.org.readthedocs.build/en/2467/

<!-- readthedocs-preview torchmetrics end -->