### PR TITLE
Docs: fix wrong default description of `full_state_update` 

### DIFF
--- a/docs/source/pages/implement.rst
+++ b/docs/source/pages/implement.rst
@@ -209,7 +209,7 @@ metric state for accumulating over multiple batches. The ``forward()`` method ac
 to ``update``, ``compute`` and ``reset``. Depending on the class property ``full_state_update``, ``forward``
 can behave in two ways:
 
-1. If ``full_state_update`` is ``True`` it indicates that the metric during ``update`` requires access to the full
+1. If ``full_state_update`` is ``True`` or  ``full_state_update`` is ``None`` (default) it indicates that the metric during ``update`` requires access to the full
    metric state and we therefore need to do two calls to ``update`` to secure that the metric is calculated correctly
 
    1. Calls ``update()`` to update the global metric state (for accumulation over multiple batches)
@@ -219,7 +219,7 @@ can behave in two ways:
    5. Calls ``compute()`` to calculate metric for current batch.
    6. Restores the global state.
 
-2. If ``full_state_update`` is ``False`` (default) the metric state of one batch is completely independent of the state
+2. If ``full_state_update`` is ``False`` the metric state of one batch is completely independent of the state
    of other batches, which means that we only need to call ``update`` once.
 
    1. Caches the global state.

--- a/docs/source/pages/implement.rst
+++ b/docs/source/pages/implement.rst
@@ -118,7 +118,7 @@ A few important things to note for this example:
 
 * When working with list states, The ``update(...)`` method should append the batch states to the list.
 
-* In the the ``compute`` method the list states behave a bit differently dependeding on whether you are running in
+* In the ``compute`` method the list states behave a bit differently dependeding on whether you are running in
   distributed mode or not. In non-distributed mode the list states will be a list of tensors, while in distributed mode
   the list have already been concatenated into a single tensor. For this reason, we recommend always using the
   ``dim_zero_cat`` helper function which will standardize the list states to be a single concatenated tensor regardless


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/3079

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3080.org.readthedocs.build/en/3080/

<!-- readthedocs-preview torchmetrics end -->