### PR TITLE
Fix: MIFID incorrectly converts inputs to `byte` dtype with custom encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix: MIFID incorrectly converts inputs to `byte` dtype with custom encoders ([#3064](https://github.com/Lightning-AI/torchmetrics/pull/3064))
 
 ---
 

--- a/src/torchmetrics/image/mifid.py
+++ b/src/torchmetrics/image/mifid.py
@@ -164,9 +164,9 @@ class MemorizationInformedFrechetInceptionDistance(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        
+
         self.used_custom_model = False
-        
+
         if isinstance(feature, int):
             if not _TORCH_FIDELITY_AVAILABLE:
                 raise ModuleNotFoundError(

--- a/src/torchmetrics/image/mifid.py
+++ b/src/torchmetrics/image/mifid.py
@@ -115,6 +115,9 @@ class MemorizationInformedFrechetInceptionDistance(Metric):
         reset_real_features: Whether to also reset the real features. Since in many cases the real dataset does not
             change, the features can be cached them to avoid recomputing them which is costly. Set this to ``False`` if
             your dataset does not change.
+        normalize: Whether to normalize the input images. If ``True`` the input is expected to be in the range [0, 1]
+            and converted to ``uint8``. If ``False`` the input is expected to already be in the range [0, 255] and of
+            type ``uint8``. If a custom feature extractor is used, this argument is ignored.
         cosine_distance_eps: Epsilon value for the cosine distance. If the cosine distance is larger than this value
             it is set to 1 and thus ignored in the MIFID calculation.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.

--- a/src/torchmetrics/image/mifid.py
+++ b/src/torchmetrics/image/mifid.py
@@ -205,7 +205,7 @@ class MemorizationInformedFrechetInceptionDistance(Metric):
 
     def update(self, imgs: Tensor, real: bool) -> None:
         """Update the state with extracted features."""
-        imgs = (imgs * 255).byte() if self.normalize and (not self.used_custom_model) else imgs
+        imgs = (imgs * 255).byte() if self.normalize and not self.used_custom_model else imgs
         features = self.inception(imgs)
         self.orig_dtype = features.dtype
         features = features.double()

--- a/src/torchmetrics/image/mifid.py
+++ b/src/torchmetrics/image/mifid.py
@@ -201,7 +201,7 @@ class MemorizationInformedFrechetInceptionDistance(Metric):
 
     def update(self, imgs: Tensor, real: bool) -> None:
         """Update the state with extracted features."""
-        imgs = (imgs * 255).byte() if self.normalize else imgs
+        imgs = (imgs * 255).byte() if self.normalize and (not self.used_custom_model) else imgs
         features = self.inception(imgs)
         self.orig_dtype = features.dtype
         features = features.double()

--- a/src/torchmetrics/image/mifid.py
+++ b/src/torchmetrics/image/mifid.py
@@ -164,6 +164,9 @@ class MemorizationInformedFrechetInceptionDistance(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
+        
+        self.used_custom_model = False
+        
         if isinstance(feature, int):
             if not _TORCH_FIDELITY_AVAILABLE:
                 raise ModuleNotFoundError(
@@ -180,6 +183,7 @@ class MemorizationInformedFrechetInceptionDistance(Metric):
 
         elif isinstance(feature, Module):
             self.inception = feature
+            self.used_custom_model = True
         else:
             raise TypeError("Got unknown input to argument `feature`")
 

--- a/tests/unittests/image/test_mifid.py
+++ b/tests/unittests/image/test_mifid.py
@@ -18,11 +18,12 @@ import numpy as np
 import pytest
 import torch
 from scipy.linalg import sqrtm
-from torch.nn import Module
+
 from torchmetrics.image.mifid import MemorizationInformedFrechetInceptionDistance, NoTrainInceptionV3
 from torchmetrics.utilities.imports import _TORCH_FIDELITY_AVAILABLE
 from unittests import _reference_cachier
 from unittests._helpers import seed_all
+
 
 @_reference_cachier
 def _reference_mifid(preds, target, cosine_distance_eps: float = 0.1):
@@ -201,28 +202,26 @@ def test_normalize_arg(normalize):
     with context():
         metric.update(img, real=True)
 
+
 def test_mifid_custom_encoder_with_normalize():
     """Test that MIFID works with custom encoder and normalize=True without converting inputs to byte."""
     # Create a custom encoder that expects float inputs
-    custom_encoder = torch.nn.Sequential(
-        torch.nn.Flatten(),
-        torch.nn.Linear(32 * 32, 512)
-    )
-    
+    custom_encoder = torch.nn.Sequential(torch.nn.Flatten(), torch.nn.Linear(32 * 32, 512))
+
     # Create test input as float tensor
     input_tensor = torch.randn(2, 1, 32, 32)
-    
+
     # Initialize MIFID with custom encoder and normalize=True
     mifid = MemorizationInformedFrechetInceptionDistance(feature=custom_encoder, normalize=True)
-    
+
     # This should not raise an error if the fix is working properly
     mifid.update(input_tensor, real=True)
     mifid.update(input_tensor, real=False)
-    
+
     # Verify that features have been stored
     assert len(mifid.real_features) == 1
     assert len(mifid.fake_features) == 1
-    
+
     # Compute the metric to ensure the full pipeline works
     result = mifid.compute()
     assert isinstance(result, torch.Tensor)

--- a/tests/unittests/image/test_mifid.py
+++ b/tests/unittests/image/test_mifid.py
@@ -211,17 +211,14 @@ def test_mifid_custom_encoder_with_normalize():
     # Create test input as float tensor
     input_tensor = torch.randn(2, 1, 32, 32)
 
-    # Initialize MIFID with custom encoder and normalize=True
     mifid = MemorizationInformedFrechetInceptionDistance(feature=custom_encoder, normalize=True)
 
     # This should not raise an error if the fix is working properly
     mifid.update(input_tensor, real=True)
     mifid.update(input_tensor, real=False)
 
-    # Verify that features have been stored
     assert len(mifid.real_features) == 1
     assert len(mifid.fake_features) == 1
 
-    # Compute the metric to ensure the full pipeline works
     result = mifid.compute()
     assert isinstance(result, torch.Tensor)

--- a/tests/unittests/image/test_mifid.py
+++ b/tests/unittests/image/test_mifid.py
@@ -18,12 +18,11 @@ import numpy as np
 import pytest
 import torch
 from scipy.linalg import sqrtm
-
+from torch.nn import Module
 from torchmetrics.image.mifid import MemorizationInformedFrechetInceptionDistance, NoTrainInceptionV3
 from torchmetrics.utilities.imports import _TORCH_FIDELITY_AVAILABLE
 from unittests import _reference_cachier
 from unittests._helpers import seed_all
-
 
 @_reference_cachier
 def _reference_mifid(preds, target, cosine_distance_eps: float = 0.1):
@@ -201,3 +200,29 @@ def test_normalize_arg(normalize):
 
     with context():
         metric.update(img, real=True)
+
+def test_mifid_custom_encoder_with_normalize():
+    """Test that MIFID works with custom encoder and normalize=True without converting inputs to byte."""
+    # Create a custom encoder that expects float inputs
+    custom_encoder = torch.nn.Sequential(
+        torch.nn.Flatten(),
+        torch.nn.Linear(32 * 32, 512)
+    )
+    
+    # Create test input as float tensor
+    input_tensor = torch.randn(2, 1, 32, 32)
+    
+    # Initialize MIFID with custom encoder and normalize=True
+    mifid = MemorizationInformedFrechetInceptionDistance(feature=custom_encoder, normalize=True)
+    
+    # This should not raise an error if the fix is working properly
+    mifid.update(input_tensor, real=True)
+    mifid.update(input_tensor, real=False)
+    
+    # Verify that features have been stored
+    assert len(mifid.real_features) == 1
+    assert len(mifid.fake_features) == 1
+    
+    # Compute the metric to ensure the full pipeline works
+    result = mifid.compute()
+    assert isinstance(result, torch.Tensor)


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/3062

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3064.org.readthedocs.build/en/3064/

<!-- readthedocs-preview torchmetrics end -->