### PR TITLE
Feat/vif reduction none

### DIFF
--- a/src/torchmetrics/image/vif.py
+++ b/src/torchmetrics/image/vif.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any
-from typing_extensions import Literal
 
 import torch
 from torch import Tensor, tensor
+from typing_extensions import Literal
 
 from torchmetrics.functional.image.vif import _vif_per_channel
 from torchmetrics.metric import Metric
@@ -32,7 +32,7 @@ class VisualInformationFidelity(Metric):
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``vif-p`` (:class:`~torch.Tensor`): 
+    - ``vif-p`` (:class:`~torch.Tensor`):
         - If ``reduction='mean'`` (default), returns a Tensor mean VIF score.
         - If ``reduction='none'``, returns a tensor of shape ``(N,)`` with VIF values per sample.
 
@@ -99,5 +99,5 @@ class VisualInformationFidelity(Metric):
         """Compute VIF over state."""
         if self.reduction == "mean":
             return self.vif_score / self.total
-        else:  # reduction == "none"
-            return dim_zero_cat(self.vif_score)
+        # reduction == "none"
+        return dim_zero_cat(self.vif_score)

--- a/tests/unittests/image/test_vif.py
+++ b/tests/unittests/image/test_vif.py
@@ -65,6 +65,7 @@ class TestVIF(MetricTester):
 
 
 def test_vif_reduction_none():
+        """Test that VIF metric returns correct output when `reduction=None`."""
     pred = torch.rand(2, 3, 256, 256)
     target = torch.rand(2, 3, 256, 256)
     metric = VisualInformationFidelity(reduction="none")

--- a/tests/unittests/image/test_vif.py
+++ b/tests/unittests/image/test_vif.py
@@ -63,6 +63,7 @@ class TestVIF(MetricTester):
             preds, target, metric_functional=visual_information_fidelity, reference_metric=_reference_sewar_vif
         )
 
+
 def test_vif_reduction_none():
     pred = torch.rand(2, 3, 256, 256)
     target = torch.rand(2, 3, 256, 256)

--- a/tests/unittests/image/test_vif.py
+++ b/tests/unittests/image/test_vif.py
@@ -62,3 +62,10 @@ class TestVIF(MetricTester):
         self.run_functional_metric_test(
             preds, target, metric_functional=visual_information_fidelity, reference_metric=_reference_sewar_vif
         )
+
+def test_vif_reduction_none():
+    pred = torch.rand(2, 3, 256, 256)
+    target = torch.rand(2, 3, 256, 256)
+    metric = VisualInformationFidelity(reduction="none")
+    result = metric(pred, target)
+    assert result.shape == (2,)


### PR DESCRIPTION
## What does this PR do?

Enhances the **Visual Information Fidelity (VIF)** metric by adding support for `reduction='none'`.  
This allows users to retrieve per-sample metric values instead of only reduced tensor outputs, bringing the VIF metric in line with other metrics that already support `reduction` modes.

Fixes #3194 

---

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a GitHub issue? (not required for minor typos or docs)  
- [x] Did you read the [contributor guidelines](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md)?  
- [x] Did you make sure to **update the documentation** (docstrings + examples)?  
- [x] Did you write **unit tests** for the new feature?

</details>

---

## Why is this needed?

- `reduction='none'` enables batch-level debugging, per-sample metric analysis, and flexible custom aggregations.  
- Maintains **API consistency** with other TorchMetrics metrics that already support multiple reduction modes.

---

## Additional Context

- Added **unit tests** covering `reduction='none'` behavior for VIF.  
- Updated **docstring** in python file.

---

## Did you have fun?

That was my first Open Source Commit. 💯  


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3195.org.readthedocs.build/en/3195/

<!-- readthedocs-preview torchmetrics end -->