### PR TITLE
fix slow calculations of classification metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `top_k` for `multiclassf1score` with one-hot encoding ([#2839](https://github.com/Lightning-AI/torchmetrics/issues/2839))
 
 
+- Fixed slow calculations of classification metrics with MPS ([#2876](https://github.com/Lightning-AI/torchmetrics/issues/2876))
+
 ---
 
 ## [1.6.0] - 2024-11-12

--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -199,7 +199,7 @@ def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
     if minlength is None:
         minlength = len(torch.unique(x))
 
-    if torch.are_deterministic_algorithms_enabled() or _XLA_AVAILABLE and x.is_mps:
+    if torch.are_deterministic_algorithms_enabled() or _XLA_AVAILABLE or x.is_mps:
         mesh = torch.arange(minlength, device=x.device).repeat(len(x), 1)
         return torch.eq(x.reshape(-1, 1), mesh).sum(dim=0)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2868 

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun? Yes

Make sure you had fun coding 🙃

## Details

The flag for the **_TORCH_GREATER_EQUAL_1_12** was removed on the changed line in the following commit: 346bcdc41dc5487b18b96e4b01a8d34258dbd85a
Now problem with the removal is that if before condition for checking was:
`if torch.are_deterministic_algorithms_enabled() or _XLA_AVAILABLE or _TORCH_GREATER_EQUAL_1_12 and x.is_mps:`

which meant if tensor was on mps and torch was greater or equal 1.12 it would choose the conditional path. With removal of the flag _TORCH_GREATER_EQUAL_1_12, now for the code to enter this path the XLA should be available and tensor should be on mps and I don't think there is such a device at all that supports both XLA and mps tensors. After changing the code the performance issue on the issue posted above gets fixed




<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2876.org.readthedocs.build/en/2876/

<!-- readthedocs-preview torchmetrics end -->