### PR TITLE
Bugfix so multilabel confusion matrix can plot for 2 or more labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed plotting of multilabel confusion matrix ([#2858](https://github.com/PyTorchLightning/metrics/pull/2858))
+
+
 - Fixed issue with shared state in metric collection when using dice score ([#2848](https://github.com/PyTorchLightning/metrics/pull/2848))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed plotting of multilabel confusion matrix ([#2858](https://github.com/PyTorchLightning/metrics/pull/2858))
 
 
 ---

--- a/requirements/_tests.txt
+++ b/requirements/_tests.txt
@@ -20,3 +20,5 @@ cloudpickle >1.3, <=3.1.0
 scikit-learn ==1.2.*; python_version < "3.9"
 scikit-learn ==1.5.*; python_version > "3.8"  # we do not use `> =` because of oldest replcement
 cachier ==3.1.2
+
+matplotlib==3.9.3

--- a/requirements/_tests.txt
+++ b/requirements/_tests.txt
@@ -20,5 +20,3 @@ cloudpickle >1.3, <=3.1.0
 scikit-learn ==1.2.*; python_version < "3.9"
 scikit-learn ==1.5.*; python_version > "3.8"  # we do not use `> =` because of oldest replcement
 cachier ==3.1.2
-
-matplotlib==3.9.3

--- a/src/torchmetrics/utilities/plot.py
+++ b/src/torchmetrics/utilities/plot.py
@@ -270,7 +270,7 @@ def plot_confusion_matrix(
     fig, axs = plt.subplots(nrows=rows, ncols=cols, constrained_layout=True) if ax is None else (ax.get_figure(), ax)
     axs = trim_axs(axs, nb)
     for i in range(nb):
-        ax = axs[i] if rows != 1 or cols != 1 else axs
+        ax = axs[i] if (rows != 1 or cols != 1) else axs
         if fig_label is not None:
             ax.set_title(f"Label {fig_label[i]}", fontsize=15)
         im = ax.imshow(confmat[i].cpu().detach() if confmat.ndim == 3 else confmat.cpu().detach(), cmap=cmap)

--- a/src/torchmetrics/utilities/plot.py
+++ b/src/torchmetrics/utilities/plot.py
@@ -270,7 +270,7 @@ def plot_confusion_matrix(
     fig, axs = plt.subplots(nrows=rows, ncols=cols, constrained_layout=True) if ax is None else (ax.get_figure(), ax)
     axs = trim_axs(axs, nb)
     for i in range(nb):
-        ax = axs[i] if rows != 1 and cols != 1 else axs
+        ax = axs[i] if rows != 1 or cols != 1 else axs
         if fig_label is not None:
             ax.set_title(f"Label {fig_label[i]}", fontsize=15)
         im = ax.imshow(confmat[i].cpu().detach() if confmat.ndim == 3 else confmat.cpu().detach(), cmap=cmap)

--- a/tests/unittests/classification/test_confusion_matrix.py
+++ b/tests/unittests/classification/test_confusion_matrix.py
@@ -243,28 +243,28 @@ class TestMulticlassConfusionMatrix(MetricTester):
     ("preds", "target", "ignore_index", "error_message"),
     [
         (
-                torch.randint(NUM_CLASSES + 1, (100,)),
-                torch.randint(NUM_CLASSES, (100,)),
-                None,
-                f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES}.*",
+            torch.randint(NUM_CLASSES + 1, (100,)),
+            torch.randint(NUM_CLASSES, (100,)),
+            None,
+            f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES}.*",
         ),
         (
-                torch.randint(NUM_CLASSES, (100,)),
-                torch.randint(NUM_CLASSES + 1, (100,)),
-                None,
-                f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES}.*",
+            torch.randint(NUM_CLASSES, (100,)),
+            torch.randint(NUM_CLASSES + 1, (100,)),
+            None,
+            f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES}.*",
         ),
         (
-                torch.randint(NUM_CLASSES + 2, (100,)),
-                torch.randint(NUM_CLASSES, (100,)),
-                1,
-                f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES + 1}.*",
+            torch.randint(NUM_CLASSES + 2, (100,)),
+            torch.randint(NUM_CLASSES, (100,)),
+            1,
+            f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES + 1}.*",
         ),
         (
-                torch.randint(NUM_CLASSES, (100,)),
-                torch.randint(NUM_CLASSES + 2, (100,)),
-                1,
-                f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES + 1}.*",
+            torch.randint(NUM_CLASSES, (100,)),
+            torch.randint(NUM_CLASSES + 2, (100,)),
+            1,
+            f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES + 1}.*",
         ),
     ],
 )
