### PR TITLE
iou_type: correct type hints

### DIFF
--- a/src/torchmetrics/detection/_mean_ap.py
+++ b/src/torchmetrics/detection/_mean_ap.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 from collections.abc import Sequence
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
 import numpy as np
 import torch
@@ -35,7 +35,7 @@ if not _TORCHVISION_AVAILABLE or not _PYCOCOTOOLS_AVAILABLE:
 log = logging.getLogger(__name__)
 
 
-def compute_area(inputs: list[Any], iou_type: str = "bbox") -> Tensor:
+def compute_area(inputs: list[Any], iou_type: Literal["bbox", "segm"] = "bbox") -> Tensor:
     """Compute area of input depending on the specified iou_type.
 
     Default output for empty input is :class:`~torch.Tensor`
@@ -59,7 +59,7 @@ def compute_area(inputs: list[Any], iou_type: str = "bbox") -> Tensor:
 def compute_iou(
     det: list[Any],
     gt: list[Any],
-    iou_type: str = "bbox",
+    iou_type: Literal["bbox", "segm"] = "bbox",
 ) -> Tensor:
     """Compute IOU between detections and ground-truth using the specified iou_type."""
     from torchvision.ops import box_iou
@@ -315,7 +315,7 @@ class MeanAveragePrecision(Metric):
     def __init__(
         self,
         box_format: str = "xyxy",
-        iou_type: str = "bbox",
+        iou_type: Literal["bbox", "segm"] = "bbox",
         iou_thresholds: Optional[list[float]] = None,
         rec_thresholds: Optional[list[float]] = None,
         max_detection_thresholds: Optional[list[int]] = None,

--- a/src/torchmetrics/detection/_mean_ap.py
+++ b/src/torchmetrics/detection/_mean_ap.py
@@ -367,7 +367,7 @@ class MeanAveragePrecision(Metric):
 
     def update(self, preds: list[dict[str, Tensor]], target: list[dict[str, Tensor]]) -> None:
         """Update state with predictions and targets."""
-        _input_validator(preds, target, iou_type=self.iou_type)  # type: ignore[arg-type]
+        _input_validator(preds, target, iou_type=self.iou_type)
 
         for item in preds:
             detections = self._get_safe_item_values(item)

--- a/src/torchmetrics/detection/helpers.py
+++ b/src/torchmetrics/detection/helpers.py
@@ -20,7 +20,7 @@ from torch import Tensor
 def _input_validator(
     preds: Sequence[dict[str, Tensor]],
     targets: Sequence[dict[str, Tensor]],
-    iou_type: Union[Literal["bbox", "segm"], tuple[Literal["bbox", "segm"]]] = "bbox",
+    iou_type: Union[Literal["bbox", "segm"], tuple[Literal["bbox", "segm"], ...]] = "bbox",
     ignore_score: bool = False,
 ) -> None:
     """Ensure the correct input format of `preds` and `targets`."""
@@ -89,8 +89,8 @@ def _fix_empty_tensors(boxes: Tensor) -> Tensor:
 
 
 def _validate_iou_type_arg(
-    iou_type: Union[Literal["bbox", "segm"], tuple[str]] = "bbox",
-) -> tuple[str]:
+    iou_type: Union[Literal["bbox", "segm"], tuple[Literal["bbox", "segm"], ...]] = "bbox",
+) -> tuple[Literal["bbox", "segm"], ...]:
     """Validate that iou type argument is correct."""
     allowed_iou_types = ("segm", "bbox")
     if isinstance(iou_type, str):

--- a/src/torchmetrics/detection/mean_ap.py
+++ b/src/torchmetrics/detection/mean_ap.py
@@ -497,7 +497,7 @@ class MeanAveragePrecision(Metric):
                 If any score is not type float and of length 1
 
         """
-        _input_validator(preds, target, iou_type=self.iou_type)  # type: ignore[arg-type]
+        _input_validator(preds, target, iou_type=self.iou_type)
 
         for item in preds:
             bbox_detection, mask_detection = self._get_safe_item_values(item, warn=self.warn_on_many_detections)
@@ -681,7 +681,7 @@ class MeanAveragePrecision(Metric):
             ... )  # doctest: +SKIP
 
         """
-        iou_type = _validate_iou_type_arg(iou_type)  # type: ignore[arg-type]
+        iou_type = _validate_iou_type_arg(iou_type)
         coco, _, _ = _load_backend_tools(backend)
 
         with contextlib.redirect_stdout(io.StringIO()):

--- a/src/torchmetrics/detection/mean_ap.py
+++ b/src/torchmetrics/detection/mean_ap.py
@@ -373,7 +373,7 @@ class MeanAveragePrecision(Metric):
     def __init__(
         self,
         box_format: Literal["xyxy", "xywh", "cxcywh"] = "xyxy",
-        iou_type: Union[Literal["bbox", "segm"], tuple[str]] = "bbox",
+        iou_type: Union[Literal["bbox", "segm"], tuple[Literal["bbox", "segm"], ...]] = "bbox",
         iou_thresholds: Optional[list[float]] = None,
         rec_thresholds: Optional[list[float]] = None,
         max_detection_thresholds: Optional[list[int]] = None,
@@ -651,7 +651,7 @@ class MeanAveragePrecision(Metric):
     def coco_to_tm(
         coco_preds: str,
         coco_target: str,
-        iou_type: Union[Literal["bbox", "segm"], list[str]] = "bbox",
+        iou_type: Union[Literal["bbox", "segm"], tuple[Literal["bbox", "segm"], ...]] = "bbox",
         backend: Literal["pycocotools", "faster_coco_eval"] = "pycocotools",
     ) -> tuple[list[dict[str, Tensor]], list[dict[str, Tensor]]]:
         """Utility function for converting .json coco format files to the input format of this metric.


### PR DESCRIPTION
## What does this PR do?

Corrects a few issues with the type hints for `iou_type`:

- [x] We sometimes use `str` and other times use `Literal["bbox", "segm"]`
- [x] `tuple[foo]` means a tuple of length 1, use `...` to make it a variadic tuple

Note that there are several other examples of the latter issue in the codebase, I only fixed `iou_type`.

Alternatively, we could force it to be a tuple of length 2.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2966.org.readthedocs.build/en/2966/

<!-- readthedocs-preview torchmetrics end -->