### PR TITLE
Enhance Support Adding a `MetricCollection` to Another `MetricCollection` in `add_metrics` Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Enhance Support Adding a `MetricCollection` to Another `MetricCollection` in `add_metrics` Function ([#3032](https://github.com/Lightning-AI/torchmetrics/pull/3032))
 
 
 ### Deprecated

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -430,7 +430,9 @@ class MetricCollection(ModuleDict):
             m.persistent(mode)
 
     def add_metrics(
-        self, metrics: Union[Metric, Sequence[Metric], dict[str, Metric], MetricCollection], *additional_metrics: Metric
+        self,
+        metrics: Union[Metric, Sequence[Metric], dict[str, Metric], "MetricCollection"],
+        *additional_metrics: Metric,
     ) -> None:
         """Add new metrics to Metric Collection."""
         if isinstance(metrics, Metric):

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -430,7 +430,7 @@ class MetricCollection(ModuleDict):
             m.persistent(mode)
 
     def add_metrics(
-        self, metrics: Union[Metric, Sequence[Metric], dict[str, Metric]], *additional_metrics: Metric
+        self, metrics: Union[Metric, Sequence[Metric], dict[str, Metric], MetricCollection], *additional_metrics: Metric
     ) -> None:
         """Add new metrics to Metric Collection."""
         if isinstance(metrics, Metric):
@@ -490,6 +490,12 @@ class MetricCollection(ModuleDict):
                         v.prefix = metric.prefix
                         v._from_collection = True
                         self[k] = v
+        elif isinstance(metrics, MetricCollection):
+            # New case: handle MetricCollection input
+            for name, metric in metrics.items(keep_base=True):
+                if name in self:
+                    raise ValueError(f"Metric with name '{name}' already exists in the collection.")
+                self[name] = metric
         else:
             raise ValueError(
                 "Unknown input to MetricCollection. Expected, `Metric`, `MetricCollection` or `dict`/`sequence` of the"

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -198,7 +198,12 @@ class MetricCollection(ModuleDict):
 
     def __init__(
         self,
-        metrics: Union[Metric, Sequence[Metric], dict[str, Metric]],
+        metrics: Union[
+            Metric,
+            "MetricCollection",
+            Sequence[Union[Metric, "MetricCollection"]],
+            dict[str, Union[Metric, "MetricCollection"]],
+        ],
         *additional_metrics: Metric,
         prefix: Optional[str] = None,
         postfix: Optional[str] = None,
@@ -431,7 +436,12 @@ class MetricCollection(ModuleDict):
 
     def add_metrics(
         self,
-        metrics: Union[Metric, Sequence[Metric], dict[str, Metric], "MetricCollection"],
+        metrics: Union[
+            Metric,
+            "MetricCollection",
+            Sequence[Union[Metric, "MetricCollection"]],
+            dict[str, Union[Metric, "MetricCollection"]],
+        ],
         *additional_metrics: Metric,
     ) -> None:
         """Add new metrics to Metric Collection."""

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -493,8 +493,7 @@ class MetricCollection(ModuleDict):
                         v._from_collection = True
                         self[k] = v
         elif isinstance(metrics, MetricCollection):
-            # New case: handle MetricCollection input
-            for name, metric in metrics.items(keep_base=True):
+            for name, metric in metrics.items(keep_base=False):
                 if name in self:
                     raise ValueError(f"Metric with name '{name}' already exists in the collection.")
                 self[name] = metric

--- a/src/torchmetrics/wrappers/feature_share.py
+++ b/src/torchmetrics/wrappers/feature_share.py
@@ -88,7 +88,7 @@ class FeatureShare(MetricCollection):
         max_cache_size: Optional[int] = None,
     ) -> None:
         # disable compute groups because the feature sharing is more custom
-        super().__init__(metrics=metrics, compute_groups=False)
+        super().__init__(metrics=metrics, compute_groups=False)  # type: ignore
 
         if max_cache_size is None:
             max_cache_size = len(self)

--- a/tests/unittests/bases/test_collections.py
+++ b/tests/unittests/bases/test_collections.py
@@ -269,26 +269,24 @@ def test_collection_add_metrics():
     collection.add_metrics({"m1_": DummyMetricSum()})
     collection.add_metrics(m2)
     collection1 = MetricCollection([DummyMetricSum()])
-    collection2 = MetricCollection({"diff_metric": DummyMetricDiff(),"custom_sum": DummyMetricSum()})
+    collection2 = MetricCollection({"diff_metric": DummyMetricDiff(), "custom_sum": DummyMetricSum()})
     collection1.add_metrics(collection2)
-    
 
     collection.update(5)
     results = collection.compute()
     assert results["DummyMetricSum"] == results["m1_"]
     assert results["m1_"] == 5
     assert results["DummyMetricDiff"] == -5
-    
+
     collection1.update(5)
     results = collection1.compute()
-    assert results["DummyMetricSum"] == 5  
-    assert results["diff_metric"] == -5    
-    assert results["custom_sum"] == 5   
-    
+    assert results["DummyMetricSum"] == 5
+    assert results["diff_metric"] == -5
+    assert results["custom_sum"] == 5
+
     duplicate_collection = MetricCollection([DummyMetricSum()])
     with pytest.raises(ValueError, match="Metric with name 'DummyMetricSum' already exists in the collection."):
         collection1.add_metrics(duplicate_collection)
-
 
 
 def test_collection_check_arg():

--- a/tests/unittests/bases/test_collections.py
+++ b/tests/unittests/bases/test_collections.py
@@ -268,12 +268,27 @@ def test_collection_add_metrics():
     collection = MetricCollection([m1])
     collection.add_metrics({"m1_": DummyMetricSum()})
     collection.add_metrics(m2)
+    collection1 = MetricCollection([DummyMetricSum()])
+    collection2 = MetricCollection({"diff_metric": DummyMetricDiff(),"custom_sum": DummyMetricSum()})
+    collection1.add_metrics(collection2)
+    
 
     collection.update(5)
     results = collection.compute()
     assert results["DummyMetricSum"] == results["m1_"]
     assert results["m1_"] == 5
     assert results["DummyMetricDiff"] == -5
+    
+    collection1.update(5)
+    results = collection1.compute()
+    assert results["DummyMetricSum"] == 5  
+    assert results["diff_metric"] == -5    
+    assert results["custom_sum"] == 5   
+    
+    duplicate_collection = MetricCollection([DummyMetricSum()])
+    with pytest.raises(ValueError, match="Metric with name 'DummyMetricSum' already exists in the collection."):
+        collection1.add_metrics(duplicate_collection)
+
 
 
 def test_collection_check_arg():


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/3030

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3032.org.readthedocs.build/en/3032/

<!-- readthedocs-preview torchmetrics end -->