### PR TITLE
Add `input_format` argument to segmentation metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `MetricInputTransformer` wrapper ([#2392](https://github.com/Lightning-AI/torchmetrics/pull/2392))
 
 
+- Added `input_format` argument to segmentation metrics ([#2572](https://github.com/Lightning-AI/torchmetrics/pull/2572))
+
+
 ### Changed
 
 -

--- a/src/torchmetrics/functional/segmentation/generalized_dice.py
+++ b/src/torchmetrics/functional/segmentation/generalized_dice.py
@@ -25,6 +25,7 @@ def _generalized_dice_validate_args(
     include_background: bool,
     per_class: bool,
     weight_type: Literal["square", "simple", "linear"],
+    input_format: Literal["one-hot", "index"],
 ) -> None:
     """Validate the arguments of the metric."""
     if num_classes <= 0:
@@ -37,6 +38,8 @@ def _generalized_dice_validate_args(
         raise ValueError(
             f"Expected argument `weight_type` to be one of 'square', 'simple', 'linear', but got {weight_type}."
         )
+    if input_format not in ["one-hot", "index"]:
+        raise ValueError(f"Expected argument `input_format` to be one of 'one-hot', 'index', but got {input_format}.")
 
 
 def _generalized_dice_update(
@@ -45,15 +48,16 @@ def _generalized_dice_update(
     num_classes: int,
     include_background: bool,
     weight_type: Literal["square", "simple", "linear"] = "square",
+    input_format: Literal["one-hot", "index"] = "one-hot",
 ) -> Tensor:
     """Update the state with the current prediction and target."""
     _check_same_shape(preds, target)
     if preds.ndim < 3:
         raise ValueError(f"Expected both `preds` and `target` to have at least 3 dimensions, but got {preds.ndim}.")
 
-    if (preds.bool() != preds).any():  # preds is an index tensor
+    if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-    if (target.bool() != target).any():  # target is an index tensor
+    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
 
     if not include_background:
@@ -104,6 +108,7 @@ def generalized_dice_score(
     include_background: bool = True,
     per_class: bool = False,
     weight_type: Literal["square", "simple", "linear"] = "square",
+    input_format: Literal["one-hot", "index"] = "one-hot",
 ) -> Tensor:
     """Compute the Generalized Dice Score for semantic segmentation.
 
@@ -114,6 +119,8 @@ def generalized_dice_score(
         include_background: Whether to include the background class in the computation
         per_class: Whether to compute the IoU for each class separately, else average over all classes
         weight_type: Type of weight factor to apply to the classes. One of ``"square"``, ``"simple"``, or ``"linear"``
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
+            or ``"index"`` for index tensors
 
     Returns:
         The Generalized Dice Score
@@ -133,6 +140,8 @@ def generalized_dice_score(
                 [0.4715, 0.4925, 0.4797, 0.5267, 0.4788]])
 
     """
-    _generalized_dice_validate_args(num_classes, include_background, per_class, weight_type)
-    numerator, denominator = _generalized_dice_update(preds, target, num_classes, include_background, weight_type)
+    _generalized_dice_validate_args(num_classes, include_background, per_class, weight_type, input_format)
+    numerator, denominator = _generalized_dice_update(
+        preds, target, num_classes, include_background, weight_type, input_format
+    )
     return _generalized_dice_compute(numerator, denominator, per_class)

--- a/src/torchmetrics/functional/segmentation/generalized_dice.py
+++ b/src/torchmetrics/functional/segmentation/generalized_dice.py
@@ -57,7 +57,6 @@ def _generalized_dice_update(
 
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
 
     if not include_background:

--- a/src/torchmetrics/functional/segmentation/mean_iou.py
+++ b/src/torchmetrics/functional/segmentation/mean_iou.py
@@ -15,6 +15,7 @@ from typing import Tuple
 
 import torch
 from torch import Tensor
+from typing_extensions import Literal
 
 from torchmetrics.functional.segmentation.utils import _ignore_background
 from torchmetrics.utilities.checks import _check_same_shape
@@ -25,6 +26,7 @@ def _mean_iou_validate_args(
     num_classes: int,
     include_background: bool,
     per_class: bool,
+    input_format: Literal["one-hot", "index"] = "one-hot",
 ) -> None:
     """Validate the arguments of the metric."""
     if num_classes <= 0:
@@ -33,6 +35,8 @@ def _mean_iou_validate_args(
         raise ValueError(f"Expected argument `include_background` must be a boolean, but got {include_background}.")
     if not isinstance(per_class, bool):
         raise ValueError(f"Expected argument `per_class` must be a boolean, but got {per_class}.")
+    if input_format not in ["one-hot", "index"]:
+        raise ValueError(f"Expected argument `input_format` to be one of 'one-hot', 'index', but got {input_format}.")
 
 
 def _mean_iou_update(
@@ -40,13 +44,14 @@ def _mean_iou_update(
     target: Tensor,
     num_classes: int,
     include_background: bool = False,
+    input_format: Literal["one-hot", "index"] = "one-hot",
 ) -> Tuple[Tensor, Tensor]:
     """Update the intersection and union counts for the mean IoU computation."""
     _check_same_shape(preds, target)
 
-    if (preds.bool() != preds).any():  # preds is an index tensor
+    if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-    if (target.bool() != target).any():  # target is an index tensor
+    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
 
     if not include_background:
@@ -76,6 +81,7 @@ def mean_iou(
     num_classes: int,
     include_background: bool = True,
     per_class: bool = False,
+    input_format: Literal["one-hot", "index"] = "one-hot",
 ) -> Tensor:
     """Calculates the mean Intersection over Union (mIoU) for semantic segmentation.
 
@@ -85,6 +91,8 @@ def mean_iou(
         num_classes: Number of classes
         include_background: Whether to include the background class in the computation
         per_class: Whether to compute the IoU for each class separately, else average over all classes
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
+            or ``"index"`` for index tensors
 
     Returns:
         The mean IoU score
@@ -104,6 +112,6 @@ def mean_iou(
                 [0.3085, 0.3267, 0.3155, 0.3575, 0.3147]])
 
     """
-    _mean_iou_validate_args(num_classes, include_background, per_class)
-    intersection, union = _mean_iou_update(preds, target, num_classes, include_background)
+    _mean_iou_validate_args(num_classes, include_background, per_class, input_format)
+    intersection, union = _mean_iou_update(preds, target, num_classes, include_background, input_format)
     return _mean_iou_compute(intersection, union, per_class=per_class)

--- a/src/torchmetrics/functional/segmentation/mean_iou.py
+++ b/src/torchmetrics/functional/segmentation/mean_iou.py
@@ -51,7 +51,6 @@ def _mean_iou_update(
 
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
 
     if not include_background:

--- a/tests/unittests/segmentation/test_generalized_dice_score.py
+++ b/tests/unittests/segmentation/test_generalized_dice_score.py
@@ -47,7 +47,6 @@ def _reference_generalized_dice(
     """Calculate reference metric for `MeanIoU`."""
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
-    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
     val = compute_generalized_dice(preds, target, include_background=include_background)
     if reduce:

--- a/tests/unittests/segmentation/test_generalized_dice_score.py
+++ b/tests/unittests/segmentation/test_generalized_dice_score.py
@@ -40,13 +40,14 @@ _inputs3 = _Input(
 def _reference_generalized_dice(
     preds: torch.Tensor,
     target: torch.Tensor,
+    input_format: str,
     include_background: bool = True,
     reduce: bool = True,
 ):
     """Calculate reference metric for `MeanIoU`."""
-    if (preds.bool() != preds).any():  # preds is an index tensor
+    if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
-    if (target.bool() != target).any():  # target is an index tensor
+    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
     val = compute_generalized_dice(preds, target, include_background=include_background)
     if reduce:
@@ -55,11 +56,11 @@ def _reference_generalized_dice(
 
 
 @pytest.mark.parametrize(
-    "preds, target",
+    "preds, target, input_format",
     [
-        (_inputs1.preds, _inputs1.target),
-        (_inputs2.preds, _inputs2.target),
-        (_inputs3.preds, _inputs3.target),
+        (_inputs1.preds, _inputs1.target, "one-hot"),
+        (_inputs2.preds, _inputs2.target, "one-hot"),
+        (_inputs3.preds, _inputs3.target, "index"),
     ],
 )
 @pytest.mark.parametrize("include_background", [True, False])
@@ -67,23 +68,42 @@ class TestMeanIoU(MetricTester):
     """Test class for `MeanIoU` metric."""
 
     @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
-    def test_mean_iou_class(self, preds, target, include_background, ddp):
+    def test_mean_iou_class(self, preds, target, input_format, include_background, ddp):
         """Test class implementation of metric."""
         self.run_class_metric_test(
             ddp=ddp,
             preds=preds,
             target=target,
             metric_class=GeneralizedDiceScore,
-            reference_metric=partial(_reference_generalized_dice, include_background=include_background, reduce=True),
-            metric_args={"num_classes": NUM_CLASSES, "include_background": include_background},
+            reference_metric=partial(
+                _reference_generalized_dice,
+                input_format=input_format,
+                include_background=include_background,
+                reduce=True,
+            ),
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "include_background": include_background,
+                "input_format": input_format,
+            },
         )
 
-    def test_mean_iou_functional(self, preds, target, include_background):
+    def test_mean_iou_functional(self, preds, target, input_format, include_background):
         """Test functional implementation of metric."""
         self.run_functional_metric_test(
             preds=preds,
             target=target,
             metric_functional=generalized_dice_score,
-            reference_metric=partial(_reference_generalized_dice, include_background=include_background, reduce=False),
-            metric_args={"num_classes": NUM_CLASSES, "include_background": include_background, "per_class": False},
+            reference_metric=partial(
+                _reference_generalized_dice,
+                input_format=input_format,
+                include_background=include_background,
+                reduce=False,
+            ),
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "include_background": include_background,
+                "per_class": False,
+                "input_format": input_format,
+            },
         )

--- a/tests/unittests/segmentation/test_mean_iou.py
+++ b/tests/unittests/segmentation/test_mean_iou.py
@@ -40,14 +40,15 @@ _inputs3 = _Input(
 def _reference_mean_iou(
     preds: torch.Tensor,
     target: torch.Tensor,
+    input_format: str,
     include_background: bool = True,
     per_class: bool = True,
     reduce: bool = True,
 ):
     """Calculate reference metric for `MeanIoU`."""
-    if (preds.bool() != preds).any():  # preds is an index tensor
+    if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
-    if (target.bool() != target).any():  # target is an index tensor
+    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
 
     val = compute_iou(preds, target, include_background=include_background)
@@ -58,11 +59,11 @@ def _reference_mean_iou(
 
 
 @pytest.mark.parametrize(
-    "preds, target",
+    "preds, target, input_format",
     [
-        (_inputs1.preds, _inputs1.target),
-        (_inputs2.preds, _inputs2.target),
-        (_inputs3.preds, _inputs3.target),
+        (_inputs1.preds, _inputs1.target, "one-hot"),
+        (_inputs2.preds, _inputs2.target, "one-hot"),
+        (_inputs3.preds, _inputs3.target, "index"),
     ],
 )
 @pytest.mark.parametrize("include_background", [True, False])
@@ -73,7 +74,7 @@ class TestMeanIoU(MetricTester):
 
     @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
     @pytest.mark.parametrize("per_class", [True, False])
-    def test_mean_iou_class(self, preds, target, include_background, per_class, ddp):
+    def test_mean_iou_class(self, preds, target, input_format, include_background, per_class, ddp):
         """Test class implementation of metric."""
         self.run_class_metric_test(
             ddp=ddp,
@@ -81,17 +82,33 @@ class TestMeanIoU(MetricTester):
             target=target,
             metric_class=MeanIoU,
             reference_metric=partial(
-                _reference_mean_iou, include_background=include_background, per_class=per_class, reduce=True
+                _reference_mean_iou,
+                input_format=input_format,
+                include_background=include_background,
+                per_class=per_class,
+                reduce=True,
             ),
-            metric_args={"num_classes": NUM_CLASSES, "include_background": include_background, "per_class": per_class},
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "include_background": include_background,
+                "per_class": per_class,
+                "input_format": input_format,
+            },
         )
 
-    def test_mean_iou_functional(self, preds, target, include_background):
+    def test_mean_iou_functional(self, preds, target, input_format, include_background):
         """Test functional implementation of metric."""
         self.run_functional_metric_test(
             preds=preds,
             target=target,
             metric_functional=mean_iou,
-            reference_metric=partial(_reference_mean_iou, include_background=include_background, reduce=False),
-            metric_args={"num_classes": NUM_CLASSES, "include_background": include_background, "per_class": True},
+            reference_metric=partial(
+                _reference_mean_iou, input_format=input_format, include_background=include_background, reduce=False
+            ),
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "include_background": include_background,
+                "per_class": True,
+                "input_format": input_format,
+            },
         )

--- a/tests/unittests/segmentation/test_mean_iou.py
+++ b/tests/unittests/segmentation/test_mean_iou.py
@@ -48,7 +48,6 @@ def _reference_mean_iou(
     """Calculate reference metric for `MeanIoU`."""
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
-    if input_format == "index":
         target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
 
     val = compute_iou(preds, target, include_background=include_background)


### PR DESCRIPTION
## What does this PR do?

Fixes #2563
I was foolish to think that the two formats supported in the new segmentation metrics could be differentiated on just based on the value of the tensors. My mistake. To fix this we need a explicit argument, but this opens up for supporting other input formats.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2572.org.readthedocs.build/en/2572/

<!-- readthedocs-preview torchmetrics end -->