### PR TITLE
docs: drop ref to lost SRMRToolbox

### DIFF
--- a/docs/source/links.rst
+++ b/docs/source/links.rst
@@ -74,7 +74,7 @@
 .. _Aggregate the statistics from multiple devices: https://stackoverflow.com/questions/68395368/estimate-running-correlation-on-multiple-nodes
 .. _Pearson Correlation Coefficient: https://en.wikipedia.org/wiki/Pearson_correlation_coefficient
 .. _Python ROUGE Implementation: https://pypi.org/project/rouge-score/
-.. _Scikit_Learn-Ranking.py: https: //github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/_ranking.py
+.. _Scikit_Learn-Ranking.py: https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/metrics/_ranking.py
 .. _Verified Uncertainty Calibration: https://arxiv.org/abs/1909.10155
 .. _SQuAD Metric: https://arxiv.org/abs/1606.05250
 .. _chrF score: https://aclanthology.org/W15-3049
@@ -125,7 +125,6 @@
 .. _Complex scale-invariant signal-to-noise ratio: https://arxiv.org/abs/2011.09162
 .. _Signal-to-noise ratio: https://arxiv.org/abs/1811.02508
 .. _Speech-to-Reverberation Modulation Energy Ratio: https://ieeexplore.ieee.org/abstract/document/5547575
-.. _SRMRToolbox: https://github.com/MuSAELab/SRMRToolbox
 .. _SRMRpy: https://github.com/jfsantos/SRMRpy
 .. _Permutation invariant training: https://arxiv.org/abs/1607.00325
 .. _ranking ref1: https://link.springer.com/chapter/10.1007/978-0-387-09823-4_34

--- a/src/torchmetrics/audio/srmr.py
+++ b/src/torchmetrics/audio/srmr.py
@@ -39,7 +39,7 @@ class SpeechReverberationModulationEnergyRatio(Metric):
 
     SRMR is a non-intrusive metric for speech quality and intelligibility based on
     a modulation spectral representation of the speech signal.
-    This code is translated from `SRMRToolbox`_ and `SRMRpy`_.
+    This code is translated from SRMRToolbox and `SRMRpy`_.
 
     As input to ``forward`` and ``update`` the metric accepts the following input
 
@@ -56,9 +56,9 @@ class SpeechReverberationModulationEnergyRatio(Metric):
 
     .. attention::
         This implementation is experimental, and might not be consistent with the matlab
-        implementation `SRMRToolbox`_, especially the fast implementation.
-        The slow versions, a) fast=False, norm=False, max_cf=128, b) fast=False, norm=True, max_cf=30, have
-        a relatively small inconsistency.
+        implementation SRMRToolbox, especially the fast implementation.
+        The slow versions, a) ``fast=False, norm=False, max_cf=128``, b) ``fast=False, norm=True, max_cf=30``,
+        have a relatively small inconsistency.
 
     Args:
         fs: the sampling rate

--- a/src/torchmetrics/functional/audio/srmr.py
+++ b/src/torchmetrics/functional/audio/srmr.py
@@ -187,7 +187,7 @@ def speech_reverberation_modulation_energy_ratio(
 
     SRMR is a non-intrusive metric for speech quality and intelligibility based on
     a modulation spectral representation of the speech signal.
-    This code is translated from `SRMRToolbox`_ and `SRMRpy`_.
+    This code is translated from SRMRToolbox and `SRMRpy`_.
 
     Args:
         preds: shape ``(..., time)``
@@ -209,9 +209,9 @@ def speech_reverberation_modulation_energy_ratio(
 
     .. attention::
         This implementation is experimental, and might not be consistent with the matlab
-        implementation `SRMRToolbox`_, especially the fast implementation.
-        The slow versions, a) fast=False, norm=False, max_cf=128, b) fast=False, norm=True, max_cf=30, have
-        a relatively small inconsistency.
+        implementation SRMRToolbox, especially the fast implementation.
+        The slow versions, a) ``fast=False, norm=False, max_cf=128``, b) ``fast=False, norm=True, max_cf=30``,
+        have a relatively small inconsistency.
 
     Returns:
         Scalar tensor with srmr value with shape ``(...)``


### PR DESCRIPTION
## What does this PR do?

seems `SRMRToolbox` was removed from GitHub

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--2997.org.readthedocs.build/en/2997/

<!-- readthedocs-preview torchmetrics end -->