### PR TITLE
tests: switch away from deprecated `jiwer` methods

### DIFF
--- a/tests/unittests/text/test_mer.py
+++ b/tests/unittests/text/test_mer.py
@@ -26,10 +26,10 @@ seed_all(42)
 
 def _reference_jiwer_mer(preds: Union[str, list[str]], target: Union[str, list[str]]):
     try:
-        from jiwer import compute_measures
+        from jiwer import mer
     except ImportError:
         pytest.skip("test requires jiwer package to be installed")
-    return compute_measures(target, preds)["mer"]
+    return mer(target, preds)
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/text/test_wer.py
+++ b/tests/unittests/text/test_wer.py
@@ -23,11 +23,11 @@ from unittests.text._inputs import _inputs_error_rate_batch_size_1, _inputs_erro
 
 def _reference_jiwer_wer(preds: Union[str, list[str]], target: Union[str, list[str]]):
     try:
-        from jiwer import compute_measures
+        from jiwer import wer
     except ImportError:
         pytest.skip("test requires jiwer package to be installed")
 
-    return compute_measures(target, preds)["wer"]
+    return wer(target, preds)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Fixes your tests breaking when you accidentally upgrade to version v4.0.0.


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2937.org.readthedocs.build/en/2937/

<!-- readthedocs-preview torchmetrics end -->