### PR TITLE
Fix: handle zero division error in binary IoU calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed handling zero division error in binary IoU (Jaccard index) calculation ([#2726](https://github.com/Lightning-AI/torchmetrics/pull/2726))
 
 
 ## [1.4.1] - 2024-08-02

--- a/src/torchmetrics/functional/classification/jaccard.py
+++ b/src/torchmetrics/functional/classification/jaccard.py
@@ -67,7 +67,7 @@ def _jaccard_index_reduce(
         raise ValueError(f"The `average` has to be one of {allowed_average}, got {average}.")
     confmat = confmat.float()
     if average == "binary":
-        return confmat[1, 1] / (confmat[0, 1] + confmat[1, 0] + confmat[1, 1])
+        return _safe_divide(confmat[1, 1], (confmat[0, 1] + confmat[1, 0] + confmat[1, 1]), zero_division=zero_division)
 
     ignore_index_cond = ignore_index is not None and 0 <= ignore_index < confmat.shape[0]
     multilabel = confmat.ndim == 3


### PR DESCRIPTION
…tion

## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/2658

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [X] Did you write any new **necessary tests**?

</details>

## Did you have fun?

Yes

## Issue:
zero_division does not work for binary IoU (Jaccard index) calculation and returns NaN when `TP + FP + FN=0`.
## Reason:
The zero_division parameter in the BinaryJaccardIndex does not take effect during binary task calculations, as the IoU calculations for the binary task are returned early (Line 70) in ` _jaccard_index_reduce` function.
## Fix:
The change replaces the direct division operation with a call to the `_safe_divide` function, which handles the case of division by zero based on the specified `zero_division` parameter in ` _jaccard_index_reduce` function.



<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2726.org.readthedocs.build/en/2726/

<!-- readthedocs-preview torchmetrics end -->