### PR TITLE
Support single `str` input for functional interface of `bert_score`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 - Added support for `reduction="none"` to `LearnedPerceptualImagePatchSimilarity` ([#3053](https://github.com/Lightning-AI/torchmetrics/pull/3053))
+- Added support single `str` input for functional interface of `bert_score` ([#3056](https://github.com/Lightning-AI/torchmetrics/pull/3056))
 
 ### Changed
 

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -289,9 +289,9 @@ def bert_score(
     This implementation follows the original implementation from `BERT_score`_.
 
     Args:
-        preds: Either a single predicted sentence (str), an iterable of predicted sentences,
+        preds: Either a single predicted sentence (`str`), an iterable of predicted sentences,
                or a ``Dict[input_ids, attention_mask]``.
-        target: Either a single target sentence (str), an iterable of target sentences,
+        target: Either a single target sentence (`str`), an iterable of target sentences,
                 or a ``Dict[input_ids, attention_mask]``.
         model_name_or_path: A name or a model path used to load ``transformers`` pretrained model.
         num_layers: A layer of representation to use.

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -351,18 +351,17 @@ def bert_score(
         {'f1': tensor([1.0000, 0.9961]), 'precision': tensor([1.0000, 0.9961]), 'recall': tensor([1.0000, 0.9961])}
 
     """
-
     if not isinstance(preds, (list, dict)):  # dict for BERTScore class compute call
         preds = list(preds)
     if not isinstance(target, (list, dict)):  # dict for BERTScore class compute call
         target = list(target)
-        
+
     if len(preds) != len(target):
         raise ValueError(
             "Expected number of predicted and reference sententes to be the same, but got"
             f"{len(preds)} and {len(target)}"
         )
-    
+
     if not isinstance(idf, bool):
         raise ValueError(f"Expected argument `idf` to be a boolean, but got {idf}.")
 

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -353,6 +353,10 @@ def bert_score(
         {'f1': tensor([1.0000, 0.9961]), 'precision': tensor([1.0000, 0.9961]), 'recall': tensor([1.0000, 0.9961])}
 
     """
+    if isinstance(preds, str):
+        preds = [preds]
+    if isinstance(target, str):
+        target = [target]
     if not isinstance(preds, (list, dict)):  # dict for BERTScore class compute call
         preds = list(preds)
     if not isinstance(target, (list, dict)):  # dict for BERTScore class compute call

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -289,8 +289,10 @@ def bert_score(
     This implementation follows the original implementation from `BERT_score`_.
 
     Args:
-        preds: Either a single predicted sentence (`str`), an iterable of predicted sentences, or a ``Dict[input_ids, attention_mask]``.
-        target: Either a single target sentence (`str`), an iterable of target sentences, or a ``Dict[input_ids, attention_mask]``.
+        preds: Either a single predicted sentence (str), an iterable of predicted sentences,
+               or a ``Dict[input_ids, attention_mask]``.
+        target: Either a single target sentence (str), an iterable of target sentences,
+                or a ``Dict[input_ids, attention_mask]``.
         model_name_or_path: A name or a model path used to load ``transformers`` pretrained model.
         num_layers: A layer of representation to use.
         all_layers:

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -289,8 +289,8 @@ def bert_score(
     This implementation follows the original implementation from `BERT_score`_.
 
     Args:
-        preds: Either an iterable of predicted sentences or a ``Dict[input_ids, attention_mask]``.
-        target: Either an iterable of target sentences or a  ``Dict[input_ids, attention_mask]``.
+        preds: Either a single predicted sentence (`str`), an iterable of predicted sentences, or a ``Dict[input_ids, attention_mask]``.
+        target: Either a single target sentence (`str`), an iterable of target sentences, or a ``Dict[input_ids, attention_mask]``.
         model_name_or_path: A name or a model path used to load ``transformers`` pretrained model.
         num_layers: A layer of representation to use.
         all_layers:
@@ -351,15 +351,18 @@ def bert_score(
         {'f1': tensor([1.0000, 0.9961]), 'precision': tensor([1.0000, 0.9961]), 'recall': tensor([1.0000, 0.9961])}
 
     """
+
+    if not isinstance(preds, (list, dict)):  # dict for BERTScore class compute call
+        preds = list(preds)
+    if not isinstance(target, (list, dict)):  # dict for BERTScore class compute call
+        target = list(target)
+        
     if len(preds) != len(target):
         raise ValueError(
             "Expected number of predicted and reference sententes to be the same, but got"
             f"{len(preds)} and {len(target)}"
         )
-    if not isinstance(preds, (str, list, dict)):  # dict for BERTScore class compute call
-        preds = list(preds)
-    if not isinstance(target, (str, list, dict)):  # dict for BERTScore class compute call
-        target = list(target)
+    
     if not isinstance(idf, bool):
         raise ValueError(f"Expected argument `idf` to be a boolean, but got {idf}.")
 

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -209,11 +209,11 @@ class BERTScore(Metric):
             preds = list(preds)
         if not isinstance(target, list):
             target = list(target)
-            
+
         if len(preds) != len(target):
             raise ValueError(
-            "Expected number of predicted and reference sententes to be the same, but got"
-            f"{len(preds)} and {len(target)}"
+                "Expected number of predicted and reference sententes to be the same, but got"
+                f"{len(preds)} and {len(target)}"
             )
 
         preds_dict, _ = _preprocess_text(

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -205,6 +205,10 @@ class BERTScore(Metric):
         It is necessary to store sentences in a tokenized form to ensure the DDP mode working.
 
         """
+        if isinstance(preds, str):
+            preds = [preds]
+        if isinstance(target, str):
+            target = [target]
         if not isinstance(preds, list):
             preds = list(preds)
         if not isinstance(target, list):

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -72,8 +72,8 @@ class BERTScore(Metric):
       corresponding values
 
     Args:
-        preds: An iterable of predicted sentences.
-        target: An iterable of target sentences.
+        preds: Either a single predicted sentence (`str`) or an iterable of predicted sentences.
+        target: Either a single target sentence (`str`) or an iterable of target sentences.
         model_type: A name or a model path used to load ``transformers`` pretrained model.
         num_layers: A layer of representation to use.
         all_layers:

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -209,6 +209,12 @@ class BERTScore(Metric):
             preds = list(preds)
         if not isinstance(target, list):
             target = list(target)
+            
+        if len(preds) != len(target):
+            raise ValueError(
+            "Expected number of predicted and reference sententes to be the same, but got"
+            f"{len(preds)} and {len(target)}"
+            )
 
         preds_dict, _ = _preprocess_text(
             preds,

--- a/tests/unittests/text/test_bertscore.py
+++ b/tests/unittests/text/test_bertscore.py
@@ -206,10 +206,11 @@ def test_bertscore_truncation(truncation: bool):
         with pytest.raises(RuntimeError, match="The expanded size of the tensor.*must match.*"):
             bert_score(pred, gt)
 
+
 @skip_on_connection_issues()
 @pytest.mark.skipif(not _TRANSFORMERS_GREATER_EQUAL_4_4, reason="test requires transformers>4.4")
 def test_bertscore_single_str_input():
-    """Test if BERTScore works with single string preds and target"""
+    """Test if BERTScore works with single string preds and target."""
     preds = "hello there"
     target = "hello there"
 

--- a/tests/unittests/text/test_bertscore.py
+++ b/tests/unittests/text/test_bertscore.py
@@ -205,3 +205,23 @@ def test_bertscore_truncation(truncation: bool):
     else:
         with pytest.raises(RuntimeError, match="The expanded size of the tensor.*must match.*"):
             bert_score(pred, gt)
+
+@skip_on_connection_issues()
+@pytest.mark.skipif(not _TRANSFORMERS_GREATER_EQUAL_4_4, reason="test requires transformers>4.4")
+def test_bertscore_single_str_input():
+    """Test if BERTScore works with single string preds and target"""
+    preds = "hello there"
+    target = "hello there"
+
+    metric = BERTScore()
+    score_class = metric(preds, target)
+
+    assert score_class["f1"].item() == pytest.approx(1.0, abs=1e-4)
+    assert score_class["precision"].item() == pytest.approx(1.0, abs=1e-4)
+    assert score_class["recall"].item() == pytest.approx(1.0, abs=1e-4)
+
+    score_functional = bert_score(preds, target)
+
+    assert score_functional["f1"].item() == pytest.approx(1.0, abs=1e-4)
+    assert score_functional["precision"].item() == pytest.approx(1.0, abs=1e-4)
+    assert score_functional["recall"].item() == pytest.approx(1.0, abs=1e-4)


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/3055

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3056.org.readthedocs.build/en/3056/

<!-- readthedocs-preview torchmetrics end -->