### PR TITLE
docs: fix specificity when metric is not defined

### DIFF
--- a/src/torchmetrics/classification/specificity.py
+++ b/src/torchmetrics/classification/specificity.py
@@ -453,7 +453,7 @@ class Specificity(_ClassificationTaskWrapper):
     .. math:: \text{Specificity} = \frac{\text{TN}}{\text{TN} + \text{FP}}
 
     Where :math:`\text{TN}` and :math:`\text{FP}` represent the number of true negatives and false positives
-    respectively. The metric is only proper defined when :math:`\text{TP} + \text{FP} \neq 0`. If this case is
+    respectively. The metric is only proper defined when :math:`\text{TN} + \text{FP} \neq 0`. If this case is
     encountered for any class/label, the metric for that class/label will be set to 0 and the overall metric may
     therefore be affected in turn.
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2487 

<details>

Fixes the definition when the specificity metric is not defined.

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Figuring out how to build the docs locally takes a while ... (see #2488)

<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2491.org.readthedocs.build/en/2491/

<!-- readthedocs-preview torchmetrics end -->