### PR TITLE
Fix typo in FID description: Replace "access" with "assess"

### DIFF
--- a/src/torchmetrics/image/fid.py
+++ b/src/torchmetrics/image/fid.py
@@ -181,7 +181,7 @@ def _compute_fid(mu1: Tensor, sigma1: Tensor, mu2: Tensor, sigma2: Tensor) -> Te
 
 
 class FrechetInceptionDistance(Metric):
-    r"""Calculate Fréchet inception distance (FID_) which is used to access the quality of generated images.
+    r"""Calculate Fréchet inception distance (FID_) which is used to assess the quality of generated images.
 
     .. math::
         FID = \|\mu - \mu_w\|^2 + tr(\Sigma + \Sigma_w - 2(\Sigma \Sigma_w)^{\frac{1}{2}})


### PR DESCRIPTION
The previous description incorrectly used the word "access" instead of "assess" when describing the purpose of Fréchet Inception Distance (FID). This change corrects the typo to ensure clarity and accuracy.



<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2919.org.readthedocs.build/en/2919/

<!-- readthedocs-preview torchmetrics end -->