### PR TITLE
Fix missing `kwargs` in `PIT` metric for permutation wise mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `MetricCollection.update` gives identical results ([#2944](https://github.com/Lightning-AI/torchmetrics/issues/2944))
 
 
+- Fixed missing `kwargs` in `PIT` metric for permutation wise mode ([#2977](https://github.com/Lightning-AI/torchmetrics/pull/2977))
+
+
 ---
 
 ## [1.6.1] - 2024-12-24

--- a/src/torchmetrics/functional/audio/pit.py
+++ b/src/torchmetrics/functional/audio/pit.py
@@ -179,7 +179,7 @@ def permutation_invariant_training(
         )
         ptarget = target.repeat_interleave(repeats=perm_num, dim=0)
         # shape of metric_of_ps [batch_size*perm_num] or [batch_size*perm_num, spk_num]
-        metric_of_ps = metric_func(ppreds, ptarget)
+        metric_of_ps = metric_func(ppreds, ptarget, **kwargs)
         metric_of_ps = torch.mean(metric_of_ps.reshape(batch_size, len(perms), -1), dim=-1)
         # find the best metric and best permutation
         best_metric, best_indexes = eval_op(metric_of_ps, dim=1)


### PR DESCRIPTION
## What does this PR do?

Fixes #2907

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2977.org.readthedocs.build/en/2977/

<!-- readthedocs-preview torchmetrics end -->