### PR TITLE
Fix incorrect caching of MetricCollection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed bug in `MetricCollection` when using compute groups and `compute` is called more than once ([#2571](https://github.com/Lightning-AI/torchmetrics/pull/2571))
 
 
 

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -187,6 +187,11 @@ class MetricCollection(ModuleDict):
 
         self.add_metrics(metrics, *additional_metrics)
 
+    @property
+    def metric_state(self) -> Dict[str, Dict[str, Any]]:
+        """Get the current state of the metric."""
+        return {k: m.metric_state for k, m in self.items(keep_base=False, copy_state=False)}
+
     @torch.jit.unused
     def forward(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
         """Call forward for each metric sequentially.

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -206,6 +206,11 @@ class MetricCollection(ModuleDict):
         """
         # Use compute groups if already initialized and checked
         if self._groups_checked:
+            # Delete the cache of all metrics to invalidate the cache and therefore recent compute calls, forcing new
+            # compute calls to recompute
+            for k in self.keys(keep_base=True):
+                mi = getattr(self, k)
+                mi._computed = None
             for cg in self._groups.values():
                 # only update the first member
                 m0 = getattr(self, cg[0])
@@ -304,7 +309,6 @@ class MetricCollection(ModuleDict):
                         # Determine if we just should set a reference or a full copy
                         setattr(mi, state, deepcopy(m0_state) if copy else m0_state)
                     mi._update_count = deepcopy(m0._update_count) if copy else m0._update_count
-                    mi._computed = deepcopy(m0._computed) if copy else m0._computed
         self._state_is_copy = copy
 
     def compute(self) -> Dict[str, Any]:

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -209,7 +209,7 @@ class MetricCollection(ModuleDict):
             # Delete the cache of all metrics to invalidate the cache and therefore recent compute calls, forcing new
             # compute calls to recompute
             for k in self.keys(keep_base=True):
-                mi = getattr(self, k)
+                mi = getattr(self, str(k))
                 mi._computed = None
             for cg in self._groups.values():
                 # only update the first member

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -619,7 +619,7 @@ class Metric(Module, ABC):
 
             # return cached value
             if self._computed is not None:
-                return self._computed
+                return deepcopy(self._computed)
 
             # compute relies on the sync context manager to gather the states across processes and apply reduction
             # if synchronization happened, the current rank accumulated states will be restored to keep
@@ -634,7 +634,8 @@ class Metric(Module, ABC):
             if self.compute_with_cache:
                 self._computed = value
 
-            return value
+            # Return a deep copy to avoid side effects for non-scalar values, e.g. ConfusionMatrix
+            return deepcopy(value)
 
         return wrapped_func
 

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -619,7 +619,7 @@ class Metric(Module, ABC):
 
             # return cached value
             if self._computed is not None:
-                return deepcopy(self._computed)
+                return self._computed
 
             # compute relies on the sync context manager to gather the states across processes and apply reduction
             # if synchronization happened, the current rank accumulated states will be restored to keep
@@ -630,12 +630,13 @@ class Metric(Module, ABC):
                 should_unsync=self._should_unsync,
             ):
                 value = _squeeze_if_scalar(compute(*args, **kwargs))
+                # clone tensor to avoid in-place operations after compute, altering already computed results
+                value = apply_to_collection(value, Tensor, lambda x: x.clone())
 
             if self.compute_with_cache:
                 self._computed = value
 
-            # Return a deep copy to avoid side effects for non-scalar values, e.g. ConfusionMatrix
-            return deepcopy(value)
+            return value
 
         return wrapped_func
 

--- a/tests/unittests/bases/test_collections.py
+++ b/tests/unittests/bases/test_collections.py
@@ -452,9 +452,28 @@ class TestComputeGroups:
             for key in res_cg:
                 assert torch.allclose(res_cg[key], res_without_cg[key])
 
+            # Check if second compute is the same
+            res_cg2 = m.compute()
+            for key in res_cg2:
+                assert torch.allclose(res_cg[key], res_cg2[key])
+
             if with_reset:
                 m.reset()
                 m2.reset()
+
+        # Test if a second compute without a reset is the same
+        m.reset()
+        m.update(preds, target)
+        res_cg = m.compute()
+        # Simulate different preds by simply inversing them
+        m.update(1 - preds, target)
+        res_cg2 = m.compute()
+        # Now check if the results from the first compute are different from the second
+        for key in res_cg:
+            # A different shape is okay, therefore skip (this happens for multidim_average="samplewise")
+            if res_cg[key].shape != res_cg2[key].shape:
+                continue
+            assert not torch.all(res_cg[key] == res_cg2[key])
 
     @pytest.mark.parametrize("method", ["items", "values", "keys"])
     def test_check_compute_groups_items_and_values(self, metrics, expected, preds, target, method):


### PR DESCRIPTION
## What does this PR do?

Fixes  #2570. Also provides a better test for #2211. A somewhat larger change is that for this fix (especially the testcases) the compute method needs to return deepcopied values.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2571.org.readthedocs.build/en/2571/

<!-- readthedocs-preview torchmetrics end -->