### PR TITLE
docs: clarify the docs of PanopticQuality inputs

### DIFF
--- a/src/torchmetrics/detection/panoptic_qualities.py
+++ b/src/torchmetrics/detection/panoptic_qualities.py
@@ -53,9 +53,11 @@ class PanopticQuality(Metric):
 
     As input to ``forward`` and ``update`` the metric accepts the following input:
 
-        - ``preds`` (:class:`~torch.Tensor`): An int tensor of shape ``(B, *spatial_dims, 2)``, where there needs to
+        - ``preds`` (:class:`~torch.Tensor`): An int tensor of shape ``(B, *spatial_dims, 2)`` containing
+          the pair ``(category_id, instance_id)`` for each point, where there needs to
           be at least one spatial dimension.
-        - ``target`` (:class:`~torch.Tensor`): An int tensor of shape ``(B, *spatial_dims, 2)``, where there needs to
+        - ``target`` (:class:`~torch.Tensor`): An int tensor of shape ``(B, *spatial_dims, 2)`` containing
+          the pair ``(category_id, instance_id)`` for each point, where there needs to
           be at least one spatial dimension.
 
     As output to ``forward`` and ``compute`` the metric returns the following output:


### PR DESCRIPTION
## What does this PR do?

I want to improve the description of the PanpoticQuality.

The current description of the PanopticQuality is unclear about the meaning of the last dimension of the input whose shape is `(B, spatial_dims, 2)`, I want to clarify the meaning of last dimension (= 2). 

The statements I added are written in the docstring of the `update` method but they do not appear in the API document so I copied them to the main part.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2546.org.readthedocs.build/en/2546/

<!-- readthedocs-preview torchmetrics end -->