### PR TITLE
Bertscore warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ lint.ignore = [
   "D104",   # todo: Missing docstring in public package
   "D107",   # Missing docstring in `__init__`
   "E731",   # Do not assign a lambda expression, use a def
+  "EXE002", # The file is executable but no shebang is present
 ]
 lint.per-file-ignores."docs/source/conf.py" = [
   "A001",

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -15,7 +15,7 @@ import csv
 import logging
 import urllib
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -37,7 +37,7 @@ from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_GREATE
 
 
 @contextmanager
-def _ignore_log_warning():  # noqa: ANN202
+def _ignore_log_warning() -> Iterator[None]:
     """Ignore irrelevant fine-tuning warning from transformers when loading the model for BertScore."""
     logger = logging.getLogger("transformers.modeling_utils")
     original_level = logger.getEffectiveLevel()

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -37,8 +37,8 @@ from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_GREATE
 
 
 @contextmanager
-def _ignore_log_warning():
-    # Ignore irrelevant fine-tuning warning from transformers when loading the model for BertScore
+def _ignore_log_warning():  # noqa: ANN202
+    """Ignore irrelevant fine-tuning warning from transformers when loading the model for BertScore."""
     logger = logging.getLogger("transformers.modeling_utils")
     original_level = logger.getEffectiveLevel()
     try:

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import csv
-import urllib
 import logging
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+import urllib
 from contextlib import contextmanager
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -46,6 +46,7 @@ def ignore_log_warning():
         yield
     finally:
         logger.setLevel(original_level)
+
 
 # Default model recommended in the original implementation.
 _DEFAULT_MODEL = "roberta-large"

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -41,8 +41,8 @@ if _TRANSFORMERS_GREATER_EQUAL_4_4:
 
     def _download_model_for_bert_score() -> None:
         """Download intensive operations."""
-        AutoTokenizer.from_pretrained(_DEFAULT_MODEL, resume_download=True)
-        AutoModel.from_pretrained(_DEFAULT_MODEL, resume_download=True)
+        AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
+        AutoModel.from_pretrained(_DEFAULT_MODEL)
 
     if _SKIP_SLOW_DOCTEST and not _try_proceed_with_timeout(_download_model_for_bert_score):
         __doctest_skip__ = ["bert_score"]

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -38,6 +38,7 @@ from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_GREATE
 
 @contextmanager
 def ignore_log_warning():
+    # Ignore irrelevant fine-tuning warning from transformers when loading the model for BertScore
     logger = logging.getLogger("transformers.modeling_utils")
     original_level = logger.getEffectiveLevel()
     try:

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -37,7 +37,7 @@ from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_GREATE
 
 
 @contextmanager
-def ignore_log_warning():
+def _ignore_log_warning():
     # Ignore irrelevant fine-tuning warning from transformers when loading the model for BertScore
     logger = logging.getLogger("transformers.modeling_utils")
     original_level = logger.getEffectiveLevel()
@@ -56,7 +56,7 @@ if _TRANSFORMERS_GREATER_EQUAL_4_4:
 
     def _download_model_for_bert_score() -> None:
         """Download intensive operations."""
-        with ignore_log_warning():
+        with _ignore_log_warning():
             AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
             AutoModel.from_pretrained(_DEFAULT_MODEL)
 
@@ -372,7 +372,7 @@ def bert_score(
                 " `transformers` model are used."
                 f"It is, therefore, used the default recommended model - {_DEFAULT_MODEL}."
             )
-        with ignore_log_warning():
+        with _ignore_log_warning():
             tokenizer = AutoTokenizer.from_pretrained(model_name_or_path or _DEFAULT_MODEL)
             model = AutoModel.from_pretrained(model_name_or_path or _DEFAULT_MODEL)
     else:

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -187,8 +187,7 @@ class BERTScore(Metric):
                     " `transformers` model is used."
                     f" It will use the default recommended model - {_DEFAULT_MODEL!r}."
                 )
-            resume_download = self.model_name_or_path == _DEFAULT_MODEL
-            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, resume_download=resume_download)
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path)
             self.user_tokenizer = False
 
         self.add_state("preds_input_ids", [], dist_reduce_fx="cat")


### PR DESCRIPTION
## What does this PR do?

Fixes a number of warnings when using `BertScore` with the default settings:
```
Some weights of RobertaModel were not initialized from the model checkpoint at roberta-base and are newly initialized: ['roberta.pooler.dense.bias', 'roberta.pooler.dense.weight']
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
```

and

```
`resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
```

which I think shouldn't be raised when using the metric correctly.


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2626.org.readthedocs.build/en/2626/

<!-- readthedocs-preview torchmetrics end -->