### PR TITLE
Don't import `pretty_errors`

### DIFF
--- a/requirements/debug.txt
+++ b/requirements/debug.txt
@@ -1,4 +1,2 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
-
-pretty-errors >=1.2.0, <1.3.0

--- a/src/torchmetrics/__init__.py
+++ b/src/torchmetrics/__init__.py
@@ -14,9 +14,6 @@ _logger.setLevel(__logging.INFO)
 _PACKAGE_ROOT = os.path.dirname(__file__)
 _PROJECT_ROOT = os.path.dirname(_PACKAGE_ROOT)
 
-if package_available("pretty_errors"):
-    import pretty_errors  # noqa: F401
-
 if package_available("PIL"):
     import PIL
 


### PR DESCRIPTION
It's really inappropriate for a low-level library like this to be making global changes to the way stack traces are rendered.  Especially since the "pretty" stack traces don't include file names or line numbers!  

This is just crazy.  All I wanted to do was import `lightning`, and I had to spend a couple hours tracking down why my stack traces were suddenly useless.  If users want this behavior, they should knowingly opt-in themselves.  They shouldn't be forced in by some dependency of a dependency of a dependency.

<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2543.org.readthedocs.build/en/2543/

<!-- readthedocs-preview torchmetrics end -->