@@ -412,8 +412,8 @@ def test_warning_on_nan():
     target = torch.randint(3, size=(20,))
 
     with pytest.warns(
-            UserWarning,
-            match=".* NaN values found in confusion matrix have been replaced with zeros.",
+        UserWarning,
+        match=".* NaN values found in confusion matrix have been replaced with zeros.",
     ):
         multiclass_confusion_matrix(preds, target, num_classes=5, normalize="true")
 

--- a/tests/unittests/classification/test_confusion_matrix.py
+++ b/tests/unittests/classification/test_confusion_matrix.py
@@ -369,7 +369,7 @@ class TestMultilabelConfusionMatrix(MetricTester):
 
         if (preds < 0).any() and dtype == torch.half:
             pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision")
-        self.run_plot_test_cpu(
+        self.run_precision_test_cpu(
             preds=preds,
             target=target,
             metric_module=MultilabelConfusionMatrix,
@@ -397,13 +397,16 @@ class TestMultilabelConfusionMatrix(MetricTester):
         multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=2)
         preds = target = torch.ones(1, 2).int()
         multi_label_confusion_matrix.update(preds, target)
-        multi_label_confusion_matrix.plot()
+        fig, ax = multi_label_confusion_matrix.plot()
+        assert fig is not None
+        assert ax is not None
 
         multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=NUM_CLASSES)
         preds = target = torch.ones(1, NUM_CLASSES).int()
-        print(preds.shape, target.shape)
         multi_label_confusion_matrix.update(preds, target)
-        multi_label_confusion_matrix.plot()
+        fig, ax = multi_label_confusion_matrix.plot()
+        assert fig is not None
+        assert ax is not None
 
 
 def test_warning_on_nan():

--- a/tests/unittests/classification/test_confusion_matrix.py
+++ b/tests/unittests/classification/test_confusion_matrix.py
@@ -243,28 +243,28 @@ class TestMulticlassConfusionMatrix(MetricTester):
     ("preds", "target", "ignore_index", "error_message"),
     [
         (
-            torch.randint(NUM_CLASSES + 1, (100,)),
-            torch.randint(NUM_CLASSES, (100,)),
-            None,
-            f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES}.*",
+                torch.randint(NUM_CLASSES + 1, (100,)),
+                torch.randint(NUM_CLASSES, (100,)),
+                None,
+                f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES}.*",
         ),
         (
-            torch.randint(NUM_CLASSES, (100,)),
-            torch.randint(NUM_CLASSES + 1, (100,)),
-            None,
-            f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES}.*",
+                torch.randint(NUM_CLASSES, (100,)),
+                torch.randint(NUM_CLASSES + 1, (100,)),
+                None,
+                f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES}.*",
         ),
         (
-            torch.randint(NUM_CLASSES + 2, (100,)),
-            torch.randint(NUM_CLASSES, (100,)),
-            1,
-            f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES + 1}.*",
+                torch.randint(NUM_CLASSES + 2, (100,)),
+                torch.randint(NUM_CLASSES, (100,)),
+                1,
+                f"Detected more unique values in `preds` than expected. Expected only {NUM_CLASSES + 1}.*",
         ),
         (
-            torch.randint(NUM_CLASSES, (100,)),
-            torch.randint(NUM_CLASSES + 2, (100,)),
-            1,
-            f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES + 1}.*",
+                torch.randint(NUM_CLASSES, (100,)),
+                torch.randint(NUM_CLASSES + 2, (100,)),
+                1,
+                f"Detected more unique values in `target` than expected. Expected only {NUM_CLASSES + 1}.*",
         ),
     ],
 )
