### PR TITLE
ci: bump dead ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -45,7 +45,7 @@ jobs:
           - "2.5.0"
         include:
           # cover additional python and PT combinations
-          - { os: "ubuntu-20.04", python-version: "3.9", pytorch-version: "2.0.1", requires: "oldest" }
+          - { os: "ubuntu-22.04", python-version: "3.9", pytorch-version: "2.0.1", requires: "oldest" }
           - { os: "ubuntu-22.04", python-version: "3.11", pytorch-version: "2.4.1" }
           - { os: "ubuntu-22.04", python-version: "3.12", pytorch-version: "2.5.0" }
           # standard mac machine, not the M1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-Devcontainer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -5,7 +5,7 @@ on: [issues] # pull_request
 
 jobs:
   greeting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/first-interaction@v1
         with:

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -14,7 +14,7 @@ on: # Trigger the workflow on push or pull request, but only for the master bran
 jobs:
   # based on https://github.com/pypa/gh-action-pypi-publish
   build-package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do?

ubuntu 20.04 was removed from all runners so we need to bump to 22.04

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3065.org.readthedocs.build/en/3065/

<!-- readthedocs-preview torchmetrics end -->