### PR TITLE
ci/doc: install with `-e` to resolve source links

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install package & dependencies
         run: |
           make get-sphinx-template
-          pip install . -U -r requirements/_docs.txt \
+          pip install -e . -U -r requirements/_docs.txt \
             --find-links="${PYPI_CACHE}" --find-links="${TORCH_URL}"
       - run: pip list
       - name: Full build for deployment

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   docs-make:
-    # if: github.event.pull_request.draft == false  # FIXME
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -47,14 +47,6 @@ jobs:
           requires: ${{ matrix.requires }}
           pytorch-version: ${{ matrix.pytorch-version }}
           pypi-dir: ${{ env.PYPI_CACHE }}
-
-      #      - name: Install Latex
-      #        if: ${{ matrix.target == 'html' }}
-      #        # install Texlive, see https://linuxconfig.org/how-to-install-latex-on-ubuntu-20-04-focal-fossa-linux
-      #        run: |
-      #          sudo apt-get update --fix-missing
-      #          sudo apt-get install -y \
-      #            texlive-latex-extra texlive-pictures texlive-fonts-recommended dvipng cm-super
 
       - name: Install package & dependencies
         run: |
@@ -77,7 +69,7 @@ jobs:
           make ${{ matrix.target }} --debug --jobs $(nproc) SPHINXOPTS="-W --keep-going"
 
       - name: Upload built docs
