### PR TITLE
ci: freeze used `setuptools==69.5.1`

### DIFF
--- a/.github/workflows/ci-integrate.yml
+++ b/.github/workflows/ci-integrate.yml
@@ -62,7 +62,7 @@ jobs:
           # this was updated in `source cashing` by optional oldest
           cat requirements/_integrate.txt
           # to have install pyTorch
-          pip install -e . --find-links=${PYTORCH_URL}
+          pip install -e . "setuptools==69.5.1" --find-links=${PYTORCH_URL}
 
           # adjust version to PT ecosystem based on installed TM
           python -m wget https://raw.githubusercontent.com/Lightning-AI/utilities/main/scripts/adjust-torch-versions.py

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -108,8 +108,8 @@ jobs:
         timeout-minutes: 25
         run: |
           pip --version
-          pip install -e . -U --find-links $PYTORCH_URL -f $PYPI_CACHE
-          pip install -r requirements/_doctest.txt -U -f $PYPI_CACHE
+          pip install -e . -U "setuptools==69.5.1" -r requirements/_doctest.txt \
+            --find-links $PYTORCH_URL -f $PYPI_CACHE
           pip list
 
       - name: DocTests

--- a/dockers/ubuntu-cuda/Dockerfile
+++ b/dockers/ubuntu-cuda/Dockerfile
@@ -76,7 +76,7 @@ COPY requirements/ requirements/
 
 RUN \
     # set particular PyTorch version
-    pip install -q wget packaging && \
+    pip install -q wget packaging "setuptools==69.5.1" && \
     python -m wget https://raw.githubusercontent.com/Lightning-AI/utilities/main/scripts/adjust-torch-versions.py  && \
     for fpath in `ls requirements/*.txt`; do \
       python ./adjust-torch-versions.py $fpath ${PYTORCH_VERSION}; \


### PR DESCRIPTION
## What does this PR do?

seeing recently several unrelated failures in bumping PRs
ref: https://github.com/aws-neuron/aws-neuron-sdk/issues/893#issuecomment-2128434372

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2569.org.readthedocs.build/en/2569/

<!-- readthedocs-preview torchmetrics end -->