### PR TITLE
Remove sigmoid in `BinaryPrecisionRecallCurve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed unintended `sigmoid` normalization in `BinaryPrecisionRecallCurve`, which might cause incorrect ROC computation when updating incrementally with raw logits. ([#3179](https://github.com/Lightning-AI/torchmetrics/pull/3179)). This fix will only take effect when setting `disable_softmax` to False (defaults to True for compatibility).
+- Fixed unintended `sigmoid` normalization in `BinaryPrecisionRecallCurve` ([#3182](https://github.com/Lightning-AI/torchmetrics/pull/3182))
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed unintended `sigmoid` normalization in `BinaryPrecisionRecallCurve`, which might cause incorrect ROC computation when updating incrementally with raw logits. ([#3179](https://github.com/Lightning-AI/torchmetrics/pull/3179))
+- Fixed unintended `sigmoid` normalization in `BinaryPrecisionRecallCurve`, which might cause incorrect ROC computation when updating incrementally with raw logits. ([#3179](https://github.com/Lightning-AI/torchmetrics/pull/3179)). This fix will only take effect when setting `disable_softmax` to False (defaults to True for compatibility).
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed unintended `sigmoid` normalization in `BinaryPrecisionRecallCurve`, which might cause incorrect ROC computation when updating incrementally with raw logits. ([#3179](https://github.com/Lightning-AI/torchmetrics/pull/3179))
 
 
 ---

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -142,7 +142,7 @@ class BinaryPrecisionRecallCurve(Metric):
         thresholds: Optional[Union[int, list[float], Tensor]] = None,
         ignore_index: Optional[int] = None,
         validate_args: bool = True,
-        normalization: Optional[str] = "sigmoid",
+        normalization: Optional[Literal["sigmoid", "softmax"]] = "sigmoid",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -107,6 +107,9 @@ class BinaryPrecisionRecallCurve(Metric):
             Specifies a target value that is ignored and does not contribute to the metric calculation
         validate_args: bool indicating if input arguments and tensors should be validated for correctness.
             Set to ``False`` for faster computations.
+        normalization:
+            Specifies a normalization method that is used for batch-wise update regarding negative logits.
+            Set to ``None`` if negative logits are desired in evaluation.
         kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 
     Example:
@@ -139,6 +142,7 @@ class BinaryPrecisionRecallCurve(Metric):
         thresholds: Optional[Union[int, list[float], Tensor]] = None,
         ignore_index: Optional[int] = None,
         validate_args: bool = True,
+        normalization: Optional[str] = "sigmoid",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -147,6 +151,7 @@ class BinaryPrecisionRecallCurve(Metric):
 
         self.ignore_index = ignore_index
         self.validate_args = validate_args
+        self.normalization = normalization
 
         thresholds = _adjust_threshold_arg(thresholds)
         if thresholds is None:
@@ -164,7 +169,7 @@ class BinaryPrecisionRecallCurve(Metric):
         if self.validate_args:
             _binary_precision_recall_curve_tensor_validation(preds, target, self.ignore_index)
         preds, target, _ = _binary_precision_recall_curve_format(
-            preds, target, self.thresholds, self.ignore_index, None
+            preds, target, self.thresholds, self.ignore_index, self.normalization,
         )
         state = _binary_precision_recall_curve_update(preds, target, self.thresholds)
         if isinstance(state, Tensor):

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -163,7 +163,9 @@ class BinaryPrecisionRecallCurve(Metric):
         """Update metric states."""
         if self.validate_args:
             _binary_precision_recall_curve_tensor_validation(preds, target, self.ignore_index)
-        preds, target, _ = _binary_precision_recall_curve_format(preds, target, self.thresholds, self.ignore_index, None)
+        preds, target, _ = _binary_precision_recall_curve_format(
+            preds, target, self.thresholds, self.ignore_index, None
+        )
         state = _binary_precision_recall_curve_update(preds, target, self.thresholds)
         if isinstance(state, Tensor):
             self.confmat += state

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -163,7 +163,7 @@ class BinaryPrecisionRecallCurve(Metric):
         """Update metric states."""
         if self.validate_args:
             _binary_precision_recall_curve_tensor_validation(preds, target, self.ignore_index)
-        preds, target, _ = _binary_precision_recall_curve_format(preds, target, self.thresholds, self.ignore_index)
+        preds, target, _ = _binary_precision_recall_curve_format(preds, target, self.thresholds, self.ignore_index, None)
         state = _binary_precision_recall_curve_update(preds, target, self.thresholds)
         if isinstance(state, Tensor):
             self.confmat += state

--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -169,7 +169,11 @@ class BinaryPrecisionRecallCurve(Metric):
         if self.validate_args:
             _binary_precision_recall_curve_tensor_validation(preds, target, self.ignore_index)
         preds, target, _ = _binary_precision_recall_curve_format(
-            preds, target, self.thresholds, self.ignore_index, self.normalization,
+            preds,
+            target,
+            self.thresholds,
+            self.ignore_index,
+            self.normalization,
         )
         state = _binary_precision_recall_curve_update(preds, target, self.thresholds)
         if isinstance(state, Tensor):

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -166,6 +166,7 @@ def _binary_precision_recall_curve_format(
     target: Tensor,
     thresholds: Optional[Union[int, list[float], Tensor]] = None,
     ignore_index: Optional[int] = None,
+    normalization: Optional[str] = "sigmoid",
 ) -> tuple[Tensor, Tensor, Optional[Tensor]]:
     """Convert all input to the right format.
 
@@ -182,7 +183,7 @@ def _binary_precision_recall_curve_format(
         preds = preds[idx]
         target = target[idx]
 
-    preds = normalize_logits_if_needed(preds, "sigmoid")
+    preds = normalize_logits_if_needed(preds, normalization)
 
     thresholds = _adjust_threshold_arg(thresholds, preds.device)
     return preds, target, thresholds

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -166,7 +166,7 @@ def _binary_precision_recall_curve_format(
     target: Tensor,
     thresholds: Optional[Union[int, list[float], Tensor]] = None,
     ignore_index: Optional[int] = None,
-    normalization: Optional[str] = "sigmoid",
+    normalization: Optional[Literal["sigmoid", "softmax"]] = "sigmoid",
 ) -> tuple[Tensor, Tensor, Optional[Tensor]]:
     """Convert all input to the right format.
 

--- a/src/torchmetrics/utilities/compute.py
+++ b/src/torchmetrics/utilities/compute.py
@@ -201,7 +201,7 @@ def interp(x: Tensor, xp: Tensor, fp: Tensor) -> Tensor:
     return m[indices] * x + b[indices]
 
 
-def normalize_logits_if_needed(tensor: Tensor, normalization: Literal["sigmoid", "softmax"]) -> Tensor:
+def normalize_logits_if_needed(tensor: Tensor, normalization: Optional[Literal["sigmoid", "softmax"]]) -> Tensor:
     """Normalize logits if needed.
 
     If input tensor is outside the [0,1] we assume that logits are provided and apply the normalization.
@@ -228,6 +228,9 @@ def normalize_logits_if_needed(tensor: Tensor, normalization: Literal["sigmoid",
         tensor([0.0000, 0.5000, 1.0000])
 
     """
+    # if not specified, do nothing.
+    if not normalization:
+        return tensor
     # decrease sigmoid on cpu .
     if tensor.device == torch.device("cpu"):
         if not torch.all((tensor >= 0) * (tensor <= 1)):


### PR DESCRIPTION
# What does this PR do?
This PR addresses [#3179](https://github.com/Lightning-AI/torchmetrics/issues/3179) by making the use of sigmoid normalization optional in `BinaryPrecisionRecallCurve`. Specifically, it introduces a normalization parameter to _binary_precision_recall_curve_format and disables automatic sigmoid application in `BinaryPrecisionRecallCurve`.

# Changes
- Adds a normalization: `Optional[str] = "sigmoid"` argument to _binary_precision_recall_curve_format, allowing users to override the default behavior.

- Passes normalization=None in `BinaryPrecisionRecallCurve` to preserve raw logits and prevent batch-wise distortion during `.update()` calls.

# Notes
- This fix only applies to `BinaryPrecisionRecallCurve`, which is the class I directly encountered issues with.

- I’ve noticed that other metric classes may also apply sigmoid implicitly in ways that could cause similar inconsistencies across batch-wise updates, but since I have not tested those cases, I am leaving them unchanged to avoid unintended side effects.

<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3182.org.readthedocs.build/en/3182/

<!-- readthedocs-preview torchmetrics end -->