### PR TITLE
Deprecate `num_outputs` in R2 because it is no longer needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update `InfoLM` class to dynamically set `higher_is_better` ([#2674](https://github.com/Lightning-AI/torchmetrics/pull/2674))
 
 
+### Deprecated
+
+- Deprecated `num_outputs` in `R2Score` ([#2705](https://github.com/Lightning-AI/torchmetrics/pull/2705))
+
+
 ### Removed
 
 -

--- a/src/torchmetrics/regression/r2.py
+++ b/src/torchmetrics/regression/r2.py
@@ -66,7 +66,7 @@ class R2Score(Metric):
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
     .. warning::
-        Argument `num_outputs` in `R2Score` has been deprecated because it is no longer necessary and will be
+        Argument ``num_outputs`` in ``R2Score`` has been deprecated because it is no longer necessary and will be
         removed in v1.6.0 of TorchMetrics. The number of outputs is now automatically inferred from the shape
         of the input tensors.
 

--- a/src/torchmetrics/regression/r2.py
+++ b/src/torchmetrics/regression/r2.py
@@ -72,19 +72,19 @@ class R2Score(Metric):
             If ``multioutput`` is not one of ``"raw_values"``, ``"uniform_average"`` or ``"variance_weighted"``.
 
     Example (single output):
-        >>> import torch
+        >>> from torch import tensor
         >>> from torchmetrics.regression import R2Score
-        >>> target = torch.tensor([3, -0.5, 2, 7])
-        >>> preds = torch.tensor([2.5, 0.0, 2, 8])
+        >>> target = tensor([3, -0.5, 2, 7])
+        >>> preds = tensor([2.5, 0.0, 2, 8])
         >>> r2score = R2Score()
         >>> r2score(preds, target)
         tensor(0.9486)
 
     Example (multioutput):
-        >>> import torch
+        >>> from torch import tensor
         >>> from torchmetrics.regression import R2Score
-        >>> target = torch.tensor([[0.5, 1], [-1, 1], [7, -6]])
-        >>> preds = torch.tensor([[0, 2], [-1, 2], [8, -5]])
+        >>> target = tensor([[0.5, 1], [-1, 1], [7, -6]])
+        >>> preds = tensor([[0, 2], [-1, 2], [8, -5]])
         >>> r2score = R2Score(multioutput='raw_values')
         >>> r2score(preds, target)
         tensor([0.9654, 0.9082])

--- a/src/torchmetrics/regression/r2.py
+++ b/src/torchmetrics/regression/r2.py
@@ -65,6 +65,11 @@ class R2Score(Metric):
             * ``'variance_weighted'`` scores are weighted by their individual variances
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
+    .. warning::
+        Argument `num_outputs` in `R2Score` has been deprecated because it is no longer necessary and will be
+        removed in v1.6.0 of TorchMetrics. The number of outputs is now automatically inferred from the shape
+        of the input tensors.
+
     Raises:
         ValueError:
             If ``adjusted`` parameter is not an integer larger or equal to 0.
@@ -116,6 +121,7 @@ class R2Score(Metric):
                 "Argument `num_outputs` in `R2Score` has been deprecated because it is no longer necessary and will be"
                 "removed in v1.6.0 of TorchMetrics. The number of outputs is now automatically inferred from the shape"
                 "of the input tensors.",
+                DeprecationWarning,
             )
 
         if adjusted < 0 or not isinstance(adjusted, int):

--- a/src/torchmetrics/regression/r2.py
+++ b/src/torchmetrics/regression/r2.py
@@ -71,7 +71,8 @@ class R2Score(Metric):
         ValueError:
             If ``multioutput`` is not one of ``"raw_values"``, ``"uniform_average"`` or ``"variance_weighted"``.
 
-    Example:
+    Example (single output):
+        >>> import torch
         >>> from torchmetrics.regression import R2Score
         >>> target = torch.tensor([3, -0.5, 2, 7])
         >>> preds = torch.tensor([2.5, 0.0, 2, 8])
@@ -79,9 +80,12 @@ class R2Score(Metric):
         >>> r2score(preds, target)
         tensor(0.9486)
 
+    Example (multioutput):
+        >>> import torch
+        >>> from torchmetrics.regression import R2Score
         >>> target = torch.tensor([[0.5, 1], [-1, 1], [7, -6]])
         >>> preds = torch.tensor([[0, 2], [-1, 2], [8, -5]])
-        >>> r2score = R2Score(num_outputs=2, multioutput='raw_values')
+        >>> r2score = R2Score(multioutput='raw_values')
         >>> r2score(preds, target)
         tensor([0.9654, 0.9082])
 

--- a/tests/unittests/test_deprecated.py
+++ b/tests/unittests/test_deprecated.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from torchmetrics.functional.regression import kl_divergence
-from torchmetrics.regression import KLDivergence
+from torchmetrics.regression import KLDivergence, R2Score
 
 
 def test_deprecated_kl_divergence_input_order():
@@ -14,3 +14,9 @@ def test_deprecated_kl_divergence_input_order():
 
     with pytest.deprecated_call(match="The input order and naming in metric `KLDivergence` is set to be deprecated.*"):
         KLDivergence()
+
+
+def test_deprecated_r2_score_num_outputs():
+    """Ensure that the deprecated num_outputs argument in R2Score raises a warning."""
+    with pytest.deprecated_call(match="Argument `num_outputs` in `R2Score` has been deprecated"):
+        R2Score(num_outputs=2)


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/2703

Passes locally, but lets see if the full test suit passes

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2705.org.readthedocs.build/en/2705/

<!-- readthedocs-preview torchmetrics end -->