### PR TITLE
ci: fix focusing diff

### DIFF
--- a/.github/assistant.py
+++ b/.github/assistant.py
@@ -143,6 +143,8 @@ class AssistantCLI:
         if len(files) == len(files_markdown):
             logging.debug("Only markdown files was changed so not reason for deep testing...")
             return _return_empty
+        # filter out markdown files
+        files = [fn for fn in files if fn not in files_markdown]
 
         # filter only testing files which are not specific tests so for example configurations or helper tools
         files_testing = [fn for fn in files if fn.startswith("tests") and not fn.endswith(".md") and "test_" not in fn]


### PR DESCRIPTION
## What does this PR do?

some strange falling running tests for
```
(.venv) jirka@Jiris-Laptop tests % python -m pytest \
    unittests/tests unittests/detection \
    --cov=torchmetrics \
    --durations=50 \
    --reruns 3 \
    --reruns-delay 1 \
    -m "not DDP" \
    -n auto \
    --dist=load \
    --timeout=75
```
where the `unittests/tests` come from because of readme

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2976.org.readthedocs.build/en/2976/

<!-- readthedocs-preview torchmetrics end -->