### PR TITLE
improve: update `InfoLM` class to dynamically set `higher_is_better`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tracker higher is better integration ([#2649](https://github.com/Lightning-AI/torchmetrics/pull/2649))
 
 
+- update `InfoLM` class to dynamically set `higher_is_better` ([#2674](https://github.com/Lightning-AI/torchmetrics/pull/2674))
+
+
 ### Removed
 
 -

--- a/src/torchmetrics/text/infolm.py
+++ b/src/torchmetrics/text/infolm.py
@@ -38,6 +38,21 @@ if not _TRANSFORMERS_GREATER_EQUAL_4_4:
     __doctest_skip__ = ["InfoLM", "InfoLM.plot"]
 
 
+_Information_Measure_Higher_Is_Better = {
+    # following values are <0
+    "kl_divergence": True,
+    "alpha_divergence": True,
+    # following values are >0
+    "beta_divergence": False,
+    "ab_divergence": False,
+    "renyi_divergence": False,
+    "l1_distance": False,
+    "l2_distance": False,
+    "l_infinity_distanc": False,
+    "fisher_rao_distanc": False,
+}
+
+
 class InfoLM(Metric):
     """Calculate `InfoLM`_.
 
@@ -111,7 +126,6 @@ class InfoLM(Metric):
     """
 
     is_differentiable = False
-    higher_is_better = True
     preds_input_ids: List[Tensor]
     preds_attention_mask: List[Tensor]
     target_input_ids: List[Tensor]
@@ -148,6 +162,7 @@ class InfoLM(Metric):
 
         self.tokenizer, self.model = _load_tokenizer_and_model(model_name_or_path, device)
         self.information_measure_cls = _InformationMeasure(information_measure, alpha, beta)
+        self.higher_is_better = _Information_Measure_Higher_Is_Better[information_measure]
         self.max_length = max_length or self.model.config.max_length
         self.special_tokens_map = _get_special_tokens_map(self.tokenizer)
 

--- a/src/torchmetrics/text/infolm.py
+++ b/src/torchmetrics/text/infolm.py
@@ -162,7 +162,6 @@ class InfoLM(Metric):
 
         self.tokenizer, self.model = _load_tokenizer_and_model(model_name_or_path, device)
         self.information_measure_cls = _InformationMeasure(information_measure, alpha, beta)
-        self.higher_is_better = _Information_Measure_Higher_Is_Better[information_measure]
         self.max_length = max_length or self.model.config.max_length
         self.special_tokens_map = _get_special_tokens_map(self.tokenizer)
 
@@ -170,6 +169,14 @@ class InfoLM(Metric):
         self.add_state("preds_attention_mask", [], dist_reduce_fx="cat")
         self.add_state("target_input_ids", [], dist_reduce_fx="cat")
         self.add_state("target_attention_mask", [], dist_reduce_fx="cat")
+
+    @property
+    def higher_is_better(self) -> bool:
+        """
+        Returns a bool indicating whether a higher value of the information measure is better.
+        Done this way as depends on if the information measure is positive or negative.
+        """
+        return _Information_Measure_Higher_Is_Better[self.information_measure]
 
     def update(self, preds: Union[str, Sequence[str]], target: Union[str, Sequence[str]]) -> None:
         """Update state with predictions and targets."""

--- a/src/torchmetrics/text/infolm.py
+++ b/src/torchmetrics/text/infolm.py
@@ -48,8 +48,8 @@ _Information_Measure_Higher_Is_Better = {
     "renyi_divergence": False,
     "l1_distance": False,
     "l2_distance": False,
-    "l_infinity_distanc": False,
-    "fisher_rao_distanc": False,
+    "l_infinity_distance": False,
+    "fisher_rao_distance": False,
 }
 
 

--- a/src/torchmetrics/text/infolm.py
+++ b/src/torchmetrics/text/infolm.py
@@ -38,7 +38,7 @@ if not _TRANSFORMERS_GREATER_EQUAL_4_4:
     __doctest_skip__ = ["InfoLM", "InfoLM.plot"]
 
 
-_Information_Measure_Higher_Is_Better = {
+_information_measure_higher_is_better = {
     # following values are <0
     "kl_divergence": True,
     "alpha_divergence": True,
@@ -177,7 +177,7 @@ class InfoLM(Metric):
         Done this way as depends on if the information measure is positive or negative.
 
         """
-        return _Information_Measure_Higher_Is_Better[self.information_measure]
+        return _information_measure_higher_is_better[self.information_measure]
 
     def update(self, preds: Union[str, Sequence[str]], target: Union[str, Sequence[str]]) -> None:
         """Update state with predictions and targets."""

--- a/src/torchmetrics/text/infolm.py
+++ b/src/torchmetrics/text/infolm.py
@@ -170,7 +170,7 @@ class InfoLM(Metric):
         self.add_state("target_attention_mask", [], dist_reduce_fx="cat")
 
     @property
-    def higher_is_better(self) -> bool:
+    def higher_is_better(self) -> bool:  # type: ignore[override]
         """Returns a bool indicating whether a higher value of the information measure is better.
 
         Done this way as depends on if the information measure is positive or negative.

--- a/src/torchmetrics/text/infolm.py
+++ b/src/torchmetrics/text/infolm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -36,21 +36,6 @@ if not _MATPLOTLIB_AVAILABLE:
 
 if not _TRANSFORMERS_GREATER_EQUAL_4_4:
     __doctest_skip__ = ["InfoLM", "InfoLM.plot"]
-
-
-_information_measure_higher_is_better = {
-    # following values are <0
-    "kl_divergence": True,
-    "alpha_divergence": True,
-    # following values are >0
-    "beta_divergence": False,
-    "ab_divergence": False,
-    "renyi_divergence": False,
-    "l1_distance": False,
-    "l2_distance": False,
-    "l_infinity_distance": False,
-    "fisher_rao_distance": False,
-}
 
 
 class InfoLM(Metric):
@@ -131,6 +116,20 @@ class InfoLM(Metric):
     target_input_ids: List[Tensor]
     target_attention_mask: List[Tensor]
 
+    _information_measure_higher_is_better: ClassVar = {
+        # following values are <0
+        "kl_divergence": True,
+        "alpha_divergence": True,
+        # following values are >0
+        "beta_divergence": False,
+        "ab_divergence": False,
+        "renyi_divergence": False,
+        "l1_distance": False,
+        "l2_distance": False,
+        "l_infinity_distance": False,
+        "fisher_rao_distance": False,
+    }
+
     def __init__(
         self,
         model_name_or_path: Union[str, os.PathLike] = "bert-base-uncased",
@@ -177,7 +176,7 @@ class InfoLM(Metric):
         Done this way as depends on if the information measure is positive or negative.
 
         """
-        return _information_measure_higher_is_better[self.information_measure]
+        return self._information_measure_higher_is_better[self.information_measure]
 
     def update(self, preds: Union[str, Sequence[str]], target: Union[str, Sequence[str]]) -> None:
         """Update state with predictions and targets."""

--- a/src/torchmetrics/text/infolm.py
+++ b/src/torchmetrics/text/infolm.py
@@ -172,9 +172,10 @@ class InfoLM(Metric):
 
     @property
     def higher_is_better(self) -> bool:
-        """
-        Returns a bool indicating whether a higher value of the information measure is better.
+        """Returns a bool indicating whether a higher value of the information measure is better.
+
         Done this way as depends on if the information measure is positive or negative.
+
         """
         return _Information_Measure_Higher_Is_Better[self.information_measure]
 

--- a/tests/unittests/text/test_infolm.py
+++ b/tests/unittests/text/test_infolm.py
@@ -16,7 +16,7 @@ from functools import partial
 import pytest
 import torch
 from torchmetrics.functional.text.infolm import infolm
-from torchmetrics.text.infolm import InfoLM, _information_measure_higher_is_better
+from torchmetrics.text.infolm import InfoLM
 from torchmetrics.utilities.imports import _TRANSFORMERS_GREATER_EQUAL_4_4
 
 from unittests._helpers import skip_on_connection_issues
@@ -196,4 +196,4 @@ class TestInfoLM(TextTester):
         }
 
         metric = InfoLM(**metric_args)
-        assert metric.higher_is_better == _information_measure_higher_is_better[information_measure]
+        assert metric.higher_is_better == metric._information_measure_higher_is_better[information_measure]

--- a/tests/unittests/text/test_infolm.py
+++ b/tests/unittests/text/test_infolm.py
@@ -16,7 +16,7 @@ from functools import partial
 import pytest
 import torch
 from torchmetrics.functional.text.infolm import infolm
-from torchmetrics.text.infolm import InfoLM
+from torchmetrics.text.infolm import InfoLM, _information_measure_higher_is_better
 from torchmetrics.utilities.imports import _TRANSFORMERS_GREATER_EQUAL_4_4
 
 from unittests._helpers import skip_on_connection_issues
@@ -182,3 +182,18 @@ class TestInfoLM(TextTester):
             metric_functional=infolm,
             metric_args=metric_args,
         )
+
+    @skip_on_connection_issues()
+    def test_infolm_higher_is_better_property(self, preds, targets, information_measure, idf, alpha, beta):
+        """Test the `higher_is_better` property of the metric."""
+        metric_args = {
+            "model_name_or_path": MODEL_NAME,
+            "information_measure": information_measure,
+            "idf": idf,
+            "alpha": alpha,
+            "beta": beta,
+            "max_length": MAX_LENGTH,
+        }
+
+        metric = InfoLM(**metric_args)
+        assert metric.higher_is_better == _information_measure_higher_is_better[information_measure]


### PR DESCRIPTION
…ed on information_measure

## What does this PR do?

Fixes #2659 

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

I had problems with the devcontainer and the environment.  

Might try and add tests for this but it seems the devcontainer uses the torchmetrics in `/usr/local/lib/python3.9/site-packages` (or similar depending on python) and its not obvious to me how you are supposed to setup things to easily/quickly add tests?  I ended up just doing editable install. 

I manually checked all the values but if I add a test ill try and include some info/example for each of these that shows the metric output on strs.


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2674.org.readthedocs.build/en/2674/

<!-- readthedocs-preview torchmetrics end -->