### PR TITLE
fix: compatibility audio do with new `scipy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct the padding related calculation errors in SSIM ([#2721](https://github.com/Lightning-AI/torchmetrics/pull/2721))
 
 
+- Fixed compatibility of audio domain with new `scipy` ([#2733](https://github.com/Lightning-AI/torchmetrics/pull/2733))
+
+
 ## [1.4.1] - 2024-08-02
 
 ### Changed

--- a/src/torchmetrics/audio/__init__.py
+++ b/src/torchmetrics/audio/__init__.py
@@ -28,9 +28,17 @@ from torchmetrics.utilities.imports import (
     _ONNXRUNTIME_AVAILABLE,
     _PESQ_AVAILABLE,
     _PYSTOI_AVAILABLE,
+    _SCIPI_AVAILABLE,
     _TORCHAUDIO_AVAILABLE,
     _TORCHAUDIO_GREATER_EQUAL_0_10,
 )
+
+if _SCIPI_AVAILABLE:
+    import scipy.signal
+
+    # back compatibility patch due to SMRMpy using scipy.signal.hamming
+    if not hasattr(scipy.signal, "hamming"):
+        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "PermutationInvariantTraining",

--- a/src/torchmetrics/functional/audio/__init__.py
+++ b/src/torchmetrics/functional/audio/__init__.py
@@ -28,9 +28,17 @@ from torchmetrics.utilities.imports import (
     _ONNXRUNTIME_AVAILABLE,
     _PESQ_AVAILABLE,
     _PYSTOI_AVAILABLE,
+    _SCIPI_AVAILABLE,
     _TORCHAUDIO_AVAILABLE,
     _TORCHAUDIO_GREATER_EQUAL_0_10,
 )
+
+if _SCIPI_AVAILABLE:
+    import scipy.signal
+
+    # back compatibility patch due to SMRMpy using scipy.signal.hamming
+    if not hasattr(scipy.signal, "hamming"):
+        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "permutation_invariant_training",

--- a/src/torchmetrics/functional/nominal/__init__.py
+++ b/src/torchmetrics/functional/nominal/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from torchmetrics.functional.nominal.cramers import cramers_v, cramers_v_matrix
 from torchmetrics.functional.nominal.fleiss_kappa import fleiss_kappa
 from torchmetrics.functional.nominal.pearson import (
@@ -19,6 +20,14 @@ from torchmetrics.functional.nominal.pearson import (
 )
 from torchmetrics.functional.nominal.theils_u import theils_u, theils_u_matrix
 from torchmetrics.functional.nominal.tschuprows import tschuprows_t, tschuprows_t_matrix
+from torchmetrics.utilities.imports import _SCIPI_AVAILABLE
+
+if _SCIPI_AVAILABLE:
+    import scipy.signal
+
+    # back compatibility patch due to SMRMpy using scipy.signal.hamming
+    if not hasattr(scipy.signal, "hamming"):
+        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "cramers_v",

--- a/src/torchmetrics/nominal/__init__.py
+++ b/src/torchmetrics/nominal/__init__.py
@@ -11,11 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from torchmetrics.nominal.cramers import CramersV
 from torchmetrics.nominal.fleiss_kappa import FleissKappa
 from torchmetrics.nominal.pearson import PearsonsContingencyCoefficient
 from torchmetrics.nominal.theils_u import TheilsU
 from torchmetrics.nominal.tschuprows import TschuprowsT
+from torchmetrics.utilities.imports import _SCIPI_AVAILABLE
+
+if _SCIPI_AVAILABLE:
+    import scipy.signal
+
+    # back compatibility patch due to SMRMpy using scipy.signal.hamming
+    if not hasattr(scipy.signal, "hamming"):
+        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "CramersV",

--- a/src/torchmetrics/utilities/imports.py
+++ b/src/torchmetrics/utilities/imports.py
@@ -64,6 +64,7 @@ _MECAB_KO_AVAILABLE = RequirementCache("mecab_ko")
 _MECAB_KO_DIC_AVAILABLE = RequirementCache("mecab_ko_dic")
 _IPADIC_AVAILABLE = RequirementCache("ipadic")
 _SENTENCEPIECE_AVAILABLE = RequirementCache("sentencepiece")
+_SCIPI_AVAILABLE = RequirementCache("scipy")
 _SKLEARN_GREATER_EQUAL_1_3 = RequirementCache("scikit-learn>=1.3.0")
 
 _LATEX_AVAILABLE: bool = shutil.which("latex") is not None

--- a/tests/unittests/classification/test_stat_scores.py
+++ b/tests/unittests/classification/test_stat_scores.py
@@ -582,8 +582,8 @@ def test_support_for_int():
     """See issue: https://github.com/Lightning-AI/torchmetrics/issues/1970."""
     seed_all(42)
     metric = MulticlassStatScores(num_classes=4, average="none", multidim_average="samplewise", ignore_index=0)
-    prediction = torch.randint(low=0, high=4, size=(1, 224, 224)).to(torch.uint8)
-    label = torch.randint(low=0, high=4, size=(1, 224, 224)).to(torch.uint8)
+    prediction = torch.randint(low=0, high=4, size=(1, 50, 50)).to(torch.uint8)
+    label = torch.randint(low=0, high=4, size=(1, 50, 50)).to(torch.uint8)
     score = metric(preds=prediction, target=label)
     assert score.shape == (1, 4, 5)
 


### PR DESCRIPTION
## What does this PR do?

Posting fix https://github.com/Lightning-AI/torchmetrics/pull/2671#issuecomment-2328708232 with compatibility issue:
```
Traceback (most recent call last):
  File "/__w/4/s/tests/unittests/nominal/test_cramers.py", line 64, in _reference_dython_cramers_v
    from dython.nominal import cramers_v
  File "/usr/local/lib/python3.9/dist-packages/dython/__init__.py", line 1, in <module>
    from . import (
  File "/usr/local/lib/python3.9/dist-packages/dython/model_utils.py", line 4, in <module>
    from scikitplot.helpers import binary_ks_curve
  File "/usr/local/lib/python3.9/dist-packages/scikitplot/__init__.py", line 2, in <module>
    from . import metrics, cluster, decomposition, estimators
  File "/usr/local/lib/python3.9/dist-packages/scikitplot/metrics.py", line 27, in <module>
    from scipy import interp
ImportError: cannot import name 'interp' from 'scipy' (/usr/local/lib/python3.9/dist-packages/scipy/__init__.py)
```

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2733.org.readthedocs.build/en/2733/

<!-- readthedocs-preview torchmetrics end -->