### PR TITLE
req: pin `pycocotools` version constraint to allow <=2.0.8

### DIFF
--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -2,4 +2,4 @@
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
 torchvision >=0.15.1, <0.23.0
-pycocotools >2.0.0, <2.1.0
+pycocotools >2.0.0, <=2.0.8


### PR DESCRIPTION
## What does this PR do?

hotfix for:
```
FAILED unittests/detection/test_map.py::test_tm_to_coco[pycocotools-bbox] - KeyError: 'info'
FAILED unittests/detection/test_map.py::test_tm_to_coco[pycocotools-segm] - KeyError: 'info'
```

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3115.org.readthedocs.build/en/3115/

<!-- readthedocs-preview torchmetrics end -->