### PR TITLE
Fix: SSIM `dist_reduce_fx` when `reduction=None` for distributed training

### DIFF
--- a/src/torchmetrics/image/ssim.py
+++ b/src/torchmetrics/image/ssim.py
@@ -109,7 +109,7 @@ class StructuralSimilarityIndexMeasure(Metric):
         if reduction in ("elementwise_mean", "sum"):
             self.add_state("similarity", default=torch.tensor(0.0), dist_reduce_fx="sum")
         else:
-            self.add_state("similarity", default=[], dist_reduce_fx="cat")
+            self.add_state("similarity", default=[], dist_reduce_fx="none")
 
         self.add_state("total", default=torch.tensor(0.0), dist_reduce_fx="sum")
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/torchmetrics/issues/3159
<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