@@ -369,7 +369,7 @@ class TestMultilabelConfusionMatrix(MetricTester):
 
         if (preds < 0).any() and dtype == torch.half:
             pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision")
-        self.run_precision_test_cpu(
+        self.run_plot_test_cpu(
             preds=preds,
             target=target,
             metric_module=MultilabelConfusionMatrix,
@@ -392,6 +392,19 @@ class TestMultilabelConfusionMatrix(MetricTester):
             dtype=dtype,
         )
 
+    def test_multilabel_confusion_matrix_plot(self, inputs):
+        """Test multilabel cm plots."""
+        multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=2)
+        preds = target = torch.ones(1, 2).int()
+        multi_label_confusion_matrix.update(preds, target)
+        multi_label_confusion_matrix.plot()
+
+        multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=NUM_CLASSES)
+        preds = target = torch.ones(1, NUM_CLASSES).int()
+        print(preds.shape, target.shape)
+        multi_label_confusion_matrix.update(preds, target)
+        multi_label_confusion_matrix.plot()
+
 
 def test_warning_on_nan():
     """Test that a warning is given if division by zero happens during normalization of confusion matrix."""
@@ -399,8 +412,8 @@ def test_warning_on_nan():
     target = torch.randint(3, size=(20,))
 
     with pytest.warns(
-        UserWarning,
-        match=".* NaN values found in confusion matrix have been replaced with zeros.",
+            UserWarning,
+            match=".* NaN values found in confusion matrix have been replaced with zeros.",
     ):
         multiclass_confusion_matrix(preds, target, num_classes=5, normalize="true")
 

--- a/tests/unittests/classification/test_confusion_matrix.py
+++ b/tests/unittests/classification/test_confusion_matrix.py
@@ -392,17 +392,11 @@ class TestMultilabelConfusionMatrix(MetricTester):
             dtype=dtype,
         )
 
-    def test_multilabel_confusion_matrix_plot(self, inputs):
+    @pytest.mark.parametrize("num_labels", [2, NUM_CLASSES])
+    def test_multilabel_confusion_matrix_plot(self, num_labels):
         """Test multilabel cm plots."""
-        multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=2)
-        preds = target = torch.ones(1, 2).int()
-        multi_label_confusion_matrix.update(preds, target)
-        fig, ax = multi_label_confusion_matrix.plot()
-        assert fig is not None
-        assert ax is not None
-
-        multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=NUM_CLASSES)
-        preds = target = torch.ones(1, NUM_CLASSES).int()
+        multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=num_labels)
+        preds = target = torch.ones(1, num_labels).int()
         multi_label_confusion_matrix.update(preds, target)
         fig, ax = multi_label_confusion_matrix.plot()
         assert fig is not None

--- a/tests/unittests/classification/test_confusion_matrix.py
+++ b/tests/unittests/classification/test_confusion_matrix.py
@@ -394,7 +394,7 @@ class TestMultilabelConfusionMatrix(MetricTester):
         )
 
     @pytest.mark.parametrize("num_labels", [2, NUM_CLASSES])
-    def test_multilabel_confusion_matrix_plot(self, num_labels):
+    def test_multilabel_confusion_matrix_plot(self, num_labels, inputs):
         """Test multilabel cm plots."""
         multi_label_confusion_matrix = MultilabelConfusionMatrix(num_labels=num_labels)
         preds = target = torch.ones(1, num_labels).int()


### PR DESCRIPTION
## What does this PR do?

Fixes #2857
Multilabel plotting failed for two labels and succeeded for greater than two. No test existed for this added one but it also requires matplotlib so that was added to the test requirements

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>


<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2858.org.readthedocs.build/en/2858/

<!-- readthedocs-preview torchmetrics end -->