### PR TITLE
drop deprecated dependabot reviewers

### DIFF
--- a/.azure/gpu-unittests.yml
+++ b/.azure/gpu-unittests.yml
@@ -35,7 +35,7 @@ jobs:
         #  docker-image: "ubuntu22.04-cuda12.6.3-py3.11-torch2.8"
         #  torch-ver: "2.8"
     # how long to run the job before automatically cancelling
-    timeoutInMinutes: "180"
+    timeoutInMinutes: "240"
     # how much time to give 'run always even if cancelled tasks' before stopping them
     cancelTimeoutInMinutes: "2"
 
@@ -191,7 +191,7 @@ jobs:
         workingDirectory: "tests/"
         # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
         condition: and(succeeded(), ne(variables['TEST_DIRS'], ''))
-        timeoutInMinutes: "95"
+        timeoutInMinutes: "120"
         displayName: "UnitTesting common"
 
       - bash: |
@@ -203,7 +203,7 @@ jobs:
         workingDirectory: "tests/"
         # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
         condition: and(succeeded(), ne(variables['TEST_DIRS'], ''))
-        timeoutInMinutes: "95"
+        timeoutInMinutes: "120"
         displayName: "UnitTesting DDP"
 
       - bash: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
       separator: "-"
     # Allow up to 5 open pull requests for pip dependencies
     open-pull-requests-limit: 5
-    reviewers:
-      - "Lightning-AI/teams/core-metrics"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -35,5 +33,3 @@ updates:
       separator: "-"
     # Allow up to 5 open pull requests for GitHub Actions
     open-pull-requests-limit: 5
-    reviewers:
-      - "Lightning-AI/teams/core-metrics"


### PR DESCRIPTION
## What does this PR do?

see deprecation warning https://github.com/Lightning-AI/torchmetrics/pull/3107#issuecomment-2910764258

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3109.org.readthedocs.build/en/3109/

<!-- readthedocs-preview torchmetrics end -->