### PR TITLE
Fix: Ensure `WrapperMetric` Resets `wrapped_metric` State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: disable non-blocking on MPS ([#3101](https://github.com/Lightning-AI/torchmetrics/pull/3101))
 
 
+- Fixed: Ensure `WrapperMetric` Resets `wrapped_metric` State ([#3123](https://github.com/Lightning-AI/torchmetrics/pull/3123))
+
+
 ---
 
 ## [1.7.1] - 2025-04-06

--- a/src/torchmetrics/wrappers/transformations.py
+++ b/src/torchmetrics/wrappers/transformations.py
@@ -75,6 +75,11 @@ class MetricInputTransformer(WrapperMetric):
         args = self._wrap_transform(*args)
         return self.wrapped_metric.forward(*args, **kwargs)
 
+    def reset(self) -> None:
+        """Wrap the reset call of the underlying metric."""
+        self.wrapped_metric.reset()
+        super().reset()
+
 
 class LambdaInputTransformer(MetricInputTransformer):
     """Wrapper class for transforming a metrics' inputs given a user-defined lambda function.

--- a/tests/unittests/wrappers/test_transformations.py
+++ b/tests/unittests/wrappers/test_transformations.py
@@ -139,10 +139,12 @@ class TestLambdaInputTransformer:
 
     def test_reset_forwards_to_wrapped_metric(self):
         """Test that reset() on LambdaInputTransformer also resets the wrapped metric.
+
         Issue: https://github.com/Lightning-AI/torchmetrics/issues/3122.
-        
+
         """
         import torch
+
         from torchmetrics import MeanSquaredError
         from torchmetrics.wrappers import LambdaInputTransformer
 

--- a/tests/unittests/wrappers/test_transformations.py
+++ b/tests/unittests/wrappers/test_transformations.py
@@ -14,8 +14,10 @@
 from typing import ClassVar
 
 import pytest
+import torch
 from torch import Tensor
-
+        
+from torchmetrics import MeanSquaredError
 from torchmetrics.aggregation import MeanMetric
 from torchmetrics.classification import BinaryAccuracy
 from torchmetrics.retrieval import RetrievalMAP
@@ -143,11 +145,6 @@ class TestLambdaInputTransformer:
         Issue: https://github.com/Lightning-AI/torchmetrics/issues/3122.
 
         """
-        import torch
-
-        from torchmetrics import MeanSquaredError
-        from torchmetrics.wrappers import LambdaInputTransformer
-
         preds_1 = torch.tensor([1.0, 2.0, 3.0])
         preds_2 = 2 * preds_1
         target = torch.tensor([2.0, 4.0, 6.0])

--- a/tests/unittests/wrappers/test_transformations.py
+++ b/tests/unittests/wrappers/test_transformations.py
@@ -16,7 +16,7 @@ from typing import ClassVar
 import pytest
 import torch
 from torch import Tensor
-        
+
 from torchmetrics import MeanSquaredError
 from torchmetrics.aggregation import MeanMetric
 from torchmetrics.classification import BinaryAccuracy

--- a/tests/unittests/wrappers/test_transformations.py
+++ b/tests/unittests/wrappers/test_transformations.py
@@ -137,6 +137,41 @@ class TestLambdaInputTransformer:
         with pytest.raises(TypeError, match=r"Expected `transform_target` to be of type .*"):
             LambdaInputTransformer(BinaryAccuracy(), transform_target=[])
 
+    def test_reset_forwards_to_wrapped_metric(self):
+        """Test that reset() on LambdaInputTransformer also resets the wrapped metric.
+        Issue: https://github.com/Lightning-AI/torchmetrics/issues/3122.
+        
+        """
+        import torch
+        from torchmetrics import MeanSquaredError
+        from torchmetrics.wrappers import LambdaInputTransformer
+
+        preds_1 = torch.tensor([1.0, 2.0, 3.0])
+        preds_2 = 2 * preds_1
+        target = torch.tensor([2.0, 4.0, 6.0])
+
+        mse_metric = MeanSquaredError()
+        lambda_metric = LambdaInputTransformer(
+            wrapped_metric=MeanSquaredError(),
+            transform_pred=lambda p: p,
+            transform_target=lambda t: t,
+        )
+
+        mse_metric.update(preds_1, target)
+        lambda_metric.update(preds_1, target)
+        assert mse_metric.compute().item() == lambda_metric.compute().item()
+        assert mse_metric.update_count == 1
+        assert lambda_metric.wrapped_metric.update_count == 1
+
+        mse_metric.reset()
+        lambda_metric.reset()
+
+        mse_metric.update(preds_2, target)
+        lambda_metric.update(preds_2, target)
+        assert mse_metric.compute().item() == lambda_metric.compute().item()
+        assert mse_metric.update_count == 1
+        assert lambda_metric.wrapped_metric.update_count == 1
+
 
 class TestBinaryTargetTransformer:
     """Test class for BinaryTargetTransformer."""


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/3122

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3123.org.readthedocs.build/en/3123/

<!-- readthedocs-preview torchmetrics end -->