### PR TITLE
Fix math typo in confusion matrix doc

### DIFF
--- a/src/torchmetrics/classification/confusion_matrix.py
+++ b/src/torchmetrics/classification/confusion_matrix.py
@@ -199,7 +199,7 @@ class MulticlassConfusionMatrix(Metric):
 
     - :math:`C_{i, i}` represents the number of true positives for class :math:`i`
     - :math:`\sum_{j=1, j\neq i}^N C_{i, j}` represents the number of false negatives for class :math:`i`
-    - :math:`\sum_{i=1, i\neq j}^N C_{i, j}` represents the number of false positives for class :math:`i`
+    - :math:`\sum_{i=1, i\neq j}^N C_{i, j}` represents the number of false positives for class :math:`j`
     - the sum of the remaining cells in the matrix represents the number of true negatives for class :math:`i`
 
     As input to ``forward`` and ``update`` the metric accepts the following input:

--- a/src/torchmetrics/classification/confusion_matrix.py
+++ b/src/torchmetrics/classification/confusion_matrix.py
@@ -199,7 +199,7 @@ class MulticlassConfusionMatrix(Metric):
 
     - :math:`C_{i, i}` represents the number of true positives for class :math:`i`
     - :math:`\sum_{j=1, j\neq i}^N C_{i, j}` represents the number of false negatives for class :math:`i`
-    - :math:`\sum_{i=1, i\neq j}^N C_{i, j}` represents the number of false positives for class :math:`j`
+    - :math:`\sum_{j=1, j\neq i}^N C_{j, i}` represents the number of false positives for class :math:`i`
     - the sum of the remaining cells in the matrix represents the number of true negatives for class :math:`i`
 
     As input to ``forward`` and ``update`` the metric accepts the following input:


### PR DESCRIPTION
## What does this PR do?

Fix a doc typo for [`MulticlassConfusionMatrix`](https://lightning.ai/docs/torchmetrics/stable/classification/confusion_matrix.html#torchmetrics.classification.MulticlassConfusionMatrix), specifically in the equation that describes false positive calculation from the confusion matrix.
The sum in the equation is over `i` (the rows), therefore the result corresponds to the number of true negatives for class `j`, not `i`.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>



<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2634.org.readthedocs.build/en/2634/

<!-- readthedocs-preview torchmetrics end -->