### PR TITLE
Fix: Memory Leak in BinaryPrecisionRecallCurve by Clearing Stored Predictions and Targets

### DIFF
--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -186,7 +186,7 @@ class BinaryPrecisionRecallCurve(Metric):
             self.preds.clear()
             self.target.clear()
             return _binary_precision_recall_curve_compute(state, None)
-        
+
         # Handle thresholded case
         state = self.confmat
         self.confmat.zero_()  # Clear the confusion matrix

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -175,7 +175,7 @@ class BinaryPrecisionRecallCurve(Metric):
         """Compute metric."""
         if self.thresholds is None:
             if not self.preds or not self.target:
-                return torch.tensor([]), torch.tensor([]), torch.tensor([])
+                return torch.zeros(1), torch.zeros(1), torch.zeros(0)
             state = (torch.cat(self.preds), torch.cat(self.target))
             self.preds.clear()
             self.target.clear()

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -182,14 +182,15 @@ class BinaryPrecisionRecallCurve(Metric):
                 )
 
             state = (torch.cat(self.preds), torch.cat(self.target))
+            # Clear the lists after concatenation to prevent memory growth
             self.preds.clear()
             self.target.clear()
             return _binary_precision_recall_curve_compute(state, None)
-
+        
+        # Handle thresholded case
         state = self.confmat
-        precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
-        self.confmat.zero_()
-        return precision, recall, thresholds if thresholds is not None else torch.zeros(0)
+        self.confmat.zero_()  # Clear the confusion matrix
+        return _binary_precision_recall_curve_compute(state, self.thresholds)
 
     def plot(
         self,

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -178,8 +178,8 @@ class BinaryPrecisionRecallCurve(Metric):
                 state = (torch.cat(self.preds), torch.cat(self.target))
                 self.preds.clear()
                 self.target.clear()
-            return _binary_precision_recall_curve_compute(state, self.thresholds)
-
+                return _binary_precision_recall_curve_compute(state, self.thresholds)
+            return torch.tensor([]), torch.tensor([]), torch.tensor([])
         state = self.confmat
         precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
         self.confmat.zero_()

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -174,6 +174,8 @@ class BinaryPrecisionRecallCurve(Metric):
     def compute(self) -> tuple[Tensor, Tensor, Tensor]:
         """Compute metric."""
         if self.thresholds is None:
+            if not self.preds or not self.target:
+                return torch.tensor([]), torch.tensor([]), torch.tensor([])
             state = (torch.cat(self.preds), torch.cat(self.target))
             self.preds.clear()
             self.target.clear()

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -174,11 +174,10 @@ class BinaryPrecisionRecallCurve(Metric):
     def compute(self) -> tuple[Tensor, Tensor, Tensor]:
         """Compute metric."""
         if self.thresholds is None:
-            if not self.preds or not self.target:
-                return torch.zeros(1), torch.zeros(1), torch.zeros(0)
-            state = (torch.cat(self.preds), torch.cat(self.target))
-            self.preds.clear()
-            self.target.clear()
+            if self.preds and self.target:
+                state = (torch.cat(self.preds), torch.cat(self.target))
+                self.preds.clear()
+                self.target.clear()
             return _binary_precision_recall_curve_compute(state, self.thresholds)
 
         state = self.confmat

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -180,12 +180,15 @@ class BinaryPrecisionRecallCurve(Metric):
 
             self.preds.clear()
             self.target.clear()
+            precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
+            return precision, recall, thresholds if thresholds is not None else torch.tensor([])
         else:
             state = self.confmat
+            precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
             self.confmat.zero_()
+            return precision, recall, thresholds if thresholds is not None else torch.tensor([])
 
-        precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
-        return precision, recall, thresholds if thresholds is not None else torch.tensor([])
+
 
     def plot(
         self,

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -174,18 +174,15 @@ class BinaryPrecisionRecallCurve(Metric):
     def compute(self) -> tuple[Tensor, Tensor, Tensor]:
         """Compute metric."""
         if self.thresholds is None:
-            if not self.preds or not self.target:
-                return torch.tensor([]), torch.tensor([]), torch.tensor([])
             state = (torch.cat(self.preds), torch.cat(self.target))
-
             self.preds.clear()
             self.target.clear()
-            precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
-            return precision, recall, thresholds if thresholds is not None else torch.tensor([])
+            return _binary_precision_recall_curve_compute(state, self.thresholds)
+
         state = self.confmat
         precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
         self.confmat.zero_()
-        return precision, recall, thresholds if thresholds is not None else torch.tensor([])
+        return precision, recall, thresholds
 
     def plot(
         self,

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -182,13 +182,10 @@ class BinaryPrecisionRecallCurve(Metric):
             self.target.clear()
             precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
             return precision, recall, thresholds if thresholds is not None else torch.tensor([])
-        else:
-            state = self.confmat
-            precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
-            self.confmat.zero_()
-            return precision, recall, thresholds if thresholds is not None else torch.tensor([])
-
-
+        state = self.confmat
+        precision, recall, thresholds = _binary_precision_recall_curve_compute(state, self.thresholds)
+        self.confmat.zero_()
+        return precision, recall, thresholds if thresholds is not None else torch.tensor([])
 
     def plot(
         self,


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/2921

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
Used the solution proposed by @[suahelen](https://github.com/suahelen) in https://github.com/Lightning-AI/torchmetrics/issues/2921  with a little modification.

<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2945.org.readthedocs.build/en/2945/

<!-- readthedocs-preview torchmetrics end -->