### PR TITLE
Re-adding `numpy` 2+ support

### DIFF
--- a/requirements/audio.txt
+++ b/requirements/audio.txt
@@ -3,6 +3,7 @@
 
 # this need to be the same as used inside speechmetrics
 pesq >=0.0.4, <0.0.5
+numpy <2.0  # strict, for compatibility reasons
 pystoi >=0.4.0, <0.5.0
 torchaudio >=2.0.1, <2.6.0
 gammatone >=1.0.0, <1.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # NOTE: the upper bound for the package version is only set for CI stability, and it is dropped while installing this package
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
-numpy >1.20.0, <2.0  # strict, for compatibility reasons
+numpy >1.20.0
 packaging >17.1
 torch >=2.0.0, <2.6.0
 typing-extensions; python_version < '3.9'


### PR DESCRIPTION
## What does this PR do?

The ability to install torchmetrics with numpy 2 was removed in #2692 due to a dependency that does not yet support numpy 2. However, this dependency (PESQ) is optional, so there is no reason to prevent the base installation from using numpy 2.

@Borda

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2804.org.readthedocs.build/en/2804/

<!-- readthedocs-preview torchmetrics end -->