### PR TITLE
Fix issue with shared state of `MetricCollection` compute group when using `DiceScore(average="weighted")`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed issue with shared state in metric collection when using dice score ([#2848](https://github.com/PyTorchLightning/metrics/pull/2848))
 
 
 ---

--- a/src/torchmetrics/segmentation/dice.py
+++ b/src/torchmetrics/segmentation/dice.py
@@ -131,8 +131,7 @@ class DiceScore(Metric):
         )
         self.numerator.append(numerator)
         self.denominator.append(denominator)
-        if self.average == "weighted":
-            self.support.append(support)
+        self.support.append(support)
 
     def compute(self) -> Tensor:
         """Computes the Dice Score."""

--- a/tests/unittests/segmentation/test_dice.py
+++ b/tests/unittests/segmentation/test_dice.py
@@ -108,6 +108,7 @@ class TestDiceScore(MetricTester):
             },
         )
 
+
 @pytest.mark.parametrize("compute_groups", [True, False])
 def test_dice_score_metric_collection(compute_groups: bool, num_batches: int = 4):
     """Test that the metric works within a metric collection with and without compute groups."""
@@ -125,11 +126,10 @@ def test_dice_score_metric_collection(compute_groups: bool, num_batches: int = 4
                 num_classes=NUM_CLASSES,
                 average="weighted",
             ),
-
         },
         compute_groups=compute_groups,
     )
-    
+
     for _ in range(num_batches):
         metric_collection.update(_inputs1.preds, _inputs1.target)
     result = metric_collection.compute()


### PR DESCRIPTION
## What does this PR do?

Fixes #2847

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
</details>

Tested using the code snippet provided in the issue description.

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2848.org.readthedocs.build/en/2848/

<!-- readthedocs-preview torchmetrics end -->