### PR TITLE
Fix pylint warning `redefined-outer-name`

### DIFF
--- a/_samples/bert_score-own_model.py
+++ b/_samples/bert_score-own_model.py
@@ -96,21 +96,21 @@ def get_user_model_encoder(num_layers: int = _NUM_LAYERS, d_model: int = _MODEL_
     return nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
 
 
-def user_forward_fn(model: Module, batch: Dict[str, Tensor]) -> Tensor:
+def user_forward_fn(model_: Module, batch: Dict[str, Tensor]) -> Tensor:
     """User forward function used for the computation of model embeddings.
 
     This function might be arbitrarily complicated inside. However, to ensure functionality, it should obey the
     input/output argument structure described below.
 
     Args:
-        model: a torch.nn.module that implements a forward pass
+        model_: a torch.nn.module that implements a forward pass
         batch: a batch of inputs to pass through the model
 
     Return:
         The model output.
 
     """
-    return model(batch["input_ids"])
+    return model_(batch["input_ids"])
 
 
 _PREDS = ["hello", "hello world", "world world world"]

--- a/_samples/plotting.py
+++ b/_samples/plotting.py
@@ -27,14 +27,14 @@ def pesq_example() -> tuple:
     # plot single value
     metric = PerceptualEvaluationSpeechQuality(8000, "nb")
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = PerceptualEvaluationSpeechQuality(16000, "wb")
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def pit_example() -> tuple:
@@ -48,14 +48,14 @@ def pit_example() -> tuple:
     # plot single value
     metric = PermutationInvariantTraining(scale_invariant_signal_noise_ratio, "max")
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = PermutationInvariantTraining(scale_invariant_signal_noise_ratio, "max")
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def sdr_example() -> tuple:
@@ -68,14 +68,14 @@ def sdr_example() -> tuple:
     # plot single value
     metric = SignalDistortionRatio()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    sdr_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = SignalDistortionRatio()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    sdr_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return sdr_fig, _ax
 
 
 def si_sdr_example() -> tuple:
@@ -88,14 +88,14 @@ def si_sdr_example() -> tuple:
     # plot single value
     metric = ScaleInvariantSignalDistortionRatio()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = ScaleInvariantSignalDistortionRatio()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def snr_example() -> tuple:
@@ -108,14 +108,14 @@ def snr_example() -> tuple:
     # plot single value
     metric = SignalNoiseRatio()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    snr_plot, _ax = metric.plot()
 
     # plot multiple values
     metric = SignalNoiseRatio()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    snr_plot_multi, _ax = metric.plot(vals)
 
-    return fig, ax
+    return snr_plot, snr_plot_multi
 
 
 def si_snr_example() -> tuple:
@@ -128,14 +128,14 @@ def si_snr_example() -> tuple:
     # plot single value
     metric = ScaleInvariantSignalNoiseRatio()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = ScaleInvariantSignalNoiseRatio()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def stoi_example() -> tuple:
@@ -148,14 +148,14 @@ def stoi_example() -> tuple:
     # plot single value
     metric = ShortTimeObjectiveIntelligibility(8000, False)
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    fig_single, ax_single = metric.plot()
 
     # plot multiple values
     metric = ShortTimeObjectiveIntelligibility(8000, False)
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    fig_multiple, ax_multiple = metric.plot(vals)
 
-    return fig, ax
+    return (fig_single, fig_multiple), (ax_single, ax_multiple)
 
 
 def accuracy_example() -> tuple:
@@ -168,25 +168,30 @@ def accuracy_example() -> tuple:
     # plot single value
     metric = MulticlassAccuracy(num_classes=5)
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    accuracy_plot = metric.plot()
+    fig = accuracy_plot.figure
 
     # plot a value per class
     metric = MulticlassAccuracy(num_classes=5, average=None)
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    accuracy_plot = metric.plot()
+    fig = accuracy_plot.figure
 
     # plot two values as a series
     metric = MulticlassAccuracy(num_classes=5)
     val1 = metric(p(), t())
     val2 = metric(p(), t())
-    fig, ax = metric.plot([val1, val2])
+    accuracy_plot = metric.plot([val1, val2])
+    fig = accuracy_plot.figure
 
     # plot a series of values per class
     metric = MulticlassAccuracy(num_classes=5, average=None)
     val1 = metric(p(), t())
     val2 = metric(p(), t())
-    fig, ax = metric.plot([val1, val2])
-    return fig, ax
+    accuracy_plot = metric.plot([val1, val2])
+    fig = accuracy_plot.figure
+
+    return fig, accuracy_plot
 
 
 def mean_squared_error_example() -> tuple:
@@ -199,13 +204,13 @@ def mean_squared_error_example() -> tuple:
     # single val
     metric = MeanSquaredError()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, plot_ax = metric.plot()
 
     # multiple values
     metric = MeanSquaredError()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
-    return fig, ax
+    plot_fig, plot_ax = metric.plot(vals)
+    return plot_fig, plot_ax
 
 
 def confusion_matrix_example() -> tuple:
@@ -218,8 +223,8 @@ def confusion_matrix_example() -> tuple:
     # plot single value
     metric = MulticlassConfusionMatrix(num_classes=5)
     metric.update(p(), t())
-    fig, ax = metric.plot()
-    return fig, ax
+    confusion_matrix_fig, confusion_matrix_ax = metric.plot()
+    return confusion_matrix_fig, confusion_matrix_ax
 
 
 def spectral_distortion_index_example() -> tuple:
@@ -232,14 +237,14 @@ def spectral_distortion_index_example() -> tuple:
     # plot single value
     metric = SpectralDistortionIndex()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = SpectralDistortionIndex()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def error_relative_global_dimensionless_synthesis() -> tuple:
@@ -253,14 +258,14 @@ def error_relative_global_dimensionless_synthesis() -> tuple:
     # plot single value
     metric = ErrorRelativeGlobalDimensionlessSynthesis()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = ErrorRelativeGlobalDimensionlessSynthesis()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def peak_signal_noise_ratio() -> tuple:
@@ -273,14 +278,14 @@ def peak_signal_noise_ratio() -> tuple:
     # plot single value
     metric = PeakSignalNoiseRatio()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    psnr_plot, _ax = metric.plot()
 
     # plot multiple values
     metric = PeakSignalNoiseRatio()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    psnr_plots, _ax = metric.plot(vals)
 
-    return fig, ax
+    return psnr_plot, psnr_plots
 
 
 def spectral_angle_mapper() -> tuple:
@@ -294,14 +299,14 @@ def spectral_angle_mapper() -> tuple:
     # plot single value
     metric = SpectralAngleMapper()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = SpectralAngleMapper()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def structural_similarity_index_measure() -> tuple:
@@ -315,14 +320,14 @@ def structural_similarity_index_measure() -> tuple:
     # plot single value
     metric = StructuralSimilarityIndexMeasure()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = StructuralSimilarityIndexMeasure()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def multiscale_structural_similarity_index_measure() -> tuple:
@@ -336,14 +341,14 @@ def multiscale_structural_similarity_index_measure() -> tuple:
     # plot single value
     metric = MultiScaleStructuralSimilarityIndexMeasure()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = MultiScaleStructuralSimilarityIndexMeasure()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def universal_image_quality_index() -> tuple:
@@ -356,14 +361,14 @@ def universal_image_quality_index() -> tuple:
     # plot single value
     metric = UniversalImageQualityIndex()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = UniversalImageQualityIndex()
     vals = [metric(p(), t()) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def mean_average_precision() -> tuple:
@@ -387,14 +392,14 @@ def mean_average_precision() -> tuple:
     # plot single value
     metric = MeanAveragePrecision()
     metric.update(preds(), target)
-    fig, ax = metric.plot()
+    plot_fig, _ax = metric.plot()
 
     # plot multiple values
     metric = MeanAveragePrecision()
     vals = [metric(preds(), target) for _ in range(10)]
-    fig, ax = metric.plot(vals)
+    plot_fig, _ax = metric.plot(vals)
 
-    return fig, ax
+    return plot_fig, _ax
 
 
 def roc_example() -> tuple:
@@ -406,14 +411,14 @@ def roc_example() -> tuple:
 
     metric = BinaryROC()
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    binary_roc_fig, binary_roc_ax = metric.plot()
 
     p = lambda: torch.randn(200, 5)
     t = lambda: torch.randint(5, (200,))
 
     metric = MulticlassROC(5)
     metric.update(p(), t())
-    fig, ax = metric.plot()
+    multiclass_roc_fig, multiclass_roc_ax = metric.plot()
 
     p = lambda: torch.rand(20, 2)
     t = lambda: torch.randint(2, (20, 2))
@@ -421,7 +426,7 @@ def roc_example() -> tuple:
     metric = MultilabelROC(2)
     metric.update(p(), t())
 
-    return fig, ax
+    return (binary_roc_fig, multiclass_roc_fig), (binary_roc_ax, multiclass_roc_ax)
 
 
 if __name__ == "__main__":

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,14 +61,14 @@ _transform_changelog(
 
 def _set_root_image_path(page_path: str) -> None:
     """Set relative path to be from the root, drop all `../` in images used gallery."""
-    with open(page_path, encoding="UTF-8") as fopen:
-        body = fopen.read()
+    with open(page_path, encoding="UTF-8") as file:
+        body = file.read()
     found = re.findall(r"   :image: (.*)\.svg", body)
     for occur in found:
         occur_ = occur.replace("../", "")
         body = body.replace(occur, occur_)
-    with open(page_path, "w", encoding="UTF-8") as fopen:
-        fopen.write(body)
+    with open(page_path, "w", encoding="UTF-8") as file:
+        file.write(body)
 
 
 if SPHINX_FETCH_ASSETS:

--- a/examples/image/clip_score.py
+++ b/examples/image/clip_score.py
@@ -60,9 +60,9 @@ fig, (ax_img, ax_table) = plt.subplots(1, 2, figsize=(10, 5))
 def update(num: int) -> tuple:
     """Update the image and table with the scores for the given model."""
     results = score_results[num]
-    scores, image, model = results["scores"], results["image"], results["model"]
+    scores, image, model_name = results["scores"], results["image"], results["model"]
 
-    fig.suptitle(f"Model: {model.split('/')[-1]}", fontsize=16, fontweight="bold")
+    fig.suptitle(f"Model: {model_name.split('/')[-1]}", fontsize=16, fontweight="bold")
 
     # Update image
     ax_img.imshow(images[image])

--- a/src/torchmetrics/functional/classification/f_beta.py
+++ b/src/torchmetrics/functional/classification/f_beta.py
@@ -54,8 +54,8 @@ def _fbeta_reduce(
         fp = fp.sum(dim=0 if multidim_average == "global" else 1)
         return _safe_divide((1 + beta2) * tp, (1 + beta2) * tp + beta2 * fn + fp, zero_division)
 
-    fbeta_score = _safe_divide((1 + beta2) * tp, (1 + beta2) * tp + beta2 * fn + fp, zero_division)
-    return _adjust_weights_safe_divide(fbeta_score, average, multilabel, tp, fp, fn)
+    fbeta_score_value = _safe_divide((1 + beta2) * tp, (1 + beta2) * tp + beta2 * fn + fp, zero_division)
+    return _adjust_weights_safe_divide(fbeta_score_value, average, multilabel, tp, fp, fn)
 
 
 def _binary_fbeta_score_arg_validation(

--- a/src/torchmetrics/functional/image/scc.py
+++ b/src/torchmetrics/functional/image/scc.py
@@ -73,19 +73,19 @@ def _scc_update(preds: Tensor, target: Tensor, hp_filter: Tensor, window_size: i
     return preds, target, hp_filter
 
 
-def _symmetric_reflect_pad_2d(input_img: Tensor, pad: Union[int, Tuple[int, ...]]) -> Tensor:
+def _symmetric_reflect_pad_2d(input_img: Tensor, padding: Union[int, Tuple[int, ...]]) -> Tensor:
     """Applies symmetric padding to the 2D image tensor input using ``reflect`` mode (d c b a | a b c d | d c b a)."""
-    if isinstance(pad, int):
-        pad = (pad, pad, pad, pad)
-    if len(pad) != 4:
-        raise ValueError(f"Expected padding to have length 4, but got {len(pad)}")
+    if isinstance(padding, int):
+        padding = (padding, padding, padding, padding)
+    if len(padding) != 4:
+        raise ValueError(f"Expected padding to have length 4, but got {len(padding)}")
 
-    left_pad = input_img[:, :, :, 0 : pad[0]].flip(dims=[3])
-    right_pad = input_img[:, :, :, -pad[1] :].flip(dims=[3])
+    left_pad = input_img[:, :, :, 0 : padding[0]].flip(dims=[3])
+    right_pad = input_img[:, :, :, -padding[1] :].flip(dims=[3])
     padded = torch.cat([left_pad, input_img, right_pad], dim=3)
 
-    top_pad = padded[:, :, 0 : pad[2], :].flip(dims=[2])
-    bottom_pad = padded[:, :, -pad[3] :, :].flip(dims=[2])
+    top_pad = padded[:, :, 0 : padding[2], :].flip(dims=[2])
+    bottom_pad = padded[:, :, -padding[3] :, :].flip(dims=[2])
     return torch.cat([top_pad, padded, bottom_pad], dim=2)
 
 


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `consider-using-f-string`.
"Used when a variable's name hides a name defined in an outer scope or except handler.. See [https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/redefined-outer-name.html](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/redefined-outer-name.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.