### PR TITLE
Fix incorrect CLIP-IQA type hints

### DIFF
--- a/src/torchmetrics/functional/multimodal/clip_iqa.py
+++ b/src/torchmetrics/functional/multimodal/clip_iqa.py
@@ -89,7 +89,9 @@ def _get_clip_iqa_model_and_processor(
     return _get_clip_model_and_processor(model_name_or_path)
 
 
-def _clip_iqa_format_prompts(prompts: tuple[Union[str, tuple[str, str]], ...] = ("quality",)) -> tuple[list[str], list[str]]:
+def _clip_iqa_format_prompts(
+    prompts: tuple[Union[str, tuple[str, str]], ...] = ("quality",),
+) -> tuple[list[str], list[str]]:
     """Converts the provided keywords into a list of prompts for the model to calculate the anchor vectors.
 
     Args:
@@ -330,12 +332,19 @@ def clip_image_quality_assessment(
         img_features = _clip_iqa_update(model_name_or_path, images, model, processor, data_range, device)
         return _clip_iqa_compute(img_features, anchors, prompts_names)
 
+
 if TYPE_CHECKING:
     from typing import Any, cast
+
     images = cast(Any, None)
     from functools import partial
+
     f = partial(clip_image_quality_assessment, images=images)
     f(prompts=("colorfullness",))
-    f(prompts=("quality", "brightness", "noisiness"),)
-    f(prompts=("quality", "brightness", "noisiness", "colorfullness"),)
+    f(
+        prompts=("quality", "brightness", "noisiness"),
+    )
+    f(
+        prompts=("quality", "brightness", "noisiness", "colorfullness"),
+    )
     f(prompts=(("Photo of a cat", "Photo of a dog"), "quality", ("Colorful photo", "Black and white photo")))

--- a/src/torchmetrics/functional/multimodal/clip_iqa.py
+++ b/src/torchmetrics/functional/multimodal/clip_iqa.py
@@ -335,9 +335,9 @@ def clip_image_quality_assessment(
 
 if TYPE_CHECKING:
     from typing import Any, cast
+    from functools import partial
 
     images = cast(Any, None)
-    from functools import partial
 
     f = partial(clip_image_quality_assessment, images=images)
     f(prompts=("colorfullness",))

--- a/src/torchmetrics/functional/multimodal/clip_iqa.py
+++ b/src/torchmetrics/functional/multimodal/clip_iqa.py
@@ -334,8 +334,8 @@ def clip_image_quality_assessment(
 
 
 if TYPE_CHECKING:
-    from typing import Any, cast
     from functools import partial
+    from typing import Any, cast
 
     images = cast(Any, None)
 

--- a/src/torchmetrics/functional/multimodal/clip_iqa.py
+++ b/src/torchmetrics/functional/multimodal/clip_iqa.py
@@ -329,3 +329,13 @@ def clip_image_quality_assessment(
         anchors = _clip_iqa_get_anchor_vectors(model_name_or_path, model, processor, prompts_list, device)
         img_features = _clip_iqa_update(model_name_or_path, images, model, processor, data_range, device)
         return _clip_iqa_compute(img_features, anchors, prompts_names)
+
+if TYPE_CHECKING:
+    from typing import Any, cast
+    images = cast(Any, None)
+    from functools import partial
+    f = partial(clip_image_quality_assessment, images=images)
+    f(prompts=("colorfullness",))
+    f(prompts=("quality", "brightness", "noisiness"),)
+    f(prompts=("quality", "brightness", "noisiness", "colorfullness"),)
+    f(prompts=(("Photo of a cat", "Photo of a dog"), "quality", ("Colorful photo", "Black and white photo")))

--- a/src/torchmetrics/functional/multimodal/clip_iqa.py
+++ b/src/torchmetrics/functional/multimodal/clip_iqa.py
@@ -89,7 +89,7 @@ def _get_clip_iqa_model_and_processor(
     return _get_clip_model_and_processor(model_name_or_path)
 
 
-def _clip_iqa_format_prompts(prompts: tuple[Union[str, tuple[str, str]]] = ("quality",)) -> tuple[list[str], list[str]]:
+def _clip_iqa_format_prompts(prompts: tuple[Union[str, tuple[str, str]], ...] = ("quality",)) -> tuple[list[str], list[str]]:
     """Converts the provided keywords into a list of prompts for the model to calculate the anchor vectors.
 
     Args:
@@ -225,7 +225,7 @@ def clip_image_quality_assessment(
         "openai/clip-vit-large-patch14",
     ] = "clip_iqa",
     data_range: float = 1.0,
-    prompts: tuple[Union[str, tuple[str, str]]] = ("quality",),
+    prompts: tuple[Union[str, tuple[str, str]], ...] = ("quality",),
 ) -> Union[Tensor, dict[str, Tensor]]:
     """Calculates `CLIP-IQA`_, that can be used to measure the visual content of images.
 

--- a/src/torchmetrics/multimodal/clip_iqa.py
+++ b/src/torchmetrics/multimodal/clip_iqa.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Sequence
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, TYPE_CHECKING, Union
 
 import torch
 from torch import Tensor
@@ -259,3 +259,12 @@ class CLIPImageQualityAssessment(Metric):
 
         """
         return self._plot(val, ax)
