### PR TITLE
fix: ignore zero and negative predictions in retrieval metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- Fixed: Ignore zero and negative predictions in retrieval metrics ([#3160](https://github.com/Lightning-AI/torchmetrics/pull/3160))
+-
 
 
 ### Removed
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed: Ignore zero and negative predictions in retrieval metrics ([#3160](https://github.com/Lightning-AI/torchmetrics/pull/3160))
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
--
+- Fixed: Ignore zero and negative predictions in retrieval metrics ([#3160](https://github.com/Lightning-AI/torchmetrics/pull/3160))
 
 
 ### Removed

--- a/src/torchmetrics/functional/retrieval/average_precision.py
+++ b/src/torchmetrics/functional/retrieval/average_precision.py
@@ -52,7 +52,9 @@ def retrieval_average_precision(preds: Tensor, target: Tensor, top_k: Optional[i
     if not isinstance(top_k, int) and top_k <= 0:
         raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
 
+    target = torch.where(preds > 0, target, torch.zeros_like(target))
     target = target[preds.topk(min(top_k, preds.shape[-1]), sorted=True, dim=-1)[1]]
+
     if not target.sum():
         return tensor(0.0, device=preds.device)
 

--- a/src/torchmetrics/functional/retrieval/precision.py
+++ b/src/torchmetrics/functional/retrieval/precision.py
@@ -66,6 +66,6 @@ def retrieval_precision(preds: Tensor, target: Tensor, top_k: Optional[int] = No
         return tensor(0.0, device=preds.device)
 
     target_filtered = torch.where(preds > 0, target, torch.zeros_like(target))
-    relevant = target_filtered[torch.argsort(preds, dim=-1, descending=True)][:top_k].sum().float()
+    relevant = target_filtered[preds.topk(min(top_k, preds.shape[-1]), dim=-1)[1]].sum().float()
 
     return relevant / top_k

--- a/src/torchmetrics/functional/retrieval/precision.py
+++ b/src/torchmetrics/functional/retrieval/precision.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from typing import Optional
 
+import torch
 from torch import Tensor, tensor
 
 from torchmetrics.utilities.checks import _check_retrieval_functional_inputs
@@ -64,5 +65,7 @@ def retrieval_precision(preds: Tensor, target: Tensor, top_k: Optional[int] = No
     if not target.sum():
         return tensor(0.0, device=preds.device)
 
-    relevant = target[preds.topk(min(top_k, preds.shape[-1]), dim=-1)[1]].sum().float()
+    target_filtered = torch.where(preds > 0, target, torch.zeros_like(target))
+    relevant = target_filtered[torch.argsort(preds, dim=-1, descending=True)][:top_k].sum().float()
+
     return relevant / top_k

--- a/src/torchmetrics/functional/retrieval/recall.py
+++ b/src/torchmetrics/functional/retrieval/recall.py
@@ -59,5 +59,7 @@ def retrieval_recall(preds: Tensor, target: Tensor, top_k: Optional[int] = None)
     if not target.sum():
         return tensor(0.0, device=preds.device)
 
-    relevant = target[torch.argsort(preds, dim=-1, descending=True)][:top_k].sum().float()
+    target_filtered = torch.where(preds > 0, target, torch.zeros_like(target))
+    relevant = target_filtered[torch.argsort(preds, dim=-1, descending=True)][:top_k].sum().float()
+
     return relevant / target.sum()

--- a/src/torchmetrics/functional/retrieval/reciprocal_rank.py
+++ b/src/torchmetrics/functional/retrieval/reciprocal_rank.py
@@ -52,7 +52,9 @@ def retrieval_reciprocal_rank(preds: Tensor, target: Tensor, top_k: Optional[int
     if not isinstance(top_k, int) and top_k <= 0:
         raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
 
+    target = torch.where(preds > 0, target, torch.zeros_like(target))
     target = target[preds.topk(min(top_k, preds.shape[-1]), sorted=True, dim=-1)[1]]
+
     if not target.sum():
         return tensor(0.0, device=preds.device)
 

--- a/tests/unittests/retrieval/test_map.py
+++ b/tests/unittests/retrieval/test_map.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pytest
+import torch
 from sklearn.metrics import average_precision_score as sk_average_precision_score
 from torch import Tensor
 from typing_extensions import Literal
@@ -178,3 +179,12 @@ class TestMAP(RetrievalMetricTester):
             exception_type=ValueError,
             kwargs_update=metric_args,
         )
+
+    def test_map_all_zero_predictions_returns_zero(self):
+        """Test that MAP returns 0 when all predictions are zero and there are positive targets."""
+        preds = torch.tensor([0.0, 0.0, 0.0])
+        target = torch.tensor([1, 0, 1])
+        indexes = torch.tensor([0, 0, 0])
+        metric = RetrievalMAP()
+        result = metric(preds, target, indexes=indexes)
+        assert result == 0.0, f"Expected MAP to be 0.0, got {result}"

--- a/tests/unittests/retrieval/test_mrr.py
+++ b/tests/unittests/retrieval/test_mrr.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pytest
+import torch
 from sklearn.metrics import label_ranking_average_precision_score
 from torch import Tensor
 from typing_extensions import Literal
@@ -197,3 +198,12 @@ class TestMRR(RetrievalMetricTester):
             exception_type=ValueError,
             kwargs_update=metric_args,
         )
+
+    def test_mrr_all_zero_predictions_returns_zero(self):
+        """Test that MRR returns 0 when all predictions are zero and there are positive targets."""
+        preds = torch.tensor([0.0, 0.0, 0.0])
+        target = torch.tensor([1, 0, 1])
+        indexes = torch.tensor([0, 0, 0])
+        metric = RetrievalMRR()
+        result = metric(preds, target, indexes=indexes)
+        assert result == 0.0, f"Expected MRR to be 0.0, got {result}"

--- a/tests/unittests/retrieval/test_precision.py
+++ b/tests/unittests/retrieval/test_precision.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pytest
+import torch
 from torch import Tensor
 from typing_extensions import Literal
 
@@ -211,3 +212,12 @@ class TestPrecision(RetrievalMetricTester):
             exception_type=ValueError,
             kwargs_update=metric_args,
         )
+
+    def test_precision_all_zero_predictions_returns_zero(self):
+        """Test that Precision returns 0 when all predictions are zero and there are positive targets."""
+        preds = torch.tensor([0.0, 0.0, 0.0])
+        target = torch.tensor([1, 0, 1])
+        indexes = torch.tensor([0, 0, 0])
+        metric = RetrievalPrecision()
+        result = metric(preds, target, indexes=indexes)
+        assert result == 0.0, f"Expected Precision to be 0.0, got {result}"

--- a/tests/unittests/retrieval/test_recall.py
+++ b/tests/unittests/retrieval/test_recall.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pytest
+import torch
 from torch import Tensor
 from typing_extensions import Literal
 
@@ -193,3 +194,12 @@ class TestRecall(RetrievalMetricTester):
             exception_type=ValueError,
             kwargs_update=metric_args,
         )
+
+    def test_recall_all_zero_predictions_returns_zero(self):
+        """Test that Recall returns 0 when all predictions are zero and there are positive targets."""
+        preds = torch.tensor([0.0, 0.0, 0.0])
+        target = torch.tensor([1, 0, 1])
+        indexes = torch.tensor([0, 0, 0])
+        metric = RetrievalRecall()
+        result = metric(preds, target, indexes=indexes)
+        assert result == 0.0, f"Expected Recall to be 0.0, got {result}"


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/pull/3104

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3160.org.readthedocs.build/en/3160/

<!-- readthedocs-preview torchmetrics end -->