### PR TITLE
Dimension mismatch error: fix string formatting

### DIFF
--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -298,8 +298,8 @@ def _multiclass_stat_scores_tensor_validation(
     elif preds.ndim == target.ndim:
         if preds.shape != target.shape:
             raise ValueError(
-                "The `preds` and `target` should have the same shape,",
-                f" got `preds` with shape={preds.shape} and `target` with shape={target.shape}.",
+                "The `preds` and `target` should have the same shape,"
+                f" got `preds` with shape={preds.shape} and `target` with shape={target.shape}."
             )
         if multidim_average != "global" and preds.ndim < 2:
             raise ValueError(


### PR DESCRIPTION
Very simple PR.

### Before

```
ValueError: ('The `preds` and `target` should have the same shape,', ' got `preds` with shape=torch.Size([2, 5, 64, 64]) and `target` with shape=torch.Size([2, 1, 64, 64]).')
```

### After

```
ValueError: The `preds` and `target` should have the same shape, got `preds` with shape=torch.Size([2, 5, 64, 64]) and `target` with shape=torch.Size([2, 1, 64, 64]).
```

<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2635.org.readthedocs.build/en/2635/

<!-- readthedocs-preview torchmetrics end -->