### PR TITLE
enhance: avoid unnecessary fallback in _bincount on CUDA with determi… #1

### DIFF
--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -178,10 +178,12 @@ def _squeeze_if_scalar(data: Any) -> Any:
 def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
     """Implement custom bincount.
 
-    PyTorch currently does not support ``torch.bincount`` when running in deterministic mode on GPU or when running
-    MPS devices or when running on XLA device. This implementation therefore falls back to using a combination of
-    `torch.arange` and `torch.eq` in these scenarios. A small performance hit can expected and higher memory consumption
-    as `[batch_size, mincount]` tensor needs to be initialized compared to native ``torch.bincount``.
+    As of PyTorch v2.1, ``torch.bincount`` is supported in deterministic mode on CUDA 
+    when no ``weights`` are provided and gradients are not required. However, this 
+    operation remains unsupported or limited on some backends, such as MPS and XLA. 
+    In those cases, we fall back to a manual implementation using `torch.arange` and `torch.eq`. 
+    A small performance hit can expected and higher memory consumption as `[batch_size, mincount]` 
+    tensor needs to be initialized compared to native ``torch.bincount``.
 
     Args:
         x: tensor to count
@@ -199,7 +201,7 @@ def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
     if minlength is None:
         minlength = len(torch.unique(x))
 
-    if torch.are_deterministic_algorithms_enabled() or _XLA_AVAILABLE or x.is_mps:
+    if (torch.__version__ < "2.1" and torch.are_deterministic_algorithms_enabled()) or _XLA_AVAILABLE or x.is_mps:
         mesh = torch.arange(minlength, device=x.device).repeat(len(x), 1)
         return torch.eq(x.reshape(-1, 1), mesh).sum(dim=0)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #3086

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.  
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