### PR TITLE
docs: Fix the rouge internal example

### DIFF
--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -313,27 +313,18 @@ def _rouge_score_update(
             This function must take a `str` and return `Sequence[str]`
 
     Example:
-        >>> preds = "My name is John".split()
-        >>> target = "Is your name John".split()
+        >>> preds = ["My name is John"]
+        >>> target = [["Is your name John"]]
         >>> from pprint import pprint
-        >>> score = _rouge_score_update(preds, target, rouge_keys_values=[1, 2, 3, 'L'], accumulate='best')
+        >>> score = _rouge_score_update(preds, target, rouge_keys_values=[1, 2, 'L'], accumulate='best')
         >>> pprint(score)
-        {1: [{'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)}],
-         2: [{'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)}],
-         3: [{'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-             {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)}],
-         'L': [{'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-               {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-               {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)},
-               {'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)}]}
+        {1: [{'fmeasure': tensor(0.7500),
+              'precision': tensor(0.7500),
+              'recall': tensor(0.7500)}],
+         2: [{'fmeasure': tensor(0.), 'precision': tensor(0.), 'recall': tensor(0.)}],
+         'L': [{'fmeasure': tensor(0.5000),
+                'precision': tensor(0.5000),
+                'recall': tensor(0.5000)}]}
 
     """
     results: Dict[Union[int, str], List[Dict[str, Tensor]]] = {rouge_key: [] for rouge_key in rouge_keys_values}


### PR DESCRIPTION
Current example is computing ROUGE on the letters 😛 seems a bit fishy

<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2599.org.readthedocs.build/en/2599/

<!-- readthedocs-preview torchmetrics end -->