+
+if TYPE_CHECKING:
+    from typing import cast
+    images = cast(Any, None)
+    f = CLIPImageQualityAssessment
+    f(prompts=("colorfullness",))
+    f(prompts=("quality", "brightness", "noisiness"),)
+    f(prompts=("quality", "brightness", "noisiness", "colorfullness"),)
+    f(prompts=(("Photo of a cat", "Photo of a dog"), "quality", ("Colorful photo", "Black and white photo")))

--- a/src/torchmetrics/multimodal/clip_iqa.py
+++ b/src/torchmetrics/multimodal/clip_iqa.py
@@ -262,8 +262,6 @@ class CLIPImageQualityAssessment(Metric):
 
 
 if TYPE_CHECKING:
-    from typing import cast
-
     f = CLIPImageQualityAssessment
     f(prompts=("colorfullness",))
     f(

--- a/src/torchmetrics/multimodal/clip_iqa.py
+++ b/src/torchmetrics/multimodal/clip_iqa.py
@@ -179,7 +179,7 @@ class CLIPImageQualityAssessment(Metric):
             "openai/clip-vit-large-patch14",
         ] = "clip_iqa",
         data_range: float = 1.0,
-        prompts: tuple[Union[str, tuple[str, str]]] = ("quality",),
+        prompts: tuple[Union[str, tuple[str, str]], ...] = ("quality",),
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/torchmetrics/multimodal/clip_iqa.py
+++ b/src/torchmetrics/multimodal/clip_iqa.py
@@ -264,7 +264,6 @@ class CLIPImageQualityAssessment(Metric):
 if TYPE_CHECKING:
     from typing import cast
 
-    images = cast(Any, None)
     f = CLIPImageQualityAssessment
     f(prompts=("colorfullness",))
     f(

--- a/src/torchmetrics/multimodal/clip_iqa.py
+++ b/src/torchmetrics/multimodal/clip_iqa.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Sequence
-from typing import Any, List, Literal, Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
 import torch
 from torch import Tensor
@@ -260,11 +260,17 @@ class CLIPImageQualityAssessment(Metric):
         """
         return self._plot(val, ax)
 
+
 if TYPE_CHECKING:
     from typing import cast
+
     images = cast(Any, None)
     f = CLIPImageQualityAssessment
     f(prompts=("colorfullness",))
-    f(prompts=("quality", "brightness", "noisiness"),)
-    f(prompts=("quality", "brightness", "noisiness", "colorfullness"),)
+    f(
+        prompts=("quality", "brightness", "noisiness"),
+    )
+    f(
+        prompts=("quality", "brightness", "noisiness", "colorfullness"),
+    )
     f(prompts=(("Photo of a cat", "Photo of a dog"), "quality", ("Colorful photo", "Black and white photo")))


### PR DESCRIPTION
## What does this PR do?

Fixes #2951

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
  - I've just submitted #2951.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
  - Seems like it's covered by something called [`autoclass`](https://github.com/Lightning-AI/torchmetrics/blob/2ffcedfc0edaee173b9ab513106346b899008ea0/docs/source/multimodal/clip_iqa.rst#L15) and [`autofunction`](https://github.com/Lightning-AI/torchmetrics/blob/2ffcedfc0edaee173b9ab513106346b899008ea0/docs/source/multimodal/clip_iqa.rst#L23)
- [x] Did you write any new **necessary tests**?
  - I don't think this requires a new test code. I thought [utilizing `TYPE_CHECKING`](https://github.com/Lightning-AI/torchmetrics/commit/f56874b42f3280c54a298ba5395d9c236eb1ebd7) would suffice, but that's not something I'm not willing to change.

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

frfr


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2952.org.readthedocs.build/en/2952/

<!-- readthedocs-preview torchmetrics end -->