### PR TITLE
ci/test: patch unstable `test_bleu_score_functional`

### DIFF
--- a/tests/unittests/text/test_sacre_bleu.py
+++ b/tests/unittests/text/test_sacre_bleu.py
@@ -21,6 +21,7 @@ from torch import Tensor, tensor
 from torchmetrics.functional.text.sacre_bleu import AVAILABLE_TOKENIZERS, _TokenizersLiteral, sacre_bleu_score
 from torchmetrics.text.sacre_bleu import SacreBLEUScore
 
+from unittests._helpers import skip_on_connection_issues
 from unittests.text._helpers import TextTester
 from unittests.text._inputs import _inputs_multiple_references
 
@@ -69,6 +70,7 @@ class TestSacreBLEUScore(TextTester):
             metric_args=metric_args,
         )
 
+    @skip_on_connection_issues(reason="could not download model or tokenizer")
     def test_bleu_score_functional(self, preds, targets, tokenize, lowercase):
         """Test functional implementation of metric."""
         if _should_skip_tokenizer(tokenize):


### PR DESCRIPTION
## What does this PR do?

not sure why we are getting:
```
unittests/text/_helpers.py:298: in run_functional_metric_test
    _functional_test(
unittests/text/_helpers.py:224: in _functional_test
    ref_result = _reference_cachier(reference_metric)(preds[i], targets[i], **extra_kwargs)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/cachier/core.py:290: in func_wrapper
    return _calc_entry(core, key, func, args, kwds)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/cachier/core.py:63: in _calc_entry
    func_res = func(*args, **kwds)
unittests/text/test_sacre_bleu.py:36: in _reference_sacre_bleu
    sacrebleu_fn = BLEU(tokenize=tokenize, lowercase=lowercase)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/sacrebleu/metrics/bleu.py:201: in __init__
    self.tokenizer = _get_tokenizer(best_tokenizer)()
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/sacrebleu/tokenizers/tokenizer_spm.py:66: in __init__
    super().__init__("flores200")
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/sacrebleu/tokenizers/tokenizer_spm.py:51: in __init__
    download_file(url, model_path)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/sacrebleu/utils.py:429: in download_file
    with urllib.request.urlopen(source_path) as f, open(dest_path, 'wb') as out:
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/urllib/request.py:214: in urlopen
    return opener.open(url, data, timeout)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/urllib/request.py:523: in open
    response = meth(req, response)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/urllib/request.py:632: in http_response
    response = self.parent.error(
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/urllib/request.py:561: in error
    return self._call_chain(*args)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/urllib/request.py:494: in _call_chain
    result = func(*args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <urllib.request.HTTPDefaultErrorHandler object at 0x7f55d57fb880>
req = <urllib.request.Request object at 0x7f55d5555250>
fp = <http.client.HTTPResponse object at 0x7f55de37c580>, code = 403
msg = 'Forbidden', hdrs = <http.client.HTTPMessage object at 0x7f55de3ed100>

    def http_error_default(self, req, fp, code, msg, hdrs):
>       raise HTTPError(req.full_url, code, msg, hdrs, fp)
E       urllib.error.HTTPError: HTTP Error 403: Forbidden
```

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2533.org.readthedocs.build/en/2533/

<!-- readthedocs-preview torchmetrics end -->