### PR TITLE
Fix: Discard zero and negative predictions in retrieval metrics

### DIFF
--- a/src/torchmetrics/functional/retrieval/average_precision.py
+++ b/src/torchmetrics/functional/retrieval/average_precision.py
@@ -50,11 +50,17 @@ def retrieval_average_precision(preds: Tensor, target: Tensor, top_k: Optional[i
 
     top_k = top_k or preds.shape[-1]
     if not isinstance(top_k, int) and top_k <= 0:
-        raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
-
-    target = target[preds.topk(min(top_k, preds.shape[-1]), sorted=True, dim=-1)[1]]
-    if not target.sum():
+        raise ValueError(
+            f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
+    top_k_values, top_k_indices = preds.topk(top_k, sorted=True, dim=-1)
+    mask = top_k_values > 0
+    if not mask.sum():
         return tensor(0.0, device=preds.device)
 
-    positions = torch.arange(1, len(target) + 1, device=target.device, dtype=torch.float32)[target > 0]
+    target_filtered = target[top_k_indices][mask]
+    if not target_filtered.sum():
+        return tensor(0.0, device=preds.device)
+
+    positions = torch.arange(
+        1, len(target_filtered) + 1, device=target_filtered.device, dtype=torch.float32)[target_filtered > 0]
     return torch.div((torch.arange(len(positions), device=positions.device, dtype=torch.float32) + 1), positions).mean()

--- a/src/torchmetrics/functional/retrieval/precision.py
+++ b/src/torchmetrics/functional/retrieval/precision.py
@@ -65,7 +65,7 @@ def retrieval_precision(preds: Tensor, target: Tensor, top_k: Optional[int] = No
         return tensor(0.0, device=preds.device)
 
     top_k_values, top_k_indices = preds.topk(
-        top_k, dim=-1)
+        min(top_k, preds.shape[-1]), dim=-1)
     mask = top_k_values > 0
     relevant = target[top_k_indices][mask].sum().float()
     return relevant / top_k

--- a/src/torchmetrics/functional/retrieval/precision.py
+++ b/src/torchmetrics/functional/retrieval/precision.py
@@ -64,5 +64,8 @@ def retrieval_precision(preds: Tensor, target: Tensor, top_k: Optional[int] = No
     if not target.sum():
         return tensor(0.0, device=preds.device)
 
-    relevant = target[preds.topk(min(top_k, preds.shape[-1]), dim=-1)[1]].sum().float()
+    top_k_values, top_k_indices = preds.topk(
+        min(top_k, preds.shape[-1]), dim=-1)
+    mask = top_k_values > 0
+    relevant = target[top_k_indices][mask].sum().float()
     return relevant / top_k

--- a/src/torchmetrics/functional/retrieval/precision.py
+++ b/src/torchmetrics/functional/retrieval/precision.py
@@ -65,7 +65,7 @@ def retrieval_precision(preds: Tensor, target: Tensor, top_k: Optional[int] = No
         return tensor(0.0, device=preds.device)
 
     top_k_values, top_k_indices = preds.topk(
-        min(top_k, preds.shape[-1]), dim=-1)
+        top_k, dim=-1)
     mask = top_k_values > 0
     relevant = target[top_k_indices][mask].sum().float()
     return relevant / top_k

--- a/src/torchmetrics/functional/retrieval/recall.py
+++ b/src/torchmetrics/functional/retrieval/recall.py
@@ -48,8 +48,6 @@ def retrieval_recall(preds: Tensor, target: Tensor, top_k: Optional[int] = None)
         tensor(0.5000)
 
     """
-    preds, target = _check_retrieval_functional_inputs(preds, target)
-
     if top_k is None:
         top_k = preds.shape[-1]
 
@@ -61,10 +59,11 @@ def retrieval_recall(preds: Tensor, target: Tensor, top_k: Optional[int] = None)
 
     top_k_values, top_k_indices = preds.topk(
         min(top_k, preds.shape[-1]), sorted=True, dim=-1)
+
     mask = top_k_values > 0
 
     if not mask.sum():
         return tensor(0.0, device=preds.device)
 
     relevant_retrieved = target[top_k_indices][mask].sum().float()
-    return relevant / target.sum()
+    return relevant_retrieved / target.sum()

--- a/src/torchmetrics/functional/retrieval/recall.py
+++ b/src/torchmetrics/functional/retrieval/recall.py
@@ -59,5 +59,12 @@ def retrieval_recall(preds: Tensor, target: Tensor, top_k: Optional[int] = None)
     if not target.sum():
         return tensor(0.0, device=preds.device)
 
-    relevant = target[torch.argsort(preds, dim=-1, descending=True)][:top_k].sum().float()
+    top_k_values, top_k_indices = preds.topk(
+        min(top_k, preds.shape[-1]), sorted=True, dim=-1)
+    mask = top_k_values > 0
+
+    if not mask.sum():
+        return tensor(0.0, device=preds.device)
+
+    relevant_retrieved = target[top_k_indices][mask].sum().float()
     return relevant / target.sum()

--- a/src/torchmetrics/functional/retrieval/recall.py
+++ b/src/torchmetrics/functional/retrieval/recall.py
@@ -48,6 +48,9 @@ def retrieval_recall(preds: Tensor, target: Tensor, top_k: Optional[int] = None)
         tensor(0.5000)
 
     """
+    
+    preds, target = _check_retrieval_functional_inputs(preds, target)
+
     if top_k is None:
         top_k = preds.shape[-1]
 


### PR DESCRIPTION
## What does this PR do?

Retrieval metrics are currently considering all input predictions as positive predictions regardless of their probability values. This was leading to unexpected numbers.

For instance, an input prediction tensor ([0.0,0.0,0.0]) is equivalent to no prediction and should always return 0 (for all retrieval metrics). A simple way to fix this problem is to use a mask of positive predictions to calculate the metrics.

This PR fixes this bug for the following metrics:
- Precision
- Mean Average Precision
- Recall
- MRR (reciprocal_rank)
- NDCG
