### PR TITLE
ci: prune testing matrix & set PT 2.4 as stable

### DIFF
--- a/.azure/gpu-integrations.yml
+++ b/.azure/gpu-integrations.yml
@@ -22,8 +22,8 @@ jobs:
           torch-ver: "1.13"
           requires: "oldest"
         "torch | 2.x":
-          docker-image: "pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime"
-          torch-ver: "2.3"
+          docker-image: "pytorch/pytorch:2.4.0-cuda12.1-cudnn8-runtime"
+          torch-ver: "2.4"
     # how long to run the job before automatically cancelling
     timeoutInMinutes: "40"
     # how much time to give 'run always even if cancelled tasks' before stopping them

--- a/.azure/gpu-integrations.yml
+++ b/.azure/gpu-integrations.yml
@@ -22,7 +22,7 @@ jobs:
           torch-ver: "1.13"
           requires: "oldest"
         "torch | 2.x":
-          docker-image: "pytorch/pytorch:2.4.0-cuda12.1-cudnn8-runtime"
+          docker-image: "pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime"
           torch-ver: "2.4"
     # how long to run the job before automatically cancelling
     timeoutInMinutes: "40"

--- a/.azure/gpu-unittests.yml
+++ b/.azure/gpu-unittests.yml
@@ -25,9 +25,6 @@ jobs:
           docker-image: "ubuntu22.04-cuda11.8.0-py3.9-torch1.13"
           torch-ver: "1.13"
         "PyTorch | 2.X stable":
-          docker-image: "ubuntu22.04-cuda12.1.1-py3.11-torch2.3"
-          torch-ver: "2.3"
-        "PyTorch | 2.X future":
           docker-image: "ubuntu22.04-cuda12.1.1-py3.11-torch2.4"
           torch-ver: "2.4"
     # how long to run the job before automatically cancelling

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,7 +52,7 @@ jobs:
           # standard mac machine, not the M1
           - { os: "macOS-13", python-version: "3.8", pytorch-version: "1.13.1" }
           - { os: "macOS-13", python-version: "3.10", pytorch-version: "2.0.1" }
-          - { os: "macOS-13", python-version: "3.11", pytorch-version: "2.3.1" }
+          - { os: "macOS-13", python-version: "3.11", pytorch-version: "2.3.0" }  # 2.3.1 is missing for this config.
           # using the ARM based M1 machine
           - { os: "macOS-14", python-version: "3.10", pytorch-version: "2.0.1" }
           - { os: "macOS-14", python-version: "3.11", pytorch-version: "2.4.0" }

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -41,28 +41,29 @@ jobs:
           - "2.0.1"
           - "2.1.2"
           - "2.2.2"
-          - "2.3.0"
+          - "2.3.1"
+          - "2.4.0"
         include:
-          # cover additional python nad PR combinations
+          # cover additional python and PT combinations
           - { os: "ubuntu-22.04", python-version: "3.8", pytorch-version: "1.13.1" }
           - { os: "ubuntu-22.04", python-version: "3.10", pytorch-version: "2.0.1" }
           - { os: "ubuntu-22.04", python-version: "3.10", pytorch-version: "2.2.2" }
-          - { os: "ubuntu-22.04", python-version: "3.11", pytorch-version: "2.3.0" }
+          - { os: "ubuntu-22.04", python-version: "3.11", pytorch-version: "2.3.1" }
           # standard mac machine, not the M1
           - { os: "macOS-13", python-version: "3.8", pytorch-version: "1.13.1" }
           - { os: "macOS-13", python-version: "3.10", pytorch-version: "2.0.1" }
-          - { os: "macOS-13", python-version: "3.11", pytorch-version: "2.2.2" }
+          - { os: "macOS-13", python-version: "3.11", pytorch-version: "2.3.1" }
           # using the ARM based M1 machine
           - { os: "macOS-14", python-version: "3.10", pytorch-version: "2.0.1" }
-          - { os: "macOS-14", python-version: "3.11", pytorch-version: "2.3.0" }
+          - { os: "macOS-14", python-version: "3.11", pytorch-version: "2.4.0" }
           # some windows
           - { os: "windows-2022", python-version: "3.8", pytorch-version: "1.13.1" }
           - { os: "windows-2022", python-version: "3.10", pytorch-version: "2.0.1" }
-          - { os: "windows-2022", python-version: "3.11", pytorch-version: "2.3.0" }
-          # Future released version
-          - { os: "ubuntu-22.04", python-version: "3.11", pytorch-version: "2.4.0" }
-          - { os: "macOS-14", python-version: "3.11", pytorch-version: "2.4.0" }
           - { os: "windows-2022", python-version: "3.11", pytorch-version: "2.4.0" }
+          # Future released version
+          #- { os: "ubuntu-22.04", python-version: "3.11", pytorch-version: "2.5.0" }
+          #- { os: "macOS-14", python-version: "3.11", pytorch-version: "2.5.0" }
+          #- { os: "windows-2022", python-version: "3.11", pytorch-version: "2.5.0" }
     env:
       FREEZE_REQUIREMENTS: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
       PYPI_CACHE_DIR: "_ci-cache_PyPI"
@@ -105,9 +106,9 @@ jobs:
           pytorch-version: ${{ matrix.pytorch-version }}
           pypi-dir: ${{ env.PYPI_CACHE_DIR }}
 
-      - name: Switch to PT test URL
-        if: ${{ matrix.pytorch-version == '2.4.0' }}
-        run: echo 'PIP_EXTRA_INDEX_URL=--extra-index-url https://download.pytorch.org/whl/test/cpu/' >> $GITHUB_ENV
+      #- name: Switch to PT test URL
+      #  if: ${{ matrix.pytorch-version == '2.X.0' }}
+      #  run: echo 'PIP_EXTRA_INDEX_URL=--extra-index-url https://download.pytorch.org/whl/test/cpu/' >> $GITHUB_ENV
       - name: Install pkg
         timeout-minutes: 25
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -52,7 +52,6 @@ jobs:
           # standard mac machine, not the M1
           - { os: "macOS-13", python-version: "3.8", pytorch-version: "1.13.1" }
           - { os: "macOS-13", python-version: "3.10", pytorch-version: "2.0.1" }
-          - { os: "macOS-13", python-version: "3.11", pytorch-version: "2.3.0" } # 2.3.1 is missing for this config.
           # using the ARM based M1 machine
           - { os: "macOS-14", python-version: "3.10", pytorch-version: "2.0.1" }
           - { os: "macOS-14", python-version: "3.11", pytorch-version: "2.4.0" }

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -72,8 +72,9 @@ jobs:
           - { python: "3.10", pytorch: "2.2", cuda: "12.1.1", ubuntu: "22.04" }
           - { python: "3.11", pytorch: "2.2", cuda: "12.1.1", ubuntu: "22.04" }
           - { python: "3.11", pytorch: "2.3", cuda: "12.1.1", ubuntu: "22.04" }
-          # the future version - test or RC version
           - { python: "3.11", pytorch: "2.4", cuda: "12.1.1", ubuntu: "22.04" }
+          # the future version - test or RC version
+          #- { python: "3.11", pytorch: "2.5", cuda: "12.1.1", ubuntu: "22.04" }
     steps:
       - uses: actions/checkout@v4
 

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -1,5 +1,5 @@
 mypy ==1.11.0
-torch ==2.3.1
+torch ==2.4.0
 
 types-PyYAML
 types-emoji


### PR DESCRIPTION
## What does this PR do?

setting PT 2.4 as stable not just future and prune testing matrix

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2670.org.readthedocs.build/en/2670/

<!-- readthedocs-preview torchmetrics end -->