-        # if: ${{ matrix.target == 'html' && github.event_name != 'pull_request' }}  # FIXME
+        if: ${{ matrix.target == 'html' && github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: docs-${{ matrix.target }}-${{ github.sha }}

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -48,13 +48,13 @@ jobs:
           pytorch-version: ${{ matrix.pytorch-version }}
           pypi-dir: ${{ env.PYPI_CACHE }}
 
-      - name: Install Latex
-        if: ${{ matrix.target == 'html' }}
-        # install Texlive, see https://linuxconfig.org/how-to-install-latex-on-ubuntu-20-04-focal-fossa-linux
-        run: |
-          sudo apt-get update --fix-missing
-          sudo apt-get install -y \
-            texlive-latex-extra texlive-pictures texlive-fonts-recommended dvipng cm-super
+#      - name: Install Latex
+#        if: ${{ matrix.target == 'html' }}
+#        # install Texlive, see https://linuxconfig.org/how-to-install-latex-on-ubuntu-20-04-focal-fossa-linux
+#        run: |
+#          sudo apt-get update --fix-missing
+#          sudo apt-get install -y \
+#            texlive-latex-extra texlive-pictures texlive-fonts-recommended dvipng cm-super
 
       - name: Install package & dependencies
         run: |
@@ -70,7 +70,10 @@ jobs:
         run: echo "SPHINX_ENABLE_GALLERY=0" >> $GITHUB_ENV
       - name: make ${{ matrix.target }}
         working-directory: ./docs
-        run: make ${{ matrix.target }} --debug --jobs $(nproc) SPHINXOPTS="-W --keep-going"
+        run: |
+          pwd
+          ls -la
+          make ${{ matrix.target }} --debug --jobs $(nproc) SPHINXOPTS="-W --keep-going"
 
       - name: Upload built docs
         # if: ${{ matrix.target == 'html' && github.event_name != 'pull_request' }}  # FIXME

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install package & dependencies
         run: |
           make get-sphinx-template
+          # install with -e so the path to source link comes from this project not from the installed package
           pip install -e . -U -r requirements/_docs.txt \
             --find-links="${PYPI_CACHE}" --find-links="${TORCH_URL}"
       - run: pip list

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   docs-make:
-    if: github.event.pull_request.draft == false
+    # if: github.event.pull_request.draft == false  # FIXME
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -73,7 +73,7 @@ jobs:
         run: make ${{ matrix.target }} --debug --jobs $(nproc) SPHINXOPTS="-W --keep-going"
 
       - name: Upload built docs
-        if: ${{ matrix.target == 'html' && github.event_name != 'pull_request' }}
+        # if: ${{ matrix.target == 'html' && github.event_name != 'pull_request' }}  # FIXME
         uses: actions/upload-artifact@v4
         with:
           name: docs-${{ matrix.target }}-${{ github.sha }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,16 +11,15 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 import glob
-import inspect
 import os
 import re
 import shutil
 import sys
-from typing import Optional, Tuple
+from typing import Optional
 
 import lai_sphinx_theme
 import torchmetrics
-from lightning_utilities.docs.formatting import _transform_changelog
+from lightning_utilities.docs.formatting import _linkcode_resolve, _transform_changelog
 
 _PATH_HERE = os.path.abspath(os.path.dirname(__file__))
 _PATH_ROOT = os.path.realpath(os.path.join(_PATH_HERE, "..", ".."))
@@ -299,9 +298,9 @@ epub_exclude_files = ["search.html"]
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "torch": ("https://pytorch.org/docs/2.4/", None),
-    "numpy": ("https://numpy.org/doc/2.1/", None),
-    "matplotlib": ("https://matplotlib.org/3.9.2/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 nitpicky = True
 
@@ -364,50 +363,7 @@ MOCK_PACKAGES = [PACKAGE_MAPPING.get(pkg, pkg) for pkg in MOCK_PACKAGES]
 autodoc_mock_imports = MOCK_PACKAGES
 
 
-def _linkcode_resolve(
-    domain: str,
-    info: dict,
-    github_user: str,
-    github_repo: str,
-    main_branch: str = "master",
-    stable_branch: str = "release/stable",
-) -> str:
-    def find_source() -> Tuple[str, int, int]:
-        # try to find the file and line number, based on code from numpy:
-        # https://github.com/numpy/numpy/blob/master/doc/source/conf.py#L286
-        obj = sys.modules[info["module"]]
-        for part in info["fullname"].split("."):
-            obj = getattr(obj, part)
-        fname = str(inspect.getsourcefile(obj))
-        # https://github.com/rtfd/readthedocs.org/issues/5735
-        if any(s in fname for s in ("readthedocs", "rtfd", "checkouts")):
-            # /home/docs/checkouts/readthedocs.org/user_builds/pytorch_lightning/checkouts/
-            #  devel/pytorch_lightning/utilities/cls_experiment.py#L26-L176
-            path_top = os.path.abspath(os.path.join("..", "..", ".."))
-            fname = str(os.path.relpath(fname, start=path_top))
-        else:
-            # Local build, imitate master
-            fname = f'{main_branch}/{os.path.relpath(fname, start=os.path.abspath(".."))}'
-        source, line_start = inspect.getsourcelines(obj)
-        return fname, line_start, line_start + len(source) - 1
-
-    if domain != "py" or not info["module"]:
-        return ""
-    try:
-        filename = "%s#L%d-L%d" % find_source()
-    except Exception:
-        filename = info["module"].replace(".", "/") + ".py"
-    # import subprocess
-    # tag = subprocess.Popen(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE,
-    #                        universal_newlines=True).communicate()[0][:-1]
-    branch = filename.split("/")[0]
-    # do mapping from latest tags to master
-    branch = {"latest": main_branch, "stable": stable_branch}.get(branch, branch)
-    filename = "/".join([branch] + filename.split("/")[1:])
-    return f"https://github.com/{github_user}/{github_repo}/blob/{filename}"
-
-
-# Resolve function, this function is used to populate the (source) links in the API
+# Resolve function - this function is used to populate the (source) links in the API
 def linkcode_resolve(domain, info) -> Optional[str]:  # noqa: ANN001
     return _linkcode_resolve(domain, info=info, github_user="Lightning-AI", github_repo="torchmetrics")
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -270,6 +270,11 @@ texinfo_documents = [
     ),
 ]
 
+# MathJax configuration
+mathjax3_config = {
+    "tex": {"packages": {"[+]": ["ams", "newcommand", "configMacros"]}},
+}
+
 # -- Options for Epub output -------------------------------------------------
 
 # Bibliographic Dublin Core info.


### PR DESCRIPTION
## What does this PR do?

Fixes #2739

seems that the problem was the used package was the installed one not the within the project folder and so the expected path was wrong... so installed with `-e`

validated such that I have download the docs artifact and look to the source and the path link seems correct 🦩 

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2740.org.readthedocs.build/en/2740/

<!-- readthedocs-preview torchmetrics end -->