### PR TITLE
Docs: multilabel is also a string

### DIFF
--- a/src/torchmetrics/classification/accuracy.py
+++ b/src/torchmetrics/classification/accuracy.py
@@ -468,7 +468,7 @@ class Accuracy(_ClassificationTaskWrapper):
     Where :math:`y` is a tensor of target values, and :math:`\hat{y}` is a tensor of predictions.
 
     This module is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryAccuracy`, :class:`~torchmetrics.classification.MulticlassAccuracy` and
     :class:`~torchmetrics.classification.MultilabelAccuracy` for the specific details of each argument influence and
     examples.

--- a/src/torchmetrics/classification/auroc.py
+++ b/src/torchmetrics/classification/auroc.py
@@ -482,7 +482,7 @@ class AUROC(_ClassificationTaskWrapper):
     corresponds to random guessing.
 
     This module is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryAUROC`, :class:`~torchmetrics.classification.MulticlassAUROC` and
     :class:`~torchmetrics.classification.MultilabelAUROC` for the specific details of each argument influence and
     examples.

--- a/src/torchmetrics/classification/average_precision.py
+++ b/src/torchmetrics/classification/average_precision.py
@@ -492,7 +492,7 @@ class AveragePrecision(_ClassificationTaskWrapper):
     equivalent to the area under the precision-recall curve (AUPRC).
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryAveragePrecision`,
     :class:`~torchmetrics.classification.MulticlassAveragePrecision` and
     :class:`~torchmetrics.classification.MultilabelAveragePrecision` for the specific details of each argument

--- a/src/torchmetrics/classification/confusion_matrix.py
+++ b/src/torchmetrics/classification/confusion_matrix.py
@@ -483,7 +483,7 @@ class ConfusionMatrix(_ClassificationTaskWrapper):
     r"""Compute the `confusion matrix`_.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryConfusionMatrix`,
     :class:`~torchmetrics.classification.MulticlassConfusionMatrix` and
     :class:`~torchmetrics.classification.MultilabelConfusionMatrix` for the specific details of each argument influence

--- a/src/torchmetrics/classification/exact_match.py
+++ b/src/torchmetrics/classification/exact_match.py
@@ -405,7 +405,7 @@ class ExactMatch(_ClassificationTaskWrapper):
     correctly classified.
 
     This module is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.MulticlassExactMatch` and
     :class:`~torchmetrics.classification.MultilabelExactMatch` for the specific details of each argument influence and
     examples.

--- a/src/torchmetrics/classification/f_beta.py
+++ b/src/torchmetrics/classification/f_beta.py
@@ -1100,7 +1100,7 @@ class FBetaScore(_ClassificationTaskWrapper):
     affected in turn.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryFBetaScore`,
     :class:`~torchmetrics.classification.MulticlassFBetaScore` and
     :class:`~torchmetrics.classification.MultilabelFBetaScore` for the specific details of each argument influence
@@ -1168,7 +1168,7 @@ class F1Score(_ClassificationTaskWrapper):
     affected in turn.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryF1Score`, :class:`~torchmetrics.classification.MulticlassF1Score` and
     :class:`~torchmetrics.classification.MultilabelF1Score` for the specific details of each argument influence and
     examples.

--- a/src/torchmetrics/classification/hamming.py
+++ b/src/torchmetrics/classification/hamming.py
@@ -477,7 +477,7 @@ class HammingDistance(_ClassificationTaskWrapper):
     tensor.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryHammingDistance`,
     :class:`~torchmetrics.classification.MulticlassHammingDistance` and
     :class:`~torchmetrics.classification.MultilabelHammingDistance` for the specific details of each argument influence

