### PR TITLE
tests: skip if `pytest.pool` not used

### DIFF
--- a/tests/unittests/bases/test_ddp.py
+++ b/tests/unittests/bases/test_ddp.py
@@ -339,6 +339,7 @@ def _test_sync_with_unequal_size_lists(rank):
 @pytest.mark.DDP
 @pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test only works on newer torch versions")
 @pytest.mark.skipif(sys.platform == "win32", reason="DDP not available on windows")
+@pytest.mark.skipif(not USE_PYTEST_POOL, reason="DDP pool is not available.")
 def test_sync_with_unequal_size_lists():
     """Test that synchronization of states can be enabled and disabled for compute."""
     pytest.pool.map(_test_sync_with_unequal_size_lists, range(NUM_PROCESSES))


### PR DESCRIPTION
## What does this PR do?

Fixes failing test when 
```python
tests/unittests/bases/test_ddp.py sssssssssssssssF

=================================================================================================================== FAILURES ===================================================================================================================
______________________________________________________________________________________________________ test_sync_with_unequal_size_lists _______________________________________________________________________________________________________

    @pytest.mark.DDP
    @pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test only works on newer torch versions")
    @pytest.mark.skipif(sys.platform == "win32", reason="DDP not available on windows")
    def test_sync_with_unequal_size_lists():
        """Test that synchronization of states can be enabled and disabled for compute."""
>       pytest.pool.map(_test_sync_with_unequal_size_lists, range(NUM_PROCESSES))
E       AttributeError: module 'pytest' has no attribute 'pool'


tests/unittests/bases/test_ddp.py:346: AttributeError
=========================================================================================================== short test summary info ============================================================================================================
FAILED tests/unittests/bases/test_ddp.py::test_sync_with_unequal_size_lists - AttributeError: module 'pytest' has no attribute 'pool'
```

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [] Did you make sure to **update the docs**?
- [] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2930.org.readthedocs.build/en/2930/

<!-- readthedocs-preview torchmetrics end -->