### PR TITLE
Improve CI stability for clustering examples

### DIFF
--- a/src/torchmetrics/clustering/calinski_harabasz_score.py
+++ b/src/torchmetrics/clustering/calinski_harabasz_score.py
@@ -56,11 +56,11 @@ class CalinskiHarabaszScore(Metric):
     Example::
         >>> from torch import randn, randint
         >>> from torchmetrics.clustering import CalinskiHarabaszScore
-        >>> data = randn(10, 3)
-        >>> labels = randint(3, (10,))
+        >>> data = randn(20, 3)
+        >>> labels = randint(3, (20,))
         >>> metric = CalinskiHarabaszScore()
         >>> metric(data, labels)
-        tensor(3.0053)
+        tensor(2.2128)
 
     """
 
@@ -108,7 +108,7 @@ class CalinskiHarabaszScore(Metric):
             >>> import torch
             >>> from torchmetrics.clustering import CalinskiHarabaszScore
             >>> metric = CalinskiHarabaszScore()
-            >>> metric.update(torch.randn(10, 3), torch.randint(0, 2, (10,)))
+            >>> metric.update(torch.randn(20, 3), torch.randint(3, (20,)))
             >>> fig_, ax_ = metric.plot(metric.compute())
 
         .. plot::
@@ -120,7 +120,7 @@ class CalinskiHarabaszScore(Metric):
             >>> metric = CalinskiHarabaszScore()
             >>> values = [ ]
             >>> for _ in range(10):
-            ...     values.append(metric(torch.randn(10, 3), torch.randint(0, 2, (10,))))
+            ...     values.append(metric(torch.randn(20, 3), torch.randint(3, (20,))))
             >>> fig_, ax_ = metric.plot(values)
 
         """

--- a/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
+++ b/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
@@ -33,8 +33,8 @@ def calinski_harabasz_score(data: Tensor, labels: Tensor) -> Tensor:
     Example:
         >>> from torch import randn, randint
         >>> from torchmetrics.functional.clustering import calinski_harabasz_score
-        >>> data = randn(10, 3)
-        >>> labels = randint(0, 2, (10,))
+        >>> data = randn(20, 3)
+        >>> labels = randint(0, 3, (20,))
         >>> calinski_harabasz_score(data, labels)
         tensor(3.4998)
 

--- a/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
+++ b/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
@@ -36,7 +36,7 @@ def calinski_harabasz_score(data: Tensor, labels: Tensor) -> Tensor:
         >>> data = randn(20, 3)
         >>> labels = randint(0, 3, (20,))
         >>> calinski_harabasz_score(data, labels)
-        tensor(3.4998)
+        tensor(2.2128)
 
     """
     _validate_intrinsic_cluster_data(data, labels)

--- a/src/torchmetrics/functional/clustering/davies_bouldin_score.py
+++ b/src/torchmetrics/functional/clustering/davies_bouldin_score.py
@@ -36,7 +36,7 @@ def davies_bouldin_score(data: Tensor, labels: Tensor) -> Tensor:
         >>> data = randn(20, 3)
         >>> labels = randint(0, 3, (20,))
         >>> davies_bouldin_score(data, labels)
-        tensor(1.3249)
+        tensor(2.7418)
 
     """
     _validate_intrinsic_cluster_data(data, labels)

--- a/src/torchmetrics/functional/clustering/davies_bouldin_score.py
+++ b/src/torchmetrics/functional/clustering/davies_bouldin_score.py
@@ -33,8 +33,8 @@ def davies_bouldin_score(data: Tensor, labels: Tensor) -> Tensor:
     Example:
         >>> from torch import randn, randint
         >>> from torchmetrics.functional.clustering import davies_bouldin_score
-        >>> data = randn(10, 3)
-        >>> labels = randint(0, 2, (10,))
+        >>> data = randn(20, 3)
+        >>> labels = randint(0, 3, (20,))
         >>> davies_bouldin_score(data, labels)
         tensor(1.3249)
 


### PR DESCRIPTION
## What does this PR do?

Sometimes docs build are failing due to a bad sampling in clustering metrics:
https://github.com/Lightning-AI/torchmetrics/actions/runs/11342203643/job/31542759627
This should make it more robust by increasing the number of samples.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2785.org.readthedocs.build/en/2785/

<!-- readthedocs-preview torchmetrics end -->