### PR TITLE
Fix overflow for `PSNR` metric when used with `uint8` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed `PSNR` calculation for integer type input images ([#2788](https://github.com/Lightning-AI/torchmetrics/pull/2788))
 
 
 ## [1.4.3] - 2024-10-10

--- a/src/torchmetrics/functional/image/psnr.py
+++ b/src/torchmetrics/functional/image/psnr.py
@@ -69,6 +69,11 @@ def _psnr_update(
             Default is None meaning scores will be reduced across all dimensions.
 
     """
+    if not preds.is_floating_point():
+        preds = preds.to(torch.float32)
+    if not target.is_floating_point():
+        target = target.to(torch.float32)
+
     if dim is None:
         sum_squared_error = torch.sum(torch.pow(preds - target, 2))
         num_obs = tensor(target.numel(), device=target.device)

--- a/tests/unittests/image/test_psnr.py
+++ b/tests/unittests/image/test_psnr.py
@@ -167,3 +167,16 @@ def test_missing_data_range():
 
     with pytest.raises(ValueError, match="The `data_range` must be given when `dim` is not None."):
         peak_signal_noise_ratio(_inputs[0].preds, _inputs[0].target, data_range=None, dim=0)
+
+
+def test_psnr_uint_dtype():
+    """Check that automatic casting to float is done for uint dtype.
+
+    See issue: https://github.com/Lightning-AI/torchmetrics/issues/2787
+
+    """
+    preds = torch.randint(0, 255, _input_size, dtype=torch.uint8)
+    target = torch.randint(0, 255, _input_size, dtype=torch.uint8)
+    psnr = peak_signal_noise_ratio(preds, target)
+    prnr2 = peak_signal_noise_ratio(preds.float(), target.float())
+    assert torch.allclose(psnr, prnr2)


### PR DESCRIPTION
## What does this PR do?

Fixes #2787

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2788.org.readthedocs.build/en/2788/

<!-- readthedocs-preview torchmetrics end -->