### PR TITLE
Make `data_range` required parameter

### DIFF
--- a/src/torchmetrics/image/psnr.py
+++ b/src/torchmetrics/image/psnr.py
@@ -48,9 +48,8 @@ class PeakSignalNoiseRatio(Metric):
 
     Args:
         data_range:
-            the range of the data. If None, it is determined from the data (max - min). If a tuple is provided then
-            the range is calculated as the difference and input is clamped between the values.
-            The ``data_range`` must be given when ``dim`` is not None.
+            the range of the data. If a tuple is provided then the range is calculated as the difference and
+            input is clamped between the values.
         base: a base of a logarithm to use.
         reduction: a method to reduce metric score over labels.
 
@@ -63,13 +62,9 @@ class PeakSignalNoiseRatio(Metric):
             None meaning scores will be reduced across all dimensions and all batches.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
-    Raises:
-        ValueError:
-            If ``dim`` is not ``None`` and ``data_range`` is not given.
-
     Example:
         >>> from torchmetrics.image import PeakSignalNoiseRatio
-        >>> psnr = PeakSignalNoiseRatio()
+        >>> psnr = PeakSignalNoiseRatio(data_range=3.0)
         >>> preds = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
         >>> target = torch.tensor([[3.0, 2.0], [1.0, 0.0]])
         >>> psnr(preds, target)
@@ -82,12 +77,9 @@ class PeakSignalNoiseRatio(Metric):
     full_state_update: bool = False
     plot_lower_bound: float = 0.0
 
