### PR TITLE
Support for `torch.float` weighted networks for FID and KID calculations.

### DIFF
--- a/.azure/gpu-unittests.yml
+++ b/.azure/gpu-unittests.yml
@@ -28,7 +28,7 @@ jobs:
           docker-image: "pytorchlightning/torchmetrics:ubuntu22.04-cuda12.1.1-py3.11-torch2.2"
           torch-ver: "2.2.1"
     # how long to run the job before automatically cancelling
-    timeoutInMinutes: "120"
+    timeoutInMinutes: "180"
     # how much time to give 'run always even if cancelled tasks' before stopping them
     cancelTimeoutInMinutes: "2"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for calculating segmentation quality and recognition quality in `PanopticQuality` metric ([#2381](https://github.com/Lightning-AI/torchmetrics/pull/2381))
 
 
+- Added support for `torch.float` weighted networks for FID and KID calculations ([#2483](https://github.com/Lightning-AI/torchmetrics/pull/2483))
+
+
 ### Changed
 
 - Made `__getattr__` and `__setattr__` of `ClasswiseWrapper` more general ([#2424](https://github.com/Lightning-AI/torchmetrics/pull/2424))

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -202,7 +202,7 @@ class FrechetInceptionDistance(Metric):
     custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the
     used feature extractor from default (Inception v3) to the given network. In case network doesn't have
     ``num_features`` attribute, a random tensor will be given to the network to infer feature dimensionality.
-    Size of this tensor can be controlled by `input_img_size` argument and type of the tensor can be controlled
+    Size of this tensor can be controlled by ``input_img_size`k` argument and type of the tensor can be controlled
     with `normalize` argument (True uses float32 tensors and False uses int8 tensors). In this case, update method
     expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible to
     the custom feature extractor.

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -329,7 +329,7 @@ class FrechetInceptionDistance(Metric):
                 if self.normalize:
                     dummy_image = torch.rand(1, *input_img_size, dtype=torch.float32)
                 else:
-                    dummy_image = torch.randint(0, 255, input_img_size, dtype=torch.uint8)
+                    dummy_image = torch.randint(0, 255, (1, *input_img_size), dtype=torch.uint8)
                 num_features = self.inception(dummy_image).shape[-1]
         else:
             raise TypeError("Got unknown input to argument `feature`")

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -203,9 +203,9 @@ class FrechetInceptionDistance(Metric):
     used feature extractor from default (Inception v3) to the given network. In case network doesn't have
     ``num_features`` attribute, a random tensor will be given to the network to infer feature dimensionality.
     Size of this tensor can be controlled by ``input_img_size`` argument and type of the tensor can be controlled
-    with ``normalize`` argument (``True`` uses float32 tensors and ``False`` uses int8 tensors). In this case, update method
-    expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible to
-    the custom feature extractor.
+    with ``normalize`` argument (``True`` uses float32 tensors and ``False`` uses int8 tensors). In this case, update
+    method expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible
+    to the custom feature extractor.
 
     This metric is known to be unstable in its calculatations, and we recommend for the best results using this metric
     that you calculate using `torch.float64` (default is `torch.float32`) which can be set using the `.set_dtype`
@@ -237,13 +237,18 @@ class FrechetInceptionDistance(Metric):
         reset_real_features: Whether to also reset the real features. Since in many cases the real dataset does not
             change, the features can be cached them to avoid recomputing them which is costly. Set this to ``False`` if
             your dataset does not change.
-        normalize: boolean
-            - if default feature extractor is used, controls whether input imgs have values in range [0, 1] or not.
-                - True: if input imgs have values ranged in [0, 1]. They are cast to int8/byte tensors.
-                - False: if input imgs have values ranged in [0, 255]. No casting is done.
-            - if custom feature extractor module is used, controls type of the input img tensors.
-                - True: if input imgs are expected to be in the data type of torch.float32.
-                - False: if input imgs are expected to be in the data type of torch.int8.
+        normalize:
+            Argument for controlling the input image dtype normalization:
+
+            - If default feature extractor is used, controls whether input imgs have values in range [0, 1] or not:
+
+              - True: if input imgs have values ranged in [0, 1]. They are cast to int8/byte tensors.
+              - False: if input imgs have values ranged in [0, 255]. No casting is done.
+
+            - If custom feature extractor module is used, controls type of the input img tensors:
+
+              - True: if input imgs are expected to be in the data type of torch.float32.
+              - False: if input imgs are expected to be in the data type of torch.int8.
         input_img_size: tuple of integers. Indicates input img size to the custom feature extractor network if provided.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -198,13 +198,13 @@ class FrechetInceptionDistance(Metric):
     flag ``real`` determines if the images should update the statistics of the real distribution or the
     fake distribution.
 
-    Using custom feature extractor is also possible. One can give a torch.nn.Module as `feature` argument. This 
-    custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the 
-    used feature extractor from default (Inception v3) to the given network. In case network doesn't have 
-    ``num_features`` attribute, a random tensor will be given to the network to infer feature dimentionality. 
-    Size of this tensor can be controlled by `input_img_size` argument and type of the tensor can be controlled 
-    with `normalize` argument (True uses float32 tensors and False uses int8 tensors). In this case, update method 
-    expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible to 
+    Using custom feature extractor is also possible. One can give a torch.nn.Module as `feature` argument. This
+    custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the
+    used feature extractor from default (Inception v3) to the given network. In case network doesn't have
+    ``num_features`` attribute, a random tensor will be given to the network to infer feature dimensionality.
+    Size of this tensor can be controlled by `input_img_size` argument and type of the tensor can be controlled
+    with `normalize` argument (True uses float32 tensors and False uses int8 tensors). In this case, update method
+    expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible to
     the custom feature extractor.
 
     This metric is known to be unstable in its calculatations, and we recommend for the best results using this metric
@@ -299,7 +299,7 @@ class FrechetInceptionDistance(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        
+
         if not isinstance(normalize, bool):
             raise ValueError("Argument `normalize` expected to be a bool")
         self.normalize = normalize
@@ -349,11 +349,12 @@ class FrechetInceptionDistance(Metric):
 
     def update(self, imgs: Tensor, real: bool) -> None:
         """Update the state with extracted features.
-        
+
         Args:
             imgs: Input img tensors to evaluate. If used custom feature extractor please
                 make sure dtype and size is correct for the model.
             real: Whether given image is real or fake.
+
         """
         imgs = (imgs * 255).byte() if self.normalize and (not self.used_custom_model) else imgs
         features = self.inception(imgs)

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -327,7 +327,7 @@ class FrechetInceptionDistance(Metric):
                 num_features = self.inception.num_features
             else:
                 if self.normalize:
-                    dummy_image = torch.rand(input_img_size, dtype=torch.float32)
+                    dummy_image = torch.rand(1, *input_img_size, dtype=torch.float32)
                 else:
                     dummy_image = torch.randint(0, 255, input_img_size, dtype=torch.uint8)
                 num_features = self.inception(dummy_image).shape[-1]

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -203,7 +203,7 @@ class FrechetInceptionDistance(Metric):
     used feature extractor from default (Inception v3) to the given network. In case network doesn't have
     ``num_features`` attribute, a random tensor will be given to the network to infer feature dimensionality.
     Size of this tensor can be controlled by ``input_img_size`k` argument and type of the tensor can be controlled
-    with `normalize` argument (True uses float32 tensors and False uses int8 tensors). In this case, update method
+    with ``normalize`` argument (``True`` uses float32 tensors and ``False`` uses int8 tensors). In this case, update method
     expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible to
     the custom feature extractor.
 

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -295,7 +295,7 @@ class FrechetInceptionDistance(Metric):
         feature: Union[int, Module] = 2048,
         reset_real_features: bool = True,
         normalize: bool = False,
-        input_img_size: Tuple[int, int, int, int] = (1, 3, 299, 299),
+        input_img_size: Tuple[int, int, int] = (3, 299, 299),
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -198,6 +198,15 @@ class FrechetInceptionDistance(Metric):
     flag ``real`` determines if the images should update the statistics of the real distribution or the
     fake distribution.
 
+    Using custom feature extractor is also possible. One can give a torch.nn.Module as `feature` argument. This 
+    custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the 
+    used feature extractor from default (Inception v3) to the given network. In case network doesn't have 
+    ``num_features`` attribute, a random tensor will be given to the network to infer feature dimentionality. 
+    Size of this tensor can be controlled by `input_img_size` argument and type of the tensor can be controlled 
+    with `normalize` argument (True uses float32 tensors and False uses int8 tensors). In this case, update method 
+    expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible to 
+    the custom feature extractor.
+
     This metric is known to be unstable in its calculatations, and we recommend for the best results using this metric
     that you calculate using `torch.float64` (default is `torch.float32`) which can be set using the `.set_dtype`
     method of the metric.
@@ -228,13 +237,15 @@ class FrechetInceptionDistance(Metric):
         reset_real_features: Whether to also reset the real features. Since in many cases the real dataset does not
             change, the features can be cached them to avoid recomputing them which is costly. Set this to ``False`` if
             your dataset does not change.
+        normalize: boolean
+            - if default feature extractor is used, controls whether input imgs have values in range [0, 1] or not.
+                - True: if input imgs have values ranged in [0, 1]. They are cast to int8/byte tensors.
+                - False: if input imgs have values ranged in [0, 255]. No casting is done.
+            - if custom feature extractor module is used, controls type of the input img tensors.
+                - True: if input imgs are expected to be in the data type of torch.float32.
+                - False: if input imgs are expected to be in the data type of torch.int8.
+        input_img_size: tuple of integers. Indicates input img size to the custom feature extractor network if provided.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
-
-    .. note::
-        If a custom feature extractor is provided through the `feature` argument it is expected to either have a
-        attribute called ``num_features`` that indicates the number of features returned by the forward pass or
-        alternatively we will pass through tensor of shape ``(1, 3, 299, 299)`` and dtype ``torch.uint8``` to the
-        forward pass and expect a tensor of shape ``(1, num_features)`` as output.
 
     Raises:
         ValueError:
@@ -284,6 +295,7 @@ class FrechetInceptionDistance(Metric):
         feature: Union[int, Module] = 2048,
         reset_real_features: bool = True,
         normalize: bool = False,
+        input_img_size: Tuple[int] = (1, 3, 299, 299),
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -291,6 +303,7 @@ class FrechetInceptionDistance(Metric):
         if not isinstance(normalize, bool):
             raise ValueError("Argument `normalize` expected to be a bool")
         self.normalize = normalize
+        self.used_custom_model = False
 
         if isinstance(feature, int):
             num_features = feature
@@ -309,13 +322,14 @@ class FrechetInceptionDistance(Metric):
 
         elif isinstance(feature, Module):
             self.inception = feature
+            self.used_custom_model = True
             if hasattr(self.inception, "num_features"):
                 num_features = self.inception.num_features
             else:
                 if self.normalize:
-                    dummy_image = torch.rand((1, 3, 299, 299), dtype=torch.float16)
+                    dummy_image = torch.rand(input_img_size, dtype=torch.float32)
                 else:
-                    dummy_image = torch.randint(0, 255, (1, 3, 299, 299), dtype=torch.uint8)
+                    dummy_image = torch.randint(0, 255, input_img_size, dtype=torch.uint8)
                 num_features = self.inception(dummy_image).shape[-1]
         else:
             raise TypeError("Got unknown input to argument `feature`")
@@ -334,8 +348,14 @@ class FrechetInceptionDistance(Metric):
         self.add_state("fake_features_num_samples", torch.tensor(0).long(), dist_reduce_fx="sum")
 
     def update(self, imgs: Tensor, real: bool) -> None:
-        """Update the state with extracted features."""
-        imgs = (imgs * 255).byte() if self.normalize else imgs
+        """Update the state with extracted features.
+        
+        Args:
+            imgs: Input img tensors to evaluate. If used custom feature extractor please
+                make sure dtype and size is correct for the model.
+            real: Whether given image is real or fake.
+        """
+        imgs = (imgs * 255).byte() if self.normalize and (not self.used_custom_model) else imgs
         features = self.inception(imgs)
         self.orig_dtype = features.dtype
         features = features.double()

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -199,7 +199,7 @@ class FrechetInceptionDistance(Metric):
     fake distribution.
 
     Using custom feature extractor is also possible. One can give a torch.nn.Module as `feature` argument. This
-    custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the
+    custom feature extractor is expected to have output shape of ``(1, num_features)``. This would change the
     used feature extractor from default (Inception v3) to the given network. In case network doesn't have
     ``num_features`` attribute, a random tensor will be given to the network to infer feature dimensionality.
     Size of this tensor can be controlled by ``input_img_size`k` argument and type of the tensor can be controlled

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -295,7 +295,7 @@ class FrechetInceptionDistance(Metric):
         feature: Union[int, Module] = 2048,
         reset_real_features: bool = True,
         normalize: bool = False,
-        input_img_size: Tuple[int] = (1, 3, 299, 299),
+        input_img_size: Tuple[int, int, int, int] = (1, 3, 299, 299),
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -202,7 +202,7 @@ class FrechetInceptionDistance(Metric):
     custom feature extractor is expected to have output shape of ``(1, num_features)``. This would change the
     used feature extractor from default (Inception v3) to the given network. In case network doesn't have
     ``num_features`` attribute, a random tensor will be given to the network to infer feature dimensionality.
-    Size of this tensor can be controlled by ``input_img_size`k` argument and type of the tensor can be controlled
+    Size of this tensor can be controlled by ``input_img_size`` argument and type of the tensor can be controlled
     with ``normalize`` argument (``True`` uses float32 tensors and ``False`` uses int8 tensors). In this case, update method
     expects to have the tensor given to `imgs` argument to be in the correct shape and type that is compatible to
     the custom feature extractor.

--- a/src/torchmetrics/image/kid.py
+++ b/src/torchmetrics/image/kid.py
@@ -91,10 +91,10 @@ class KernelInceptionDistance(Metric):
     flag ``real`` determines if the images should update the statistics of the real distribution or the
     fake distribution.
 
-    Using custom feature extractor is also possible. One can give a torch.nn.Module as `feature` argument. This 
-    custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the 
+    Using custom feature extractor is also possible. One can give a torch.nn.Module as `feature` argument. This
+    custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the
     used feature extractor from default (Inception v3) to the given network. ``normalize`` argument won't have any
-    effect and update method expects to have the tensor given to `imgs` argument to be in the correct shape and 
+    effect and update method expects to have the tensor given to `imgs` argument to be in the correct shape and
     type that is compatible to the custom feature extractor.
 
     .. note:: using this metric with the default feature extractor requires that ``torch-fidelity``
@@ -248,11 +248,13 @@ class KernelInceptionDistance(Metric):
 
     def update(self, imgs: Tensor, real: bool) -> None:
         """Update the state with extracted features.
-        
+
         Args:
             imgs: Input img tensors to evaluate. If used custom feature extractor please
                 make sure dtype and size is correct for the model.
-            real: Whether given image is real or fake."""
+            real: Whether given image is real or fake.
+
+        """
         imgs = (imgs * 255).byte() if self.normalize and (not self.used_custom_model) else imgs
         features = self.inception(imgs)
 

--- a/src/torchmetrics/image/kid.py
+++ b/src/torchmetrics/image/kid.py
@@ -91,6 +91,12 @@ class KernelInceptionDistance(Metric):
     flag ``real`` determines if the images should update the statistics of the real distribution or the
     fake distribution.
 
+    Using custom feature extractor is also possible. One can give a torch.nn.Module as `feature` argument. This 
+    custom feature extractor is expected to have output shape of ``(1, num_features)`` This would change the 
+    used feature extractor from default (Inception v3) to the given network. ``normalize`` argument won't have any
+    effect and update method expects to have the tensor given to `imgs` argument to be in the correct shape and 
+    type that is compatible to the custom feature extractor.
+
     .. note:: using this metric with the default feature extractor requires that ``torch-fidelity``
         is installed. Either install as ``pip install torchmetrics[image]`` or
         ``pip install torch-fidelity``
@@ -103,7 +109,7 @@ class KernelInceptionDistance(Metric):
     As output of `forward` and `compute` the metric returns the following output
 
     - ``kid_mean`` (:class:`~torch.Tensor`): float scalar tensor with mean value over subsets
-    - ``kid_std`` (:class:`~torch.Tensor`): float scalar tensor with mean value over subsets
+    - ``kid_std`` (:class:`~torch.Tensor`): float scalar tensor with standard deviation value over subsets
 
     Args:
         feature: Either an str, integer or ``nn.Module``:
@@ -187,6 +193,8 @@ class KernelInceptionDistance(Metric):
             UserWarning,
         )
 
+        self.used_custom_model = False
+
         if isinstance(feature, (str, int)):
             if not _TORCH_FIDELITY_AVAILABLE:
                 raise ModuleNotFoundError(
@@ -202,6 +210,7 @@ class KernelInceptionDistance(Metric):
             self.inception: Module = NoTrainInceptionV3(name="inception-v3-compat", features_list=[str(feature)])
         elif isinstance(feature, Module):
             self.inception = feature
+            self.used_custom_model = True
         else:
             raise TypeError("Got unknown input to argument `feature`")
 
@@ -238,8 +247,13 @@ class KernelInceptionDistance(Metric):
         self.add_state("fake_features", [], dist_reduce_fx=None)
 
     def update(self, imgs: Tensor, real: bool) -> None:
-        """Update the state with extracted features."""
-        imgs = (imgs * 255).byte() if self.normalize else imgs
+        """Update the state with extracted features.
+        
+        Args:
+            imgs: Input img tensors to evaluate. If used custom feature extractor please
+                make sure dtype and size is correct for the model.
+            real: Whether given image is real or fake."""
+        imgs = (imgs * 255).byte() if self.normalize and (not self.used_custom_model) else imgs
         features = self.inception(imgs)
 
         if real:
@@ -251,6 +265,10 @@ class KernelInceptionDistance(Metric):
         """Calculate KID score based on accumulated extracted features from the two distributions.
 
         Implementation inspired by `Fid Score`_
+
+        Returns:
+            kid_mean (:class:`~torch.Tensor`): float scalar tensor with mean value over subsets
+            kid_std (:class:`~torch.Tensor`): float scalar tensor with standard deviation value over subsets
 
         """
         real_features = dim_zero_cat(self.real_features)

--- a/tests/unittests/image/test_fid.py
+++ b/tests/unittests/image/test_fid.py
@@ -81,6 +81,7 @@ def test_fid_raises_errors_and_warnings():
 
 class DummyFeatureExtractor(Module):
     def __init__(self):
+        super().__init__()
         self.flatten = torch.nn.Flatten()
         self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
 

--- a/tests/unittests/image/test_fid.py
+++ b/tests/unittests/image/test_fid.py
@@ -86,6 +86,7 @@ class DummyFeatureExtractor(Module):
         self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
 
     def __call__(self, img):
+        img = (img / 125.5).float() # Convert int img input to float as Linear layer expects float inputs
         return self.extractor(self.flatten(img))
 
 

--- a/tests/unittests/image/test_fid.py
+++ b/tests/unittests/image/test_fid.py
@@ -79,19 +79,20 @@ def test_fid_raises_errors_and_warnings():
     with pytest.raises(TypeError, match="Got unknown input to argument `feature`"):
         _ = FrechetInceptionDistance(feature=[1, 2])
 
-class DummyFeatureExtractor(Module):
-    def __init__(self):
+
+class _DummyFeatureExtractor(Module):
+    def __init__(self) -> None:
         super().__init__()
         self.flatten = torch.nn.Flatten()
         self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
 
-    def __call__(self, img):
-        img = (img / 125.5).float() # Convert int img input to float as Linear layer expects float inputs
+    def __call__(self, img) -> torch.Tensor:
+        img = (img / 125.5).float()  # Convert int img input to float as Linear layer expects float inputs
         return self.extractor(self.flatten(img))
 
 
 @pytest.mark.skipif(not _TORCH_FIDELITY_AVAILABLE, reason="metric requires torch-fidelity")
-@pytest.mark.parametrize("feature", [64, 192, 768, 2048, DummyFeatureExtractor()])
+@pytest.mark.parametrize("feature", [64, 192, 768, 2048, _DummyFeatureExtractor()])
 def test_fid_same_input(feature):
     """If real and fake are update on the same data the fid score should be 0."""
     metric = FrechetInceptionDistance(feature=feature)

--- a/tests/unittests/image/test_fid.py
+++ b/tests/unittests/image/test_fid.py
@@ -79,9 +79,17 @@ def test_fid_raises_errors_and_warnings():
     with pytest.raises(TypeError, match="Got unknown input to argument `feature`"):
         _ = FrechetInceptionDistance(feature=[1, 2])
 
+class DummyFeatureExtractor(Module):
+    def __init__(self):
+        self.flatten = torch.nn.Flatten()
+        self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
+
+    def __call__(self, img):
+        return self.extractor(self.flatten(img))
+
 
 @pytest.mark.skipif(not _TORCH_FIDELITY_AVAILABLE, reason="metric requires torch-fidelity")
-@pytest.mark.parametrize("feature", [64, 192, 768, 2048])
+@pytest.mark.parametrize("feature", [64, 192, 768, 2048, DummyFeatureExtractor()])
 def test_fid_same_input(feature):
     """If real and fake are update on the same data the fid score should be 0."""
     metric = FrechetInceptionDistance(feature=feature)

--- a/tests/unittests/image/test_kid.py
+++ b/tests/unittests/image/test_kid.py
@@ -101,19 +101,20 @@ def test_kid_extra_parameters():
     with pytest.raises(ValueError, match="Argument `coef` expected to be float larger than 0"):
         KernelInceptionDistance(coef=-1)
 
-class DummyFeatureExtractor(Module):
-    def __init__(self):
+
+class _DummyFeatureExtractor(Module):
+    def __init__(self) -> None:
         super().__init__()
         self.flatten = torch.nn.Flatten()
         self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
 
-    def __call__(self, img):
-        img = (img / 125.5).float() # Convert int img input to float as Linear layer expects float inputs
+    def __call__(self, img) -> torch.Tensor:
+        img = (img / 125.5).float()  # Convert int img input to float as Linear layer expects float inputs
         return self.extractor(self.flatten(img))
 
 
 @pytest.mark.skipif(not _TORCH_FIDELITY_AVAILABLE, reason="metric requires torch-fidelity")
-@pytest.mark.parametrize("feature", [64, 192, 768, 2048, DummyFeatureExtractor()])
+@pytest.mark.parametrize("feature", [64, 192, 768, 2048, _DummyFeatureExtractor()])
 def test_kid_same_input(feature):
     """Test that the metric works."""
     metric = KernelInceptionDistance(feature=feature, subsets=5, subset_size=2)

--- a/tests/unittests/image/test_kid.py
+++ b/tests/unittests/image/test_kid.py
@@ -103,6 +103,7 @@ def test_kid_extra_parameters():
 
 class DummyFeatureExtractor(Module):
     def __init__(self):
+        super().__init__()
         self.flatten = torch.nn.Flatten()
         self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
 

--- a/tests/unittests/image/test_kid.py
+++ b/tests/unittests/image/test_kid.py
@@ -101,9 +101,17 @@ def test_kid_extra_parameters():
     with pytest.raises(ValueError, match="Argument `coef` expected to be float larger than 0"):
         KernelInceptionDistance(coef=-1)
 
+class DummyFeatureExtractor(Module):
+    def __init__(self):
+        self.flatten = torch.nn.Flatten()
+        self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
+
+    def __call__(self, img):
+        return self.extractor(self.flatten(img))
+
 
 @pytest.mark.skipif(not _TORCH_FIDELITY_AVAILABLE, reason="metric requires torch-fidelity")
-@pytest.mark.parametrize("feature", [64, 192, 768, 2048])
+@pytest.mark.parametrize("feature", [64, 192, 768, 2048, DummyFeatureExtractor()])
 def test_kid_same_input(feature):
     """Test that the metric works."""
     metric = KernelInceptionDistance(feature=feature, subsets=5, subset_size=2)

--- a/tests/unittests/image/test_kid.py
+++ b/tests/unittests/image/test_kid.py
@@ -108,6 +108,7 @@ class DummyFeatureExtractor(Module):
         self.extractor = torch.nn.Linear(3 * 299 * 299, 64)
 
     def __call__(self, img):
+        img = (img / 125.5).float() # Convert int img input to float as Linear layer expects float inputs
         return self.extractor(self.flatten(img))
 
 


### PR DESCRIPTION
## What does this PR do?
For evaluation of generated images in terms of how similar looking they are to the real images metrics FID is heavily used. However as pointed out in several papers, FID has some inherent flaws one of which is ImageNet InceptionV3 model is not suitable for all domains. Domains like medical MRI might be different enough to ImageNet that activation functions are not relevant to make FID comparison. For cases like this different domains use different variants of InceptionV3 model as feature extractor.

However, current implementation of FID and KID in torchmetrics only supports models with byteTensor weights as it is optimized for the tochmetrics' InceptionV3 model. In this PR I have given a bit more control to the developer so that it is possible to have better support for custom feature extractors with different dtypes and input sizes.

Details of this issue can be found in the following paper:
Liu, Shaohui, et al. "An improved evaluation framework for generative adversarial networks." arXiv preprint arXiv:1803.07474 (2018).

Fixes #\<issue_number>

<details>
  <summary>Before submitting</summary>

- [X I had issues with my implementations and didn't found a solution] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [+] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [+] Did you make sure to **update the docs**?
- [+] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2483.org.readthedocs.build/en/2483/

<!-- readthedocs-preview torchmetrics end -->