### PR TITLE
Docs: Improve CLIP Score Documentation with Text Formatting and Input Specification

### DIFF
--- a/src/torchmetrics/multimodal/clip_score.py
+++ b/src/torchmetrics/multimodal/clip_score.py
@@ -71,16 +71,33 @@ class CLIPScore(Metric):
 
     As input to ``forward`` and ``update`` the metric accepts the following input
 
-    - source: Source input. This can be:
-        - Images: (:class:`~torch.Tensor` or list of tensors): tensor with images feed to the feature extractor with. If
-            a single tensor it should have shape ``(N, C, H, W)``. If a list of tensors, each tensor should have shape
-            ``(C, H, W)``. ``C`` is the number of channels, ``H`` and ``W`` are the height and width of the image.
-        - Text: (:class:`~str` or :class:`~list` of :class:`~str`): text to compare with the images, one for each image.
-    - target: Target input. This can be:
-        - Images: (:class:`~torch.Tensor` or list of tensors): tensor with images feed to the feature extractor with. If
-            a single tensor it should have shape ``(N, C, H, W)``. If a list of tensors, each tensor should have shape
-            ``(C, H, W)``. ``C`` is the number of channels, ``H`` and ``W`` are the height and width of the image.
-        - Text: (:class:`~str` or :class:`~list` of :class:`~str`): text to compare with the images, one for each image.
+    - source: Source input. 
+    
+        This can be:
+
+        - Images: ``Tensor`` or list of ``Tensor``
+
+            If a single tensor, it should have shape ``(N, C, H, W)``.  
+            If a list of tensors, each tensor should have shape ``(C, H, W)``.  
+            ``C`` is the number of channels, ``H`` and ``W`` are the height and width of the image.
+
+        - Text: ``str`` or list of ``str``  
+            
+            Either a single caption or a list of captions.
+
+    - target: Target input. 
+
+        This can be:
+
+        - Images: ``Tensor`` or list of ``Tensor``  
+
+            If a single tensor, it should have shape ``(N, C, H, W)``.  
+            If a list of tensors, each tensor should have shape ``(C, H, W)``.  
+            ``C`` is the number of channels, ``H`` and ``W`` are the height and width of the image.
+
+        - Text: ``str`` or list of ``str``  
+            
+            Either a single caption or a list of captions.
 
     As output of `forward` and `compute` the metric returns the following output
 


### PR DESCRIPTION
## What does this PR do?

- Fixes unformatted documentation in the CLIP Score metric 
![Screenshot (36)](https://github.com/user-attachments/assets/f5ab8702-72ee-4dc8-969d-029b08cbd804)

- Adds proper reStructuredText formatting for better readability.

Fixes #\<issue_number>

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
