### PR TITLE
ci: fix determine PR's diff

### DIFF
--- a/.github/assistant.py
+++ b/.github/assistant.py
@@ -21,7 +21,6 @@ from typing import Optional, Union
 import fire
 from packaging.version import parse
 
-
 _REQUEST_TIMEOUT = 10
 _PATH_ROOT = os.path.dirname(os.path.dirname(__file__))
 _PKG_WIDE_SUBPACKAGES = ("utilities", "helpers")

--- a/.github/assistant.py
+++ b/.github/assistant.py
@@ -20,7 +20,7 @@ from typing import Optional, Union
 
 import fire
 from packaging.version import parse
-from pkg_resources import parse_requirements
+
 
 _REQUEST_TIMEOUT = 10
 _PATH_ROOT = os.path.dirname(os.path.dirname(__file__))
@@ -58,6 +58,9 @@ class AssistantCLI:
         >>> AssistantCLI.set_min_torch_by_python("../requirements/base.txt")
 
         """
+        # ToDo: `pkg_resources` is deprecates and shall be updated
+        from pkg_resources import parse_requirements
+
         py_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
         if py_ver not in LUT_PYTHON_TORCH:
             return

--- a/.github/assistant.py
+++ b/.github/assistant.py
@@ -141,9 +141,7 @@ class AssistantCLI:
         files_req = [fn for fn in files if fn.startswith("requirements")]
         req_domains = [fn.split("/")[1] for fn in files_req]
         # cleaning up determining domains
-        req_domains = set([
-            req.replace(".txt", "").replace("_test", "") for req in req_domains if not req.endswith("_")
-        ])
+        req_domains = [req.replace(".txt", "").replace("_test", "") for req in req_domains if not req.endswith("_")]
         # if you touch base, you need to run everything
         if "base" in req_domains:
             return _return_all

--- a/.github/workflows/_focus-diff.yml
+++ b/.github/workflows/_focus-diff.yml
@@ -27,7 +27,6 @@ jobs:
           set -e
           echo $PR_NUMBER
           pip install -q -U packaging fire pyGithub pyopenssl
-          # python .github/assistant.py changed-domains $PR_NUMBER
           echo "focus=$(python .github/assistant.py changed-domains $PR_NUMBER)" >> $GITHUB_OUTPUT
 
       - run: echo "${{ steps.diff-domains.outputs.focus }}"


### PR DESCRIPTION
## What does this PR do?

evaluated on #2888 with some larger/complex change including requirements we may accidentally skip building
before:
```
% python .github/assistant.py changed-domains 2888
unittests/_helpers
```
after:
```
% python .github/assistant.py changed-domains 2888
unittests/text unittests/_helpers unittests/multimodal
```


<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2894.org.readthedocs.build/en/2894/

<!-- readthedocs-preview torchmetrics end -->