### PR TITLE
bump: `pystoi>=0.4` for `scipy` compatibility

### DIFF
--- a/requirements/audio.txt
+++ b/requirements/audio.txt
@@ -3,7 +3,7 @@
 
 # this need to be the same as used inside speechmetrics
 pesq >=0.0.4, <0.0.5
-pystoi >=0.3.0, <0.5.0
+pystoi >=0.4.0, <0.5.0
 torchaudio >=0.10.0, <2.5.0
 gammatone >=1.0.0, <1.1.0
 librosa >=0.9.0, <0.11.0


### PR DESCRIPTION
## What does this PR do?

resolving compatibility issue for `pystoi==0.3` and `scipy==1.14.0`

```
065     Example:
066         >>> import torch
067         >>> from torchmetrics.audio import ShortTimeObjectiveIntelligibility
068         >>> g = torch.manual_seed(1)
069         >>> preds = torch.randn(8000)
070         >>> target = torch.randn(8000)
071         >>> stoi = ShortTimeObjectiveIntelligibility(8000, False)
072         >>> stoi(preds, target)
UNEXPECTED EXCEPTION: AttributeError("Module 'scipy' has no attribute 'hanning'")
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/scipy/__init__.py", line 137, in __getattr__
    return globals()[name]
KeyError: 'hanning'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.10/doctest.py", line 1350, in __run
    exec(compile(example.source, filename, "single",
  File "<doctest torchmetrics.audio.stoi.ShortTimeObjectiveIntelligibility[6]>", line 1, in <module>
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/__w/1/s/src/torchmetrics/metric.py", line 312, in forward
    self._forward_cache = self._forward_reduce_state_update(*args, **kwargs)
  File "/__w/1/s/src/torchmetrics/metric.py", line 381, in _forward_reduce_state_update
    self.update(*args, **kwargs)
  File "/__w/1/s/src/torchmetrics/metric.py", line 483, in wrapped_func
    update(*args, **kwargs)
  File "/__w/1/s/src/torchmetrics/audio/stoi.py", line 105, in update
    stoi_batch = short_time_objective_intelligibility(preds, target, self.fs, self.extended, False).to(
  File "/__w/1/s/src/torchmetrics/functional/audio/stoi.py", line 81, in short_time_objective_intelligibility
    stoi_val_np = stoi_backend(target.detach().cpu().numpy(), preds.detach().cpu().numpy(), fs, extended)
  File "/usr/local/lib/python3.10/dist-packages/pystoi/stoi.py", line 53, in stoi
    x, y = utils.remove_silent_frames(x, y, DYN_RANGE, N_FRAME, int(N_FRAME/2))
  File "/usr/local/lib/python3.10/dist-packages/pystoi/utils.py", line 116, in remove_silent_frames
    w = scipy.hanning(framelen + 2)[1:-1]
  File "/usr/local/lib/python3.10/dist-packages/scipy/__init__.py", line 139, in __getattr__
    raise AttributeError(
AttributeError: Module 'scipy' has no attribute 'hanning'
```

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2675.org.readthedocs.build/en/2675/

<!-- readthedocs-preview torchmetrics end -->