### PR TITLE
dice score add warnings

### DIFF
--- a/src/torchmetrics/functional/segmentation/dice.py
+++ b/src/torchmetrics/functional/segmentation/dice.py
@@ -18,6 +18,7 @@ from torch import Tensor
 from typing_extensions import Literal
 
 from torchmetrics.functional.segmentation.utils import _ignore_background
+from torchmetrics.utilities import rank_zero_warn
 from torchmetrics.utilities.checks import _check_same_shape
 from torchmetrics.utilities.compute import _safe_divide
 
@@ -154,6 +155,13 @@ def dice_score(
                 [0.1978, 0.2804, 0.1714, 0.1915, 0.2783]])
 
     """
+    if average == "micro":
+        rank_zero_warn(
+            "dice_score metric currently defaults to `average=micro`, but will change to"
+            "`average=macro` in the next release."
+            " If you've explicitly set this parameter, you can ignore this warning.",
+            UserWarning,
+        )
     _dice_score_validate_args(num_classes, include_background, average, input_format)
     numerator, denominator, support = _dice_score_update(preds, target, num_classes, include_background, input_format)
     return _dice_score_compute(numerator, denominator, average, support=support)

--- a/src/torchmetrics/functional/segmentation/dice.py
+++ b/src/torchmetrics/functional/segmentation/dice.py
@@ -160,7 +160,7 @@ def dice_score(
             "dice_score metric currently defaults to `average=micro`, but will change to"
             "`average=macro` in the v1.9 release."
             " If you've explicitly set this parameter, you can ignore this warning.",
-            DeprecationWarning,
+            UserWarning,
         )
     _dice_score_validate_args(num_classes, include_background, average, input_format)
     numerator, denominator, support = _dice_score_update(preds, target, num_classes, include_background, input_format)

--- a/src/torchmetrics/functional/segmentation/dice.py
+++ b/src/torchmetrics/functional/segmentation/dice.py
@@ -158,9 +158,9 @@ def dice_score(
     if average == "micro":
         rank_zero_warn(
             "dice_score metric currently defaults to `average=micro`, but will change to"
-            "`average=macro` in the next release."
+            "`average=macro` in the v1.9 release."
             " If you've explicitly set this parameter, you can ignore this warning.",
-            UserWarning,
+            DeprecationWarning,
         )
     _dice_score_validate_args(num_classes, include_background, average, input_format)
     numerator, denominator, support = _dice_score_update(preds, target, num_classes, include_background, input_format)

--- a/src/torchmetrics/segmentation/dice.py
+++ b/src/torchmetrics/segmentation/dice.py
@@ -23,6 +23,7 @@ from torchmetrics.functional.segmentation.dice import (
     _dice_score_validate_args,
 )
 from torchmetrics.metric import Metric
+from torchmetrics.utilities import rank_zero_warn
 from torchmetrics.utilities.data import dim_zero_cat
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
@@ -116,6 +117,13 @@ class DiceScore(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
+        if average == "micro":
+            rank_zero_warn(
+                "DiceScore metric currently defaults to `average=micro`, but will change to"
+                "`average=macro` in the next release."
+                " If you've explicitly set this parameter, you can ignore this warning.",
+                UserWarning,
+            )
         _dice_score_validate_args(num_classes, include_background, average, input_format, zero_division)
         self.num_classes = num_classes
         self.include_background = include_background

--- a/src/torchmetrics/segmentation/dice.py
+++ b/src/torchmetrics/segmentation/dice.py
@@ -122,7 +122,7 @@ class DiceScore(Metric):
                 "DiceScore metric currently defaults to `average=micro`, but will change to"
                 "`average=macro` in the v1.9 release."
                 " If you've explicitly set this parameter, you can ignore this warning.",
-                DeprecationWarning,
+                UserWarning,
             )
         _dice_score_validate_args(num_classes, include_background, average, input_format, zero_division)
         self.num_classes = num_classes

--- a/src/torchmetrics/segmentation/dice.py
+++ b/src/torchmetrics/segmentation/dice.py
@@ -120,9 +120,9 @@ class DiceScore(Metric):
         if average == "micro":
             rank_zero_warn(
                 "DiceScore metric currently defaults to `average=micro`, but will change to"
-                "`average=macro` in the next release."
+                "`average=macro` in the v1.9 release."
                 " If you've explicitly set this parameter, you can ignore this warning.",
-                UserWarning,
+                DeprecationWarning,
             )
         _dice_score_validate_args(num_classes, include_background, average, input_format, zero_division)
         self.num_classes = num_classes


### PR DESCRIPTION
## What does this PR do?

Fixes #3031 for this release and then will be changed to `average=macro` for the next release

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?

<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3041.org.readthedocs.build/en/3041/

<!-- readthedocs-preview torchmetrics end -->