-    min_target: Tensor
-    max_target: Tensor
-
     def __init__(
         self,
-        data_range: Optional[Union[float, tuple[float, float]]] = None,
+        data_range: Union[float, tuple[float, float]],
         base: float = 10.0,
         reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
         dim: Optional[Union[int, tuple[int, ...]]] = None,
@@ -106,20 +98,12 @@ class PeakSignalNoiseRatio(Metric):
             self.add_state("total", default=[], dist_reduce_fx="cat")
 
         self.clamping_fn = None
-        if data_range is None:
-            if dim is not None:
-                # Maybe we could use `torch.amax(target, dim=dim) - torch.amin(target, dim=dim)` in PyTorch 1.7 to
-                # calculate `data_range` in the future.
-                raise ValueError("The `data_range` must be given when `dim` is not None.")
-
-            self.data_range = None
-            self.add_state("min_target", default=tensor(0.0), dist_reduce_fx=torch.min)
-            self.add_state("max_target", default=tensor(0.0), dist_reduce_fx=torch.max)
-        elif isinstance(data_range, tuple):
+        if isinstance(data_range, tuple):
             self.add_state("data_range", default=tensor(data_range[1] - data_range[0]), dist_reduce_fx="mean")
             self.clamping_fn = partial(torch.clamp, min=data_range[0], max=data_range[1])
         else:
             self.add_state("data_range", default=tensor(float(data_range)), dist_reduce_fx="mean")
+
         self.base = base
         self.reduction = reduction
         self.dim = tuple(dim) if isinstance(dim, Sequence) else dim
@@ -132,11 +116,6 @@ class PeakSignalNoiseRatio(Metric):
 
         sum_squared_error, num_obs = _psnr_update(preds, target, dim=self.dim)
         if self.dim is None:
-            if self.data_range is None:
-                # keep track of min and max target values
-                self.min_target = torch.minimum(target.min(), self.min_target)
-                self.max_target = torch.maximum(target.max(), self.max_target)
-
             if not isinstance(self.sum_squared_error, Tensor):
                 raise TypeError(
                     f"Expected `self.sum_squared_error` to be a Tensor, but got {type(self.sum_squared_error)}"
@@ -158,8 +137,6 @@ class PeakSignalNoiseRatio(Metric):
 
     def compute(self) -> Tensor:
         """Compute peak signal-to-noise ratio over state."""
-        data_range = self.data_range if self.data_range is not None else self.max_target - self.min_target
-
         if isinstance(self.sum_squared_error, torch.Tensor):
             sum_squared_error = self.sum_squared_error
         elif isinstance(self.sum_squared_error, list):
@@ -174,7 +151,7 @@ class PeakSignalNoiseRatio(Metric):
         else:
             raise TypeError("Expected total to be a Tensor or a list of Tensors")
 
-        return _psnr_compute(sum_squared_error, total, data_range, base=self.base, reduction=self.reduction)
+        return _psnr_compute(sum_squared_error, total, self.data_range, base=self.base, reduction=self.reduction)
 
     def plot(
         self, val: Optional[Union[Tensor, Sequence[Tensor]]] = None, ax: Optional[_AX_TYPE] = None
@@ -199,7 +176,7 @@ class PeakSignalNoiseRatio(Metric):
             >>> # Example plotting a single value
             >>> import torch
             >>> from torchmetrics.image import PeakSignalNoiseRatio
-            >>> metric = PeakSignalNoiseRatio()
+            >>> metric = PeakSignalNoiseRatio(data_range=1.0)
             >>> preds = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
             >>> target = torch.tensor([[3.0, 2.0], [1.0, 0.0]])
             >>> metric.update(preds, target)
@@ -211,7 +188,7 @@ class PeakSignalNoiseRatio(Metric):
             >>> # Example plotting multiple values
             >>> import torch
             >>> from torchmetrics.image import PeakSignalNoiseRatio
-            >>> metric = PeakSignalNoiseRatio()
+            >>> metric = PeakSignalNoiseRatio(data_range=1.0)
             >>> preds = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
             >>> target = torch.tensor([[3.0, 2.0], [1.0, 0.0]])
             >>> values = [ ]

--- a/src/torchmetrics/image/psnrb.py
+++ b/src/torchmetrics/image/psnrb.py
@@ -48,12 +48,14 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
     - ``psnrb`` (:class:`~torch.Tensor`): float scalar tensor with aggregated PSNRB value
 
     Args:
+        data_range: the range of the data. If a tuple is provided then the range is calculated as the difference and
+            input is clamped between the values.
         block_size: integer indication the block size
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
     Example:
         >>> from torch import rand
-        >>> metric = PeakSignalNoiseRatioWithBlockedEffect()
+        >>> metric = PeakSignalNoiseRatioWithBlockedEffect(data_range=1.0)
         >>> preds = rand(2, 1, 10, 10)
         >>> target = rand(2, 1, 10, 10)
         >>> metric(preds, target)
@@ -72,6 +74,7 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
 
     def __init__(
         self,
+        data_range: Union[float, tuple[float, float]],
         block_size: int = 8,
         **kwargs: Any,
     ) -> None:
@@ -83,15 +86,24 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
         self.add_state("sum_squared_error", default=tensor(0.0), dist_reduce_fx="sum")
         self.add_state("total", default=tensor(0), dist_reduce_fx="sum")
         self.add_state("bef", default=tensor(0.0), dist_reduce_fx="sum")
-        self.add_state("data_range", default=tensor(0), dist_reduce_fx="max")
+
+        if isinstance(data_range, tuple):
+            self.add_state("data_range", default=tensor(data_range[1] - data_range[0]), dist_reduce_fx="mean")
+            self.clamping_fn = lambda x: torch.clamp(x, min=data_range[0], max=data_range[1])
+        else:
+            self.add_state("data_range", default=tensor(float(data_range)), dist_reduce_fx="mean")
+            self.clamping_fn = None
 
     def update(self, preds: Tensor, target: Tensor) -> None:
         """Update state with predictions and targets."""
+        if self.clamping_fn is not None:
+            preds = self.clamping_fn(preds)
+            target = self.clamping_fn(target)
+
         sum_squared_error, bef, num_obs = _psnrb_update(preds, target, block_size=self.block_size)
         self.sum_squared_error += sum_squared_error
         self.bef += bef
         self.total += num_obs
-        self.data_range = torch.maximum(self.data_range, torch.max(target) - torch.min(target))
 
     def compute(self) -> Tensor:
         """Compute peak signal-to-noise ratio over state."""
@@ -120,7 +132,7 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
             >>> # Example plotting a single value
             >>> import torch
             >>> from torchmetrics.image import PeakSignalNoiseRatioWithBlockedEffect
-            >>> metric = PeakSignalNoiseRatioWithBlockedEffect()
+            >>> metric = PeakSignalNoiseRatioWithBlockedEffect(data_range=1.0)
             >>> metric.update(torch.rand(2, 1, 10, 10), torch.rand(2, 1, 10, 10))
             >>> fig_, ax_ = metric.plot()
 
@@ -130,7 +142,7 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
             >>> # Example plotting multiple values
             >>> import torch
             >>> from torchmetrics.image import PeakSignalNoiseRatioWithBlockedEffect
-            >>> metric = PeakSignalNoiseRatioWithBlockedEffect()
+            >>> metric = PeakSignalNoiseRatioWithBlockedEffect(data_range=1.0)
             >>> values = [ ]
             >>> for _ in range(10):
             ...     values.append(metric(torch.rand(2, 1, 10, 10), torch.rand(2, 1, 10, 10)))

--- a/tests/unittests/image/test_psnr.py
+++ b/tests/unittests/image/test_psnr.py
@@ -154,19 +154,10 @@ def test_reduction_for_dim_none(reduction):
     """Test that warnings are raised when then reduction parameter is combined with no dim provided arg."""
     match = f"The `reduction={reduction}` will not have any effect when `dim` is None."
     with pytest.warns(UserWarning, match=match):
-        PeakSignalNoiseRatio(reduction=reduction, dim=None)
+        PeakSignalNoiseRatio(data_range=10.0, reduction=reduction, dim=None)
 
     with pytest.warns(UserWarning, match=match):
-        peak_signal_noise_ratio(_inputs[0].preds, _inputs[0].target, reduction=reduction, dim=None)
-
-
-def test_missing_data_range():
-    """Check that error is raised if data range is not provided."""
-    with pytest.raises(ValueError, match="The `data_range` must be given when `dim` is not None."):
-        PeakSignalNoiseRatio(data_range=None, dim=0)
-
-    with pytest.raises(ValueError, match="The `data_range` must be given when `dim` is not None."):
-        peak_signal_noise_ratio(_inputs[0].preds, _inputs[0].target, data_range=None, dim=0)
+        peak_signal_noise_ratio(_inputs[0].preds, _inputs[0].target, data_range=10.0, reduction=reduction, dim=None)
 
 
 def test_psnr_uint_dtype():
@@ -177,6 +168,6 @@ def test_psnr_uint_dtype():
     """
     preds = torch.randint(0, 255, _input_size, dtype=torch.uint8)
     target = torch.randint(0, 255, _input_size, dtype=torch.uint8)
-    psnr = peak_signal_noise_ratio(preds, target)
-    prnr2 = peak_signal_noise_ratio(preds.float(), target.float())
+    psnr = peak_signal_noise_ratio(preds, target, data_range=255.0)
+    prnr2 = peak_signal_noise_ratio(preds.float(), target.float(), data_range=255.0)
     assert torch.allclose(psnr, prnr2)

--- a/tests/unittests/image/test_psnrb.py
+++ b/tests/unittests/image/test_psnrb.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
+from functools import partial
 
 import numpy as np
 import pytest
@@ -35,28 +36,43 @@ _input = (
 )
 
 
-def _reference_psnrb(preds, target):
+def _reference_psnrb(preds, target, data_range):
     """Reference implementation of PSNRB metric.
 
     Inspired by
     https://github.com/andrewekhalel/sewar/blob/master/sewar/full_ref.py
     that also supports batched inputs.
 
+    Args:
+        preds: Predicted tensor
+        target: Ground truth tensor
+        data_range: Range of the data. If not provided, it's determined from the data.
+
+    Returns:
+        PSNRB score
+
     """
     preds = preds.numpy()
     target = target.numpy()
+
+    # Handle data_range parameter
+    if isinstance(data_range, tuple):
+        # Apply clamping if range is provided as tuple
+        preds = np.clip(preds, data_range[0], data_range[1])
+        target = np.clip(target, data_range[0], data_range[1])
+        dr = data_range[1] - data_range[0]
+    else:
+        # Use the provided data_range directly
+        dr = float(data_range)
+
     imdff = np.double(target) - np.double(preds)
 
     mse = np.mean(np.square(imdff.flatten()))
     bef = sum([_compute_bef(p.squeeze()) for p in preds])
     mse_b = mse + bef
 
-    if np.amax(preds) > 2:
-        psnr_b = 10 * math.log10((target.max() - target.min()) ** 2 / mse_b)
-    else:
-        psnr_b = 10 * math.log10(1 / mse_b)
-
-    return psnr_b
+    # Use the provided data_range for calculation
+    return 10 * math.log10(dr**2 / mse_b)
 
 
 @pytest.mark.parametrize(("preds", "target"), _input)
@@ -66,42 +82,58 @@ class TestPSNR(MetricTester):
     @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
     def test_psnr(self, preds, target, ddp):
         """Test that modular PSNRB metric returns the same result as the reference implementation."""
+        # Pass a data_range value appropriate for the inputs
+        data_range = 1.0 if preds.max() <= 1.0 else 255.0
         self.run_class_metric_test(
-            ddp, preds, target, metric_class=PeakSignalNoiseRatioWithBlockedEffect, reference_metric=_reference_psnrb
+            ddp,
+            preds,
+            target,
+            metric_class=PeakSignalNoiseRatioWithBlockedEffect,
+            reference_metric=partial(_reference_psnrb, data_range=data_range),
+            metric_args={"data_range": data_range},
         )
 
     def test_psnr_functional(self, preds, target):
         """Test that functional PSNRB metric returns the same result as the reference implementation."""
+        # Pass a data_range value appropriate for the inputs
+        data_range = 1.0 if preds.max() <= 1.0 else 255.0
         self.run_functional_metric_test(
             preds,
             target,
             metric_functional=peak_signal_noise_ratio_with_blocked_effect,
-            reference_metric=_reference_psnrb,
+            reference_metric=partial(_reference_psnrb, data_range=data_range),
+            metric_args={"data_range": data_range},
         )
 
     def test_psnr_half_cpu(self, preds, target):
         """Test that PSNRB metric works with half precision on cpu."""
         if target.max() - target.min() < 2:
             pytest.xfail("PSNRB metric does not support cpu + half precision")
+        # Pass a data_range value appropriate for the inputs
+        data_range = 1.0 if preds.max() <= 1.0 else 255.0
         self.run_precision_test_cpu(
             preds,
             target,
             PeakSignalNoiseRatioWithBlockedEffect,
             peak_signal_noise_ratio_with_blocked_effect,
+            metric_args={"data_range": data_range},
         )
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires cuda")
     def test_psnr_half_gpu(self, preds, target):
         """Test that PSNRB metric works with half precision on gpu."""
+        # Pass a data_range value appropriate for the inputs
+        data_range = 1.0 if preds.max() <= 1.0 else 255.0
         self.run_precision_test_gpu(
             preds,
             target,
             PeakSignalNoiseRatioWithBlockedEffect,
             peak_signal_noise_ratio_with_blocked_effect,
+            metric_args={"data_range": data_range},
         )
 
 
 def test_error_on_color_images():
     """Test that appropriate error is raised when color images are passed to PSNRB metric."""
     with pytest.raises(ValueError, match="`psnrb` metric expects grayscale images.*"):
-        peak_signal_noise_ratio_with_blocked_effect(torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16))
+        peak_signal_noise_ratio_with_blocked_effect(torch.rand(1, 3, 16, 16), torch.rand(1, 3, 16, 16), data_range=1.0)


### PR DESCRIPTION
## What does this PR do?

Fixes #3135
Makes `data_range` parameter a required arg in `psnr` and `psnrb` metrics. The linked issue makes a good argument for why this argument is essential enough to the metric that it should be required by the user to set.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