--- a/src/torchmetrics/classification/jaccard.py
+++ b/src/torchmetrics/classification/jaccard.py
@@ -441,7 +441,7 @@ class JaccardIndex(_ClassificationTaskWrapper):
     .. math:: J(A,B) = \frac{|A\cap B|}{|A\cup B|}
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryJaccardIndex`,
     :class:`~torchmetrics.classification.MulticlassJaccardIndex` and
     :class:`~torchmetrics.classification.MultilabelJaccardIndex` for the specific details of each argument influence

--- a/src/torchmetrics/classification/logauc.py
+++ b/src/torchmetrics/classification/logauc.py
@@ -468,7 +468,7 @@ class LogAUC(_ClassificationTaskWrapper):
     is of high importance.
 
     This module is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryLogAUC`, :class:`~torchmetrics.classification.MulticlassLogAUC` and
     :class:`~torchmetrics.classification.MultilabelLogAUC` for the specific details of each argument influence and
     examples.

--- a/src/torchmetrics/classification/matthews_corrcoef.py
+++ b/src/torchmetrics/classification/matthews_corrcoef.py
@@ -374,7 +374,7 @@ class MatthewsCorrCoef(_ClassificationTaskWrapper):
     This metric measures the general correlation or quality of a classification.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryMatthewsCorrCoef`,
     :class:`~torchmetrics.classification.MulticlassMatthewsCorrCoef` and
     :class:`~torchmetrics.classification.MultilabelMatthewsCorrCoef` for the specific details of each argument influence

--- a/src/torchmetrics/classification/negative_predictive_value.py
+++ b/src/torchmetrics/classification/negative_predictive_value.py
@@ -467,7 +467,7 @@ class NegativePredictiveValue(_ClassificationTaskWrapper):
     therefore be affected in turn.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryNegativePredictiveValue`,
     :class:`~torchmetrics.classification.MulticlassNegativePredictiveValue`
     and :class:`~torchmetrics.classification.MultilabelNegativePredictiveValue` for the specific details of each

--- a/src/torchmetrics/classification/precision_fixed_recall.py
+++ b/src/torchmetrics/classification/precision_fixed_recall.py
@@ -477,7 +477,7 @@ class PrecisionAtFixedRecall(_ClassificationTaskWrapper):
     a given precision level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryPrecisionAtFixedRecall`,
     :class:`~torchmetrics.classification.MulticlassPrecisionAtFixedRecall` and
     :class:`~torchmetrics.classification.MultilabelPrecisionAtFixedRecall` for the specific details of each argument

--- a/src/torchmetrics/classification/precision_recall.py
+++ b/src/torchmetrics/classification/precision_recall.py
@@ -967,7 +967,7 @@ class Precision(_ClassificationTaskWrapper):
     therefore be affected in turn.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryPrecision`, :class:`~torchmetrics.classification.MulticlassPrecision` and
     :class:`~torchmetrics.classification.MultilabelPrecision` for the specific details of each argument influence and
     examples.
@@ -1032,7 +1032,7 @@ class Recall(_ClassificationTaskWrapper):
     therefore be affected in turn.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryRecall`,
     :class:`~torchmetrics.classification.MulticlassRecall` and :class:`~torchmetrics.classification.MultilabelRecall`
     for the specific details of each argument influence and examples.

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -630,7 +630,7 @@ class PrecisionRecallCurve(_ClassificationTaskWrapper):
     tradeoff between the two values can been seen.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryPrecisionRecallCurve`,
     :class:`~torchmetrics.classification.MulticlassPrecisionRecallCurve` and
     :class:`~torchmetrics.classification.MultilabelPrecisionRecallCurve` for the specific details of each argument

