### PR TITLE
lint: fix `docformatter`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]
+        language: python
         args: ["--in-place"]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         exclude: pyproject.toml
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: 06907d0267368b49b9180eed423fae5697c1e909  # todo: fix for docformatter after last 1.7.5
+    rev: 06907d0267368b49b9180eed423fae5697c1e909 # todo: fix for docformatter after last 1.7.5
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,8 +58,9 @@ repos:
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]
-        language: python
         args: ["--in-place"]
+        language: python
+        types: ["python"]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v0.9.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,13 +54,11 @@ repos:
         exclude: pyproject.toml
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+    rev: 06907d0267368b49b9180eed423fae5697c1e909  # todo: fix for docformatter after last 1.7.5
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]
         args: ["--in-place"]
-        language: python
-        types: ["python"]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v0.9.1


### PR DESCRIPTION
## What does this PR do?

Addressing:
```
build attempt 1...
    => error
    An error has occurred: InvalidManifestError: 
    ==> File /pc/clone/jNZWZVRSTLq-4hbwuef7PA/.pre-commit-hooks.yaml
    ==> At Hook(id='docformatter-venv')
    ==> At key: language
    =====> Expected one of conda, coursier, dart, docker, docker_image, dotnet, fail, golang, haskell, lua, node, perl, pygrep, python, r, ruby, rust, script, swift, system but got: 'python_venv'
    Check the log at /pc/pre-commit.log
build attempt 2...
    => error
    An error has occurred: InvalidManifestError: 
    ==> File /pc/clone/jNZWZVRSTLq-4hbwuef7PA/.pre-commit-hooks.yaml
    ==> At Hook(id='docformatter-venv')
    ==> At key: language
    =====> Expected one of conda, coursier, dart, docker, docker_image, dotnet, fail, golang, haskell, lua, node, perl, pygrep, python, r, ruby, rust, script, swift, system but got: 'python_venv'
    Check the log at /pc/pre-commit.log
```

ref: https://github.com/PyCQA/docformatter/pull/287

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
