### PR TITLE
Fix weird docker error

### DIFF
--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -107,6 +107,7 @@ class Metric(Module, ABC):
         # see (https://github.com/pytorch/pytorch/blob/3e6bb5233f9ca2c5aa55d9cda22a7ee85439aa6e/
         # torch/nn/modules/module.py#L227)
         torch._C._log_api_usage_once(f"torchmetrics.metric.{self.__class__.__name__}")
+        # magic patch for `RuntimeError: DataLoader worker (pid(s) 104) exited unexpectedly`
         self._TORCH_GREATER_EQUAL_2_1 = bool(_TORCH_GREATER_EQUAL_2_1)
         self._device = torch.device("cpu")
         self._dtype = torch.get_default_dtype()

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -107,7 +107,7 @@ class Metric(Module, ABC):
         # see (https://github.com/pytorch/pytorch/blob/3e6bb5233f9ca2c5aa55d9cda22a7ee85439aa6e/
         # torch/nn/modules/module.py#L227)
         torch._C._log_api_usage_once(f"torchmetrics.metric.{self.__class__.__name__}")
-
+        self._TORCH_GREATER_EQUAL_2_1 = bool(_TORCH_GREATER_EQUAL_2_1)
         self._device = torch.device("cpu")
         self._dtype = torch.get_default_dtype()
 
@@ -441,7 +441,7 @@ class Metric(Module, ABC):
 
             # cornor case in distributed settings where a rank have not received any data, create empty to concatenate
             if (
-                _TORCH_GREATER_EQUAL_2_1
+                self._TORCH_GREATER_EQUAL_2_1
                 and reduction_fn == dim_zero_cat
                 and isinstance(input_dict[attr], list)
                 and len(input_dict[attr]) == 0


### PR DESCRIPTION
## What does this PR do?

Fixes #2559

I have no idea what the actual issue is here. It is therefore up for discussion if this PR should be merged.
Apparently, using torchmetrics inside a docker image can lead to the following error:
```
RuntimeError:
DataLoader worker (pid(s) 104) exited unexpectedly 
```
which can happen due to so many reasons in my experience. See the issue for more details, but I was able to reproduce the issue on v1.4.0 of torchmetrics but not on v1.3.2, thus after running `git bisect` I was able to narrow it down to this commit https://github.com/Lightning-AI/torchmetrics/commit/cd7ccfc079cc68ae3a64440d1929b171b77d8674. Then removing each line one by one I could narrow it down to the data loader having some weird interaction with the requirement cache.

I do not really think this is anything we can test for.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2581.org.readthedocs.build/en/2581/

<!-- readthedocs-preview torchmetrics end -->