--- a/src/torchmetrics/classification/recall_fixed_precision.py
+++ b/src/torchmetrics/classification/recall_fixed_precision.py
@@ -476,7 +476,7 @@ class RecallAtFixedPrecision(_ClassificationTaskWrapper):
     a given precision level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryRecallAtFixedPrecision`,
     :class:`~torchmetrics.classification.MulticlassRecallAtFixedPrecision` and
     :class:`~torchmetrics.classification.MultilabelRecallAtFixedPrecision` for the specific details of each argument

--- a/src/torchmetrics/classification/roc.py
+++ b/src/torchmetrics/classification/roc.py
@@ -512,7 +512,7 @@ class ROC(_ClassificationTaskWrapper):
     different thresholds, such that the tradeoff between the two values can be seen.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryROC`,
     :class:`~torchmetrics.classification.MulticlassROC` and
     :class:`~torchmetrics.classification.MultilabelROC` for the specific details of each argument

--- a/src/torchmetrics/classification/sensitivity_specificity.py
+++ b/src/torchmetrics/classification/sensitivity_specificity.py
@@ -337,7 +337,7 @@ class SensitivityAtSpecificity(_ClassificationTaskWrapper):
     find the sensitivity for a given specificity level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinarySensitivityAtSpecificity`,
     :class:`~torchmetrics.classification.MulticlassSensitivityAtSpecificity` and
     :class:`~torchmetrics.classification.MultilabelSensitivityAtSpecificity` for the specific details of each argument

--- a/src/torchmetrics/classification/specificity.py
+++ b/src/torchmetrics/classification/specificity.py
@@ -459,7 +459,7 @@ class Specificity(_ClassificationTaskWrapper):
     therefore be affected in turn.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinarySpecificity`, :class:`~torchmetrics.classification.MulticlassSpecificity`
     and :class:`~torchmetrics.classification.MultilabelSpecificity` for the specific details of each argument influence
     and examples.

--- a/src/torchmetrics/classification/specificity_sensitivity.py
+++ b/src/torchmetrics/classification/specificity_sensitivity.py
@@ -337,7 +337,7 @@ class SpecificityAtSensitivity(_ClassificationTaskWrapper):
     find the specificity for a given sensitivity level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinarySpecificityAtSensitivity`,
     :class:`~torchmetrics.classification.MulticlassSpecificityAtSensitivity` and
     :class:`~torchmetrics.classification.MultilabelSpecificityAtSensitivity` for the specific details of each argument

--- a/src/torchmetrics/classification/stat_scores.py
+++ b/src/torchmetrics/classification/stat_scores.py
@@ -506,7 +506,7 @@ class StatScores(_ClassificationTaskWrapper):
     r"""Compute the number of true positives, false positives, true negatives, false negatives and the support.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :class:`~torchmetrics.classification.BinaryStatScores`, :class:`~torchmetrics.classification.MulticlassStatScores`
     and :class:`~torchmetrics.classification.MultilabelStatScores` for the specific details of each argument influence
     and examples.

--- a/src/torchmetrics/functional/classification/accuracy.py
+++ b/src/torchmetrics/functional/classification/accuracy.py
@@ -394,7 +394,7 @@ def accuracy(
     Where :math:`y` is a tensor of target values, and :math:`\hat{y}` is a tensor of predictions.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_accuracy`,
     :func:`~torchmetrics.functional.classification.multiclass_accuracy` and
     :func:`~torchmetrics.functional.classification.multilabel_accuracy` for the specific details of

