### PR TITLE
Add `"mixed"` input format to segmentation metrics

### DIFF
--- a/src/torchmetrics/functional/segmentation/generalized_dice.py
+++ b/src/torchmetrics/functional/segmentation/generalized_dice.py
@@ -17,7 +17,7 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.segmentation.utils import _ignore_background
+from torchmetrics.functional.segmentation.utils import _check_mixed_shape, _ignore_background
 from torchmetrics.utilities.checks import _check_same_shape
 from torchmetrics.utilities.compute import _safe_divide
 
@@ -27,7 +27,7 @@ def _generalized_dice_validate_args(
     include_background: bool,
     per_class: bool,
     weight_type: Literal["square", "simple", "linear"],
-    input_format: Literal["one-hot", "index"],
+    input_format: Literal["one-hot", "index", "mixed"],
 ) -> None:
     """Validate the arguments of the metric."""
     if not isinstance(num_classes, int) or num_classes <= 0:
@@ -40,8 +40,10 @@ def _generalized_dice_validate_args(
         raise ValueError(
             f"Expected argument `weight_type` to be one of 'square', 'simple', 'linear', but got {weight_type}."
         )
-    if input_format not in ["one-hot", "index"]:
-        raise ValueError(f"Expected argument `input_format` to be one of 'one-hot', 'index', but got {input_format}.")
+    if input_format not in ["one-hot", "index", "mixed"]:
+        raise ValueError(
+            f"Expected argument `input_format` to be one of 'one-hot', 'index', 'mixed', but got {input_format}."
+        )
 
 
 def _generalized_dice_update(
@@ -50,14 +52,22 @@ def _generalized_dice_update(
     num_classes: int,
     include_background: bool,
     weight_type: Literal["square", "simple", "linear"] = "square",
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> Tuple[Tensor, Tensor]:
     """Update the state with the current prediction and target."""
-    _check_same_shape(preds, target)
+    if input_format == "mixed":
+        _check_mixed_shape(preds, target)
+    else:
+        _check_same_shape(preds, target)
 
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
         target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+    elif input_format == "mixed":
+        if preds.dim() == (target.dim() + 1):
+            target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+        elif (preds.dim() + 1) == target.dim():
+            preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
 
     if preds.ndim < 3:
         raise ValueError(f"Expected both `preds` and `target` to have at least 3 dimensions, but got {preds.ndim}.")
@@ -109,7 +119,7 @@ def generalized_dice_score(
     include_background: bool = True,
     per_class: bool = False,
     weight_type: Literal["square", "simple", "linear"] = "square",
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> Tensor:
     """Compute the Generalized Dice Score for semantic segmentation.
 
@@ -120,8 +130,8 @@ def generalized_dice_score(
         include_background: Whether to include the background class in the computation
         per_class: Whether to compute the score for each class separately, else average over all classes
         weight_type: Type of weight factor to apply to the classes. One of ``"square"``, ``"simple"``, or ``"linear"``
-        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
-            or ``"index"`` for index tensors
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors,
+            ``"index"`` for index tensors or ``"mixed"`` for one one-hot encoded and one index tensor
 
     Returns:
         The Generalized Dice Score

--- a/src/torchmetrics/functional/segmentation/hausdorff_distance.py
+++ b/src/torchmetrics/functional/segmentation/hausdorff_distance.py
@@ -18,6 +18,7 @@ import torch
 from torch import Tensor
 
 from torchmetrics.functional.segmentation.utils import (
+    _check_mixed_shape,
     _ignore_background,
     edge_surface_distance,
 )
@@ -30,7 +31,7 @@ def _hausdorff_distance_validate_args(
     distance_metric: Literal["euclidean", "chessboard", "taxicab"] = "euclidean",
     spacing: Optional[Union[Tensor, list[float]]] = None,
     directed: bool = False,
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> None:
     """Validate the arguments of `hausdorff_distance` function."""
     if num_classes <= 0:
@@ -45,8 +46,10 @@ def _hausdorff_distance_validate_args(
         raise ValueError(f"Arg `spacing` must be a list or tensor, but got {type(spacing)}.")
     if not isinstance(directed, bool):
         raise ValueError(f"Expected argument `directed` must be a boolean, but got {directed}.")
-    if input_format not in ["one-hot", "index"]:
-        raise ValueError(f"Expected argument `input_format` to be one of 'one-hot', 'index', but got {input_format}.")
+    if input_format not in ["one-hot", "index", "mixed"]:
+        raise ValueError(
+            f"Expected argument `input_format` to be one of 'one-hot', 'index', 'mixed', but got {input_format}."
+        )
 
 
 def hausdorff_distance(
@@ -57,7 +60,7 @@ def hausdorff_distance(
     distance_metric: Literal["euclidean", "chessboard", "taxicab"] = "euclidean",
     spacing: Optional[Union[Tensor, list[float]]] = None,
     directed: bool = False,
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> Tensor:
     """Calculate `Hausdorff Distance`_ for semantic segmentation.
 
@@ -70,8 +73,8 @@ def hausdorff_distance(
           `"chessboard"` or `"taxicab"`
         spacing: spacing between pixels along each spatial dimension. If not provided the spacing is assumed to be 1
         directed: whether to calculate directed or undirected Hausdorff distance
-        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
-          or ``"index"`` for index tensors
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors,
+            ``"index"`` for index tensors or ``"mixed"`` for one one-hot encoded and one index tensor
 
     Returns:
         Hausdorff Distance for each class and batch element
@@ -89,11 +92,19 @@ def hausdorff_distance(
 
     """
     _hausdorff_distance_validate_args(num_classes, include_background, distance_metric, spacing, directed, input_format)
-    _check_same_shape(preds, target)
+    if input_format == "mixed":
+        _check_mixed_shape(preds, target)
+    else:
+        _check_same_shape(preds, target)
 
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
         target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+    elif input_format == "mixed":
+        if preds.dim() == (target.dim() + 1):
+            target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+        elif (preds.dim() + 1) == target.dim():
+            preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
 
     if not include_background:
         preds, target = _ignore_background(preds, target)

--- a/src/torchmetrics/functional/segmentation/mean_iou.py
+++ b/src/torchmetrics/functional/segmentation/mean_iou.py
@@ -18,7 +18,7 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.segmentation.utils import _ignore_background
+from torchmetrics.functional.segmentation.utils import _check_mixed_shape, _ignore_background
 from torchmetrics.utilities.checks import _check_same_shape
 from torchmetrics.utilities.compute import _safe_divide
 
@@ -26,7 +26,7 @@ from torchmetrics.utilities.compute import _safe_divide
 def _mean_iou_reshape_args(
     preds: Tensor,
     targets: Tensor,
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> Tuple[Tensor, Tensor]:
     """Reshape tensors to 3D if needed."""
     if input_format == "one-hot":
@@ -48,10 +48,10 @@ def _mean_iou_validate_args(
     num_classes: Optional[int],
     include_background: bool,
     per_class: bool,
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> None:
     """Validate the arguments of the metric."""
-    if input_format == "index" and num_classes is None:
+    if input_format in ["index", "mixed"] and num_classes is None:
         raise ValueError("Argument `num_classes` must be provided when `input_format='index'`.")
     if num_classes is not None and num_classes <= 0:
         raise ValueError(
@@ -61,8 +61,10 @@ def _mean_iou_validate_args(
         raise ValueError(f"Expected argument `include_background` must be a boolean, but got {include_background}.")
     if not isinstance(per_class, bool):
         raise ValueError(f"Expected argument `per_class` must be a boolean, but got {per_class}.")
-    if input_format not in ["one-hot", "index"]:
-        raise ValueError(f"Expected argument `input_format` to be one of 'one-hot', 'index', but got {input_format}.")
+    if input_format not in ["one-hot", "index", "mixed"]:
+        raise ValueError(
+            f"Expected argument `input_format` to be one of 'one-hot', 'index', 'mixed', but got {input_format}."
+        )
 
 
 def _mean_iou_update(
@@ -70,11 +72,14 @@ def _mean_iou_update(
     target: Tensor,
     num_classes: Optional[int] = None,
     include_background: bool = False,
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> tuple[Tensor, Tensor]:
     """Update the intersection and union counts for the mean IoU computation."""
     preds, target = _mean_iou_reshape_args(preds, target, input_format)
-    _check_same_shape(preds, target)
+    if input_format == "mixed":
+        _check_mixed_shape(preds, target)
+    else:
+        _check_same_shape(preds, target)
 
     if input_format == "index":
         if num_classes is None:
@@ -88,6 +93,11 @@ def _mean_iou_update(
             raise IndexError(f"Cannot determine `num_classes` from `preds` tensor: {preds}.") from err
         if num_classes == 0:
             raise ValueError(f"Expected argument `num_classes` to be a positive integer, but got {num_classes}.")
+    elif input_format == "mixed":
+        if preds.dim() == (target.dim() + 1):
+            target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+        elif (preds.dim() + 1) == target.dim():
+            preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
 
     if not include_background:
         preds, target = _ignore_background(preds, target)
@@ -115,7 +125,7 @@ def mean_iou(
     num_classes: Optional[int] = None,
     include_background: bool = True,
     per_class: bool = False,
-    input_format: Literal["one-hot", "index"] = "one-hot",
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> Tensor:
     """Calculates the mean Intersection over Union (mIoU) for semantic segmentation.
 
@@ -127,8 +137,8 @@ def mean_iou(
         num_classes: Number of classes (required when input_format="index", optional when input_format="one-hot")
         include_background: Whether to include the background class in the computation
         per_class: Whether to compute the IoU for each class separately, else average over all classes
-        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
-            or ``"index"`` for index tensors
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors,
+            ``"index"`` for index tensors or ``"mixed"`` for one one-hot encoded and one index tensor
 
     Returns:
         The mean IoU score

--- a/src/torchmetrics/functional/segmentation/utils.py
+++ b/src/torchmetrics/functional/segmentation/utils.py
@@ -31,6 +31,24 @@ def _ignore_background(preds: Tensor, target: Tensor) -> tuple[Tensor, Tensor]:
     return preds, target
 
 
+def _check_mixed_shape(preds: Tensor, target: Tensor) -> None:
+    """Check that predictions and target have the same shape, else raise error."""
+    if preds.dim() == (target.dim() + 1):
+        if preds.shape[0] != target.shape[0] or preds.shape[2:] != target.shape[1:]:
+            raise RuntimeError(
+                f"Predictions and targets are expected to have the same shape, got {preds.shape} and {target.shape}."
+            )
+    elif (preds.dim() + 1) == target.dim():
+        if preds.shape[0] != target.shape[0] or preds.shape[1:] != target.shape[2:]:
+            raise RuntimeError(
+                f"Predictions and targets are expected to have the same shape, got {preds.shape} and {target.shape}."
+            )
+    else:
+        raise RuntimeError(
+            f"Predictions and targets are expected to have the same shape, got {preds.shape} and {target.shape}."
+        )
+
+
 def check_if_binarized(x: Tensor) -> None:
     """Check if tensor is binarized.
 

--- a/src/torchmetrics/segmentation/dice.py
+++ b/src/torchmetrics/segmentation/dice.py
@@ -70,8 +70,8 @@ class DiceScore(Metric):
         aggregation_level: The level at which to aggregate the dice score. Options are ``"samplewise"`` or ``"global"``.
             For ``"samplewise"`` the dice score is computed for each sample and then averaged. For ``"global"`` the dice
             score is computed globally over all samples.
-        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
-            or ``"index"`` for index tensors.
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors,
+            ``"index"`` for index tensors or ``"mixed"`` for one one-hot encoded and one index tensor
         zero_division: The value to return when there is a division by zero. Options are 1.0, 0.0, "warn" or "nan".
             Setting it to "warn" behaves like 0.0 but will also create a warning.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
@@ -84,7 +84,7 @@ class DiceScore(Metric):
         ValueError:
             If ``average`` is not one of ``"micro"``, ``"macro"``, ``"weighted"``, ``"none"`` or ``None``
         ValueError:
-            If ``input_format`` is not one of ``"one-hot"`` or ``"index"``
+            If ``input_format`` is not one of ``"one-hot"``, ``"index"`` or ``"mixed"``
 
     Example:
         >>> from torch import randint
@@ -116,7 +116,7 @@ class DiceScore(Metric):
         include_background: bool = True,
         average: Optional[Literal["micro", "macro", "weighted", "none"]] = "micro",
         aggregation_level: Optional[Literal["samplewise", "global"]] = "samplewise",
-        input_format: Literal["one-hot", "index"] = "one-hot",
+        input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/torchmetrics/segmentation/generalized_dice.py
+++ b/src/torchmetrics/segmentation/generalized_dice.py
@@ -73,8 +73,8 @@ class GeneralizedDiceScore(Metric):
         per_class: Whether to compute the metric for each class separately.
         weight_type: The type of weight to apply to each class. Can be one of ``"square"``, ``"simple"``, or
             ``"linear"``.
-        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
-            or ``"index"`` for index tensors
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors,
+            ``"index"`` for index tensors or ``"mixed"`` for one one-hot encoded and one index tensor
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
     Raises:
@@ -87,7 +87,7 @@ class GeneralizedDiceScore(Metric):
         ValueError:
             If ``weight_type`` is not one of ``"square"``, ``"simple"``, or ``"linear"``
         ValueError:
-            If ``input_format`` is not one of ``"one-hot"`` or ``"index"``
+            If ``input_format`` is not one of ``"one-hot"``, ``"index"`` or ``"mixed"``
 
     Example:
         >>> from torch import randint
@@ -120,7 +120,7 @@ class GeneralizedDiceScore(Metric):
         include_background: bool = True,
         per_class: bool = False,
         weight_type: Literal["square", "simple", "linear"] = "square",
-        input_format: Literal["one-hot", "index"] = "one-hot",
+        input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/torchmetrics/segmentation/hausdorff_distance.py
+++ b/src/torchmetrics/segmentation/hausdorff_distance.py
@@ -61,8 +61,8 @@ class HausdorffDistance(Metric):
           `"chessboard"` or `"taxicab"`
         spacing: spacing between pixels along each spatial dimension. If not provided the spacing is assumed to be 1
         directed: whether to calculate directed or undirected Hausdorff distance
-        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
-          or ``"index"`` for index tensors
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors,
+            ``"index"`` for index tensors or ``"mixed"`` for one one-hot encoded and one index tensor
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
     Example:
@@ -91,7 +91,7 @@ class HausdorffDistance(Metric):
         distance_metric: Literal["euclidean", "chessboard", "taxicab"] = "euclidean",
         spacing: Optional[Union[Tensor, list[float]]] = None,
         directed: bool = False,
-        input_format: Literal["one-hot", "index"] = "one-hot",
+        input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/torchmetrics/segmentation/mean_iou.py
+++ b/src/torchmetrics/segmentation/mean_iou.py
@@ -53,26 +53,26 @@ class MeanIoU(Metric):
           set to ``False``, the output will be a scalar tensor.
 
     Args:
-        num_classes: The number of classes in the segmentation problem. Required when input_format="index",
+        num_classes: The number of classes in the segmentation problem. Required when input_format="index" or "mixed",
             optional when input_format="one-hot".
         include_background: Whether to include the background class in the computation
         per_class: Whether to compute the IoU for each class separately. If set to ``False``, the metric will
             compute the mean IoU over all classes.
-        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors
-            or ``"index"`` for index tensors
+        input_format: What kind of input the function receives. Choose between ``"one-hot"`` for one-hot encoded tensors,
+            ``"index"`` for index tensors or ``"mixed"`` for one one-hot encoded and one index tensor
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
     Raises:
         ValueError:
             If ``num_classes`` is not ``None`` or a positive integer
         ValueError:
-            If ``num_classes`` is not provided when ``input_format="index"``
+            If ``num_classes`` is not provided when ``input_format`` is ``"index"`` or ``"mixed"``
         ValueError:
             If ``include_background`` is not a boolean
         ValueError:
             If ``per_class`` is not a boolean
         ValueError:
-            If ``input_format`` is not one of ``"one-hot"`` or ``"index"``
+            If ``input_format`` is not one of ``"one-hot"``, ``"index"`` or ``"mixed"``
 
     Example:
         >>> import torch
@@ -108,7 +108,7 @@ class MeanIoU(Metric):
         num_classes: Optional[int] = None,
         include_background: bool = True,
         per_class: bool = False,
-        input_format: Literal["one-hot", "index"] = "one-hot",
+        input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/tests/unittests/segmentation/inputs.py
+++ b/tests/unittests/segmentation/inputs.py
@@ -38,3 +38,13 @@ _inputs4 = _Input(
     preds=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32)),
     target=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32)),
 )
+
+_inputs5 = _Input(
+    preds=to_one_hot(torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32))),
+    target=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32)),
+)
+
+_inputs6 = _Input(
+    preds=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32)),
+    target=to_one_hot(torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32))),
+)

--- a/tests/unittests/segmentation/test_dice.py
+++ b/tests/unittests/segmentation/test_dice.py
@@ -23,7 +23,7 @@ from torchmetrics.segmentation.dice import DiceScore
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
-from unittests.segmentation.inputs import _inputs1, _inputs2, _inputs3, _inputs4
+from unittests.segmentation.inputs import _inputs1, _inputs2, _inputs3, _inputs4, _inputs5, _inputs6
 
 seed_all(42)
 
@@ -40,6 +40,10 @@ def _reference_dice_score(
     """Calculate reference metric for dice score."""
     if input_format == "one-hot":
         preds = preds.argmax(dim=1)
+        target = target.argmax(dim=1)
+    elif input_format == "mixed" and preds.dim() == (target.dim() + 1):
+        preds = preds.argmax(dim=1)
+    elif input_format == "mixed" and (preds.dim() + 1) == target.dim():
         target = target.argmax(dim=1)
     preds = preds.cpu().numpy()
     target = target.cpu().numpy()
@@ -63,6 +67,8 @@ def _reference_dice_score(
         (_inputs2.preds, _inputs2.target, "one-hot"),
         (_inputs3.preds, _inputs3.target, "index"),
         (_inputs4.preds, _inputs4.target, "index"),
+        (_inputs5.preds, _inputs5.target, "mixed"),
+        (_inputs6.preds, _inputs6.target, "mixed"),
     ],
 )
 @pytest.mark.parametrize("include_background", [True, False])

--- a/tests/unittests/segmentation/test_generalized_dice_score.py
+++ b/tests/unittests/segmentation/test_generalized_dice_score.py
@@ -24,7 +24,7 @@ from torchmetrics.segmentation.generalized_dice import GeneralizedDiceScore
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
-from unittests.segmentation.inputs import _inputs1, _inputs2, _inputs3, _inputs4
+from unittests.segmentation.inputs import _inputs1, _inputs2, _inputs3, _inputs4, _inputs5, _inputs6
 
 seed_all(42)
 
@@ -40,6 +40,11 @@ def _reference_generalized_dice(
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
         target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
+    elif input_format == "mixed":
+        if preds.dim() == (target.dim() + 1):
+            target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
+        elif (preds.dim() + 1) == target.dim():
+            preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
     monai_extra_arg = {"sum_over_classes": True} if RequirementCache("monai>=1.4.0") else {}
     val = compute_generalized_dice(preds, target, include_background=include_background, **monai_extra_arg)
     if reduce:
@@ -54,6 +59,8 @@ def _reference_generalized_dice(
         (_inputs2.preds, _inputs2.target, "one-hot"),
         (_inputs3.preds, _inputs3.target, "index"),
         (_inputs4.preds, _inputs4.target, "index"),
+        (_inputs5.preds, _inputs5.target, "mixed"),
+        (_inputs6.preds, _inputs6.target, "mixed"),
     ],
 )
 @pytest.mark.parametrize("include_background", [True, False])

--- a/tests/unittests/segmentation/test_hausdorff_distance.py
+++ b/tests/unittests/segmentation/test_hausdorff_distance.py
@@ -36,6 +36,14 @@ _inputs2 = _Input(
     preds=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32)),
     target=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32)),
 )
+_inputs3 = _Input(
+    preds=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 16, 16)),
+    target=torch.randint(0, 2, (NUM_BATCHES, BATCH_SIZE, NUM_CLASSES, 16, 16)),
+)
+_inputs4 = _Input(
+    preds=torch.randint(0, 2, (NUM_BATCHES, BATCH_SIZE, NUM_CLASSES, 16, 16)),
+    target=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 16, 16)),
+)
 
 
 def reference_metric(preds, target, input_format, reduce, **kwargs: Any):
@@ -43,11 +51,16 @@ def reference_metric(preds, target, input_format, reduce, **kwargs: Any):
     if input_format == "index":
         preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
         target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
+    elif input_format == "mixed":
+        if preds.dim() == (target.dim() + 1):
+            target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
+        elif (preds.dim() + 1) == target.dim():
+            preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
     score = monai_hausdorff_distance(preds, target, **kwargs)
     return score.mean() if reduce else score
 
 
-@pytest.mark.parametrize(("inputs", "input_format"), [(_inputs1, "one-hot"), (_inputs2, "index")])
+@pytest.mark.parametrize(("inputs", "input_format"), [(_inputs1, "one-hot"), (_inputs2, "index"), (_inputs3, "mixed"), (_inputs4, "mixed")])
 @pytest.mark.parametrize("distance_metric", ["euclidean", "chessboard", "taxicab"])
 @pytest.mark.parametrize("directed", [True, False])
 @pytest.mark.parametrize("spacing", [None, [2, 2]])


### PR DESCRIPTION
## What does this PR do?

Fixes #3175

I tried to add the proposed functionality as a new `"mixed"` input format.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
