### PR TITLE
Bugfix for empty preds or target in iou scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed iou scores in detection for either empty predictions/targets leading to wrong scores ([#2805](https://github.com/Lightning-AI/torchmetrics/pull/2805))
 
 
 ---

--- a/src/torchmetrics/detection/iou.py
+++ b/src/torchmetrics/detection/iou.py
@@ -192,7 +192,7 @@ class IntersectionOverUnion(Metric):
                 if det_boxes.numel() > 0 and gt_boxes.numel() > 0:
                     label_eq = p_i["labels"].unsqueeze(1) == t_i["labels"].unsqueeze(0)  # N x M
                 else:
-                    label_eq = torch.eye(iou_matrix.shape[0], dtype=bool, device=iou_matrix.device)
+                    label_eq = torch.eye(iou_matrix.shape[0], dtype=bool, device=iou_matrix.device)  # type: ignore[call-overload]
                 iou_matrix[~label_eq] = self._invalid_val
             self.iou_matrix.append(iou_matrix)
 

--- a/src/torchmetrics/functional/detection/ciou.py
+++ b/src/torchmetrics/functional/detection/ciou.py
@@ -31,6 +31,11 @@ def _ciou_update(
 
     from torchvision.ops import complete_box_iou
 
+    if preds.numel() == 0:  # if no boxes are predicted
+        return torch.zeros(target.shape[0], target.shape[0], device=target.device, dtype=torch.float32)
+    if target.numel() == 0:  # if no boxes are true
+        return torch.zeros(preds.shape[0], preds.shape[0], device=preds.device, dtype=torch.float32)
+
     iou = complete_box_iou(preds, target)
     if iou_threshold is not None:
         iou[iou < iou_threshold] = replacement_val

--- a/src/torchmetrics/functional/detection/diou.py
+++ b/src/torchmetrics/functional/detection/diou.py
@@ -31,6 +31,11 @@ def _diou_update(
 
     from torchvision.ops import distance_box_iou
 
+    if preds.numel() == 0:  # if no boxes are predicted
+        return torch.zeros(target.shape[0], target.shape[0], device=target.device, dtype=torch.float32)
+    if target.numel() == 0:  # if no boxes are true
+        return torch.zeros(preds.shape[0], preds.shape[0], device=preds.device, dtype=torch.float32)
+
     iou = distance_box_iou(preds, target)
     if iou_threshold is not None:
         iou[iou < iou_threshold] = replacement_val

--- a/src/torchmetrics/functional/detection/giou.py
+++ b/src/torchmetrics/functional/detection/giou.py
@@ -31,6 +31,11 @@ def _giou_update(
 
     from torchvision.ops import generalized_box_iou
 
+    if preds.numel() == 0:  # if no boxes are predicted
+        return torch.zeros(target.shape[0], target.shape[0], device=target.device, dtype=torch.float32)
+    if target.numel() == 0:  # if no boxes are true
+        return torch.zeros(preds.shape[0], preds.shape[0], device=preds.device, dtype=torch.float32)
+
     iou = generalized_box_iou(preds, target)
     if iou_threshold is not None:
         iou[iou < iou_threshold] = replacement_val

--- a/src/torchmetrics/functional/detection/iou.py
+++ b/src/torchmetrics/functional/detection/iou.py
@@ -32,6 +32,11 @@ def _iou_update(
 
     from torchvision.ops import box_iou
 
+    if preds.numel() == 0:  # if no boxes are predicted
+        return torch.zeros(target.shape[0], target.shape[0], device=target.device, dtype=torch.float32)
+    if target.numel() == 0:  # if no boxes are true
+        return torch.zeros(preds.shape[0], preds.shape[0], device=preds.device, dtype=torch.float32)
+
     iou = box_iou(preds, target)
     if iou_threshold is not None:
         iou[iou < iou_threshold] = replacement_val

--- a/tests/unittests/detection/test_intersection.py
+++ b/tests/unittests/detection/test_intersection.py
@@ -353,6 +353,43 @@ class TestIntersectionMetrics(MetricTester):
         for val in res.values():
             assert val == torch.tensor(0.0)
 
+    def test_empty_preds_and_target(self, class_metric, functional_metric, reference_metric):
+        """Check that for either empty preds and targets that the metric returns 0 in these cases before averaging."""
+        x = [
+            {
+                "boxes": torch.empty(size=(0, 4), dtype=torch.float32),
+                "labels": torch.tensor([], dtype=torch.long),
+            },
+            {
+                "boxes": torch.FloatTensor([[0.1, 0.1, 0.2, 0.2], [0.3, 0.3, 0.4, 0.4]]),
+                "labels": torch.LongTensor([1, 2]),
+            },
+        ]
+
+        y = [
+            {
+                "boxes": torch.FloatTensor([[0.1, 0.1, 0.2, 0.2], [0.3, 0.3, 0.4, 0.4]]),
+                "labels": torch.LongTensor([1, 2]),
+                "scores": torch.FloatTensor([0.9, 0.8]),
+            },
+            {
+                "boxes": torch.FloatTensor([[0.1, 0.1, 0.2, 0.2], [0.3, 0.3, 0.4, 0.4]]),
+                "labels": torch.LongTensor([1, 2]),
+                "scores": torch.FloatTensor([0.9, 0.8]),
+            },
+        ]
+        metric = class_metric()
+        metric.update(x, y)
+        res = metric.compute()
+        for val in res.values():
+            assert val == torch.tensor(0.5)
+
+        metric = class_metric()
+        metric.update(y, x)
+        res = metric.compute()
+        for val in res.values():
+            assert val == torch.tensor(0.5)
+
 
 def test_corner_case():
     """See issue: https://github.com/Lightning-AI/torchmetrics/issues/1921."""


### PR DESCRIPTION
## What does this PR do?

Fixes #2805
When either preds or target have empty boxes the score for that pair should be 0. Currently instead it is a empty tensor which then are not counted towards the global average making the scores too high.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2806.org.readthedocs.build/en/2806/

<!-- readthedocs-preview torchmetrics end -->