### PR TITLE
fix `_multiclass_stat_scores_update` in classification

### DIFF
--- a/src/torchmetrics/functional/classification/accuracy.py
+++ b/src/torchmetrics/functional/classification/accuracy.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 from typing import Optional
 
+import torch
 from torch import Tensor
 from typing_extensions import Literal
-import torch
 
 from torchmetrics.functional.classification.stat_scores import (
     _binary_stat_scores_arg_validation,
@@ -76,14 +76,14 @@ def _accuracy_reduce(
     """
     if average == "binary":
         return _safe_divide(tp + tn, tp + tn + fp + fn)
-    
+
     # Calculate base score
     score = _safe_divide(tp + tn, tp + tn + fp + fn) if multilabel else _safe_divide(tp, tp + fn)
-    
+
     # For top_k > 1, always use the adjust_weights function which properly handles top_k
     if top_k > 1:
         return _adjust_weights_safe_divide(score, average, multilabel, tp, fp, fn, top_k)
-    
+
     # For top_k=1, continue with the original logic
     if average == "micro":
         # Apply sum before returning for micro averaging
@@ -94,7 +94,7 @@ def _accuracy_reduce(
             tn_sum = tn.sum(dim=0 if multidim_average == "global" else 1)
             return _safe_divide(tp_sum + tn_sum, tp_sum + tn_sum + fp_sum + fn_sum)
         return _safe_divide(tp_sum, tp_sum + fn_sum)
-    
+
     # For other averaging methods, apply the adjustment
     return _adjust_weights_safe_divide(score, average, multilabel, tp, fp, fn, top_k)
 
@@ -275,13 +275,13 @@ def multiclass_accuracy(
     if validate_args:
         _multiclass_stat_scores_arg_validation(num_classes, top_k, average, multidim_average, ignore_index)
         _multiclass_stat_scores_tensor_validation(preds, target, num_classes, multidim_average, ignore_index)
-    
+
     if top_k > 1 and average == "micro" and preds.ndim == target.ndim + 1:
         if preds.ndim == target.ndim:
             num_classes = num_classes or (target.max().int().item() + 1)
             preds = torch.nn.functional.one_hot(preds, num_classes).to(preds.dtype)
             preds = preds.transpose(1, -1)
-        
+
         if multidim_average == "global":
             flat_shape = preds.shape[:2] + (-1,)
             flat_preds = preds.reshape(flat_shape)
@@ -290,15 +290,15 @@ def multiclass_accuracy(
             flat_shape = preds.shape[:2] + (-1,)
             flat_preds = preds.reshape(flat_shape)
             flat_target = target.reshape(target.shape[0], -1)
-        
+
         batch_size = flat_target.shape[0]
         num_samples = flat_target.shape[1]
-        
+
         if ignore_index is not None:
             valid_mask = flat_target != ignore_index
         else:
             valid_mask = torch.ones_like(flat_target, dtype=torch.bool)
-            
+
         correct_list = []
         for i in range(batch_size):
             for j in range(num_samples):
@@ -308,12 +308,11 @@ def multiclass_accuracy(
                 sample_target = flat_target[i, j]
                 _, top_indices = torch.topk(sample_preds, min(top_k, sample_preds.size(0)), dim=0)
                 correct_list.append(torch.any(top_indices == sample_target).int())
-        
+
         if correct_list:
             return torch.stack(correct_list).float().mean()
-        else:
-            return torch.tensor(0.0, device=preds.device)
-    
+        return torch.tensor(0.0, device=preds.device)
+
     preds, target = _multiclass_stat_scores_format(preds, target, top_k)
     tp, fp, tn, fn = _multiclass_stat_scores_update(
         preds, target, num_classes or 1, top_k, average, multidim_average, ignore_index

--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -389,7 +389,7 @@ def _multiclass_stat_scores_update(
     or outside we have do use different augmentation strategies when one hot encoding.
 
     Notes:
-        - For top_k > 1, we always use the one-hot encoding path regardless of the averaging method 
+        - For top_k > 1, we always use the one-hot encoding path regardless of the averaging method
         to ensure top-k logic is properly applied in all cases, including micro averaging.
 
     """


### PR DESCRIPTION
## What does this PR do?

Fixes #3068

This PR fixes an issue with the multiclass accuracy calculation when using `top_k > 1` with `average="micro"`. The bug caused incorrect accuracy calculations in scenarios where predictions were provided as logits/probabilities and the correct class needed to be identified among the top-k predictions.

The fix ensures that:
1. The one-hot encoding path is always used when `top_k > 1`, regardless of the averaging method
2. A special case is added in `multiclass_accuracy` to properly handle top-k with micro averaging
3. Top-k selection is consistently applied across all evaluation scenarios

The PR includes test cases that demonstrate the issue and verify the fix works correctly. These tests show the alignment between manual calculations of top-k accuracy and the results from the metric implementation.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3078.org.readthedocs.build/en/3078/

<!-- readthedocs-preview torchmetrics end -->

fixes #3068 
