### PR TITLE
tests: skip if HTTP Error 504: Gateway Time-out

### DIFF
--- a/tests/unittests/_helpers/wrappers.py
+++ b/tests/unittests/_helpers/wrappers.py
@@ -1,6 +1,7 @@
 import os
 from functools import wraps
 from typing import Any, Callable, Optional
+from urllib.error import HTTPError
 
 import pytest
 
@@ -47,6 +48,10 @@ def skip_on_connection_issues(reason: str = "Unable to load checkpoints from Hug
 
             try:
                 return function(*args, **kwargs)
+            except HTTPError as ex:
+                if ex.code != 504:  # HTTP Error 504: Gateway Time-out
+                    raise ex
+                pytest.skip(reason)
             except URLError as ex:
                 if "Error 403: Forbidden" not in str(ex) or not ALLOW_SKIP_IF_BAD_CONNECTION:
                     raise ex


### PR DESCRIPTION
## What does this PR do?

```
FAILED unittests/multimodal/test_clip_iqa.py::TestCLIPIQA::test_clip_iqa[False] - urllib.error.HTTPError: HTTP Error 504: Gateway Time-out
FAILED unittests/multimodal/test_clip_iqa.py::TestCLIPIQA::test_clip_iqa_functional[shapes0] - urllib.error.HTTPError: HTTP Error 504: Gateway Time-out
FAILED unittests/multimodal/test_clip_iqa.py::TestCLIPIQA::test_clip_iqa_functional[shapes1] - urllib.error.HTTPError: HTTP Error 504: Gateway Time-out
```

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2927.org.readthedocs.build/en/2927/

<!-- readthedocs-preview torchmetrics end -->