--- a/src/torchmetrics/functional/classification/auroc.py
+++ b/src/torchmetrics/functional/classification/auroc.py
@@ -444,7 +444,7 @@ def auroc(
     corresponds to random guessing.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_auroc`,
     :func:`~torchmetrics.functional.classification.multiclass_auroc` and
     :func:`~torchmetrics.functional.classification.multilabel_auroc` for the specific details of

--- a/src/torchmetrics/functional/classification/average_precision.py
+++ b/src/torchmetrics/functional/classification/average_precision.py
@@ -429,7 +429,7 @@ def average_precision(
     equivalent to the area under the precision-recall curve (AUPRC).
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_average_precision`,
     :func:`~torchmetrics.functional.classification.multiclass_average_precision` and
     :func:`~torchmetrics.functional.classification.multilabel_average_precision`

--- a/src/torchmetrics/functional/classification/confusion_matrix.py
+++ b/src/torchmetrics/functional/classification/confusion_matrix.py
@@ -608,7 +608,7 @@ def confusion_matrix(
     r"""Compute the `confusion matrix`_.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_confusion_matrix`,
     :func:`~torchmetrics.functional.classification.multiclass_confusion_matrix` and
     :func:`~torchmetrics.functional.classification.multilabel_confusion_matrix` for

--- a/src/torchmetrics/functional/classification/f_beta.py
+++ b/src/torchmetrics/functional/classification/f_beta.py
@@ -731,7 +731,7 @@ def fbeta_score(
         {(\beta^2 * \text{precision}) + \text{recall}}
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_fbeta_score`,
     :func:`~torchmetrics.functional.classification.multiclass_fbeta_score` and
     :func:`~torchmetrics.functional.classification.multilabel_fbeta_score` for the specific
@@ -806,7 +806,7 @@ def f1_score(
         F_{1} = 2\frac{\text{precision} * \text{recall}}{(\text{precision}) + \text{recall}}
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_f1_score`,
     :func:`~torchmetrics.functional.classification.multiclass_f1_score` and
     :func:`~torchmetrics.functional.classification.multilabel_f1_score` for the specific

--- a/src/torchmetrics/functional/classification/hamming.py
+++ b/src/torchmetrics/functional/classification/hamming.py
@@ -394,7 +394,7 @@ def hamming_distance(
     tensor.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_hamming_distance`,
     :func:`~torchmetrics.functional.classification.multiclass_hamming_distance` and
     :func:`~torchmetrics.functional.classification.multilabel_hamming_distance` for

--- a/src/torchmetrics/functional/classification/jaccard.py
+++ b/src/torchmetrics/functional/classification/jaccard.py
@@ -344,7 +344,7 @@ def jaccard_index(
     .. math:: J(A,B) = \frac{|A\cap B|}{|A\cup B|}
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_jaccard_index`,
     :func:`~torchmetrics.functional.classification.multiclass_jaccard_index` and
     :func:`~torchmetrics.functional.classification.multilabel_jaccard_index` for

--- a/src/torchmetrics/functional/classification/matthews_corrcoef.py
+++ b/src/torchmetrics/functional/classification/matthews_corrcoef.py
@@ -261,7 +261,7 @@ def matthews_corrcoef(
     This metric measures the general correlation or quality of a classification.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_matthews_corrcoef`,
     :func:`~torchmetrics.functional.classification.multiclass_matthews_corrcoef` and
     :func:`~torchmetrics.functional.classification.multilabel_matthews_corrcoef` for

--- a/src/torchmetrics/functional/classification/negative_predictive_value.py
+++ b/src/torchmetrics/functional/classification/negative_predictive_value.py
@@ -380,7 +380,7 @@ def negative_predictive_value(
     encountered a score of 0 is returned.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_negative_predictive_value`,
     :func:`~torchmetrics.functional.classification.multiclass_negative_predictive_value` and
     :func:`~torchmetrics.functional.classification.multilabel_negative_predictive_value` for the specific

--- a/src/torchmetrics/functional/classification/precision_fixed_recall.py
+++ b/src/torchmetrics/functional/classification/precision_fixed_recall.py
@@ -323,7 +323,7 @@ def precision_at_fixed_recall(
     given precision level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_precision_at_fixed_recall`,
     :func:`~torchmetrics.functional.classification.multiclass_precision_at_fixed_recall` and
     :func:`~torchmetrics.functional.classification.multilabel_precision_at_fixed_recall` for the specific details of

--- a/src/torchmetrics/functional/classification/precision_recall.py
+++ b/src/torchmetrics/functional/classification/precision_recall.py
@@ -701,7 +701,7 @@ def precision(
     false positives respecitively.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_precision`,
     :func:`~torchmetrics.functional.classification.multiclass_precision` and
     :func:`~torchmetrics.functional.classification.multilabel_precision` for the specific details of
@@ -761,7 +761,7 @@ def recall(
     false negatives respecitively.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_recall`,
     :func:`~torchmetrics.functional.classification.multiclass_recall` and
     :func:`~torchmetrics.functional.classification.multilabel_recall` for the specific details of

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -958,7 +958,7 @@ def precision_recall_curve(
     tradeoff between the two values can been seen.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_precision_recall_curve`,
     :func:`~torchmetrics.functional.classification.multiclass_precision_recall_curve` and
     :func:`~torchmetrics.functional.classification.multilabel_precision_recall_curve` for the specific details of each

--- a/src/torchmetrics/functional/classification/recall_fixed_precision.py
+++ b/src/torchmetrics/functional/classification/recall_fixed_precision.py
@@ -415,7 +415,7 @@ def recall_at_fixed_precision(
     given precision level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_recall_at_fixed_precision`,
     :func:`~torchmetrics.functional.classification.multiclass_recall_at_fixed_precision` and
     :func:`~torchmetrics.functional.classification.multilabel_recall_at_fixed_precision` for the specific details of

--- a/src/torchmetrics/functional/classification/roc.py
+++ b/src/torchmetrics/functional/classification/roc.py
@@ -485,7 +485,7 @@ def roc(
     different thresholds, such that the tradeoff between the two values can be seen.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_roc`,
     :func:`~torchmetrics.functional.classification.multiclass_roc` and
     :func:`~torchmetrics.functional.classification.multilabel_roc` for the specific details of each argument

--- a/src/torchmetrics/functional/classification/sensitivity_specificity.py
+++ b/src/torchmetrics/functional/classification/sensitivity_specificity.py
@@ -420,7 +420,7 @@ def sensitivity_at_specificity(
     the find the sensitivity for a given specificity level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_sensitivity_at_specificity`,
     :func:`~torchmetrics.functional.classification.multiclass_sensitivity_at_specificity` and
     :func:`~torchmetrics.functional.classification.multilabel_sensitivity_at_specificity` for the specific details of

--- a/src/torchmetrics/functional/classification/specificity.py
+++ b/src/torchmetrics/functional/classification/specificity.py
@@ -357,7 +357,7 @@ def specificity(
     false positives respecitively.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_specificity`,
     :func:`~torchmetrics.functional.classification.multiclass_specificity` and
     :func:`~torchmetrics.functional.classification.multilabel_specificity` for the specific

--- a/src/torchmetrics/functional/classification/specificity_sensitivity.py
+++ b/src/torchmetrics/functional/classification/specificity_sensitivity.py
@@ -457,7 +457,7 @@ def specificity_at_sensitivity(
     the find the specificity for a given sensitivity level.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_specificity_at_sensitivity`,
     :func:`~torchmetrics.functional.classification.multiclass_specificity_at_sensitivity` and
     :func:`~torchmetrics.functional.classification.multilabel_specificity_at_sensitivity` for the specific details of

--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -1123,7 +1123,7 @@ def stat_scores(
     r"""Compute the number of true positives, false positives, true negatives, false negatives and the support.
 
     This function is a simple wrapper to get the task specific versions of this metric, which is done by setting the
-    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``multilabel``. See the documentation of
+    ``task`` argument to either ``'binary'``, ``'multiclass'`` or ``'multilabel'``. See the documentation of
     :func:`~torchmetrics.functional.classification.binary_stat_scores`,
     :func:`~torchmetrics.functional.classification.multiclass_stat_scores` and
     :func:`~torchmetrics.functional.classification.multilabel_stat_scores` for the specific


### PR DESCRIPTION
## What does this PR do?

Task can be 'binary', 'multiclass', or 'multilabel', but for some reason multilabel is never written with string quotes unlike the other two. This PR updates multilabel for consistency.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2996.org.readthedocs.build/en/2996/

<!-- readthedocs-preview torchmetrics end -->