### PR TITLE
Float input support for segmentation metrics

### DIFF
--- a/src/torchmetrics/functional/segmentation/dice.py
+++ b/src/torchmetrics/functional/segmentation/dice.py
@@ -17,9 +17,8 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.segmentation.utils import _check_mixed_shape, _ignore_background
+from torchmetrics.functional.segmentation.utils import _segmentation_inputs_format
 from torchmetrics.utilities import rank_zero_warn
-from torchmetrics.utilities.checks import _check_same_shape
 from torchmetrics.utilities.compute import _safe_divide
 
 
@@ -56,25 +55,7 @@ def _dice_score_update(
     input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> tuple[Tensor, Tensor, Tensor]:
     """Update the state with the current prediction and target."""
-    if input_format == "mixed":
-        _check_mixed_shape(preds, target)
-    else:
-        _check_same_shape(preds, target)
-
-    if input_format == "index":
-        preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-        target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
-    elif input_format == "mixed":
-        if preds.dim() == (target.dim() + 1):
-            target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
-        elif (preds.dim() + 1) == target.dim():
-            preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-
-    if preds.ndim < 3:
-        raise ValueError(f"Expected both `preds` and `target` to have at least 3 dimensions, but got {preds.ndim}.")
-
-    if not include_background:
-        preds, target = _ignore_background(preds, target)
+    preds, target = _segmentation_inputs_format(preds, target, include_background, num_classes, input_format)
 
     reduce_axis = list(range(2, target.ndim))
     intersection = torch.sum(preds * target, dim=reduce_axis)

--- a/src/torchmetrics/functional/segmentation/mean_iou.py
+++ b/src/torchmetrics/functional/segmentation/mean_iou.py
@@ -18,8 +18,7 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.segmentation.utils import _check_mixed_shape, _ignore_background
-from torchmetrics.utilities.checks import _check_same_shape
+from torchmetrics.functional.segmentation.utils import _segmentation_inputs_format
 from torchmetrics.utilities.compute import _safe_divide
 
 
@@ -76,33 +75,8 @@ def _mean_iou_update(
 ) -> tuple[Tensor, Tensor]:
     """Update the intersection and union counts for the mean IoU computation."""
     preds, target = _mean_iou_reshape_args(preds, target, input_format)
-    if input_format == "mixed":
-        _check_mixed_shape(preds, target)
-    else:
-        _check_same_shape(preds, target)
 
-    if input_format == "index":
-        if num_classes is None:
-            raise ValueError("Argument `num_classes` must be provided when `input_format='index'`.")
-        preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-        target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
-    elif input_format == "one-hot" and num_classes is None:
-        try:
-            num_classes = preds.shape[1]
-        except IndexError as err:
-            raise IndexError(f"Cannot determine `num_classes` from `preds` tensor: {preds}.") from err
-        if num_classes == 0:
-            raise ValueError(f"Expected argument `num_classes` to be a positive integer, but got {num_classes}.")
-    elif input_format == "mixed":
-        if num_classes is None:
-            raise ValueError("Argument `num_classes` must be provided when `input_format='mixed'`.")
-        if preds.dim() == (target.dim() + 1):
-            target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
-        elif (preds.dim() + 1) == target.dim():
-            preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
-
-    if not include_background:
-        preds, target = _ignore_background(preds, target)
+    preds, target = _segmentation_inputs_format(preds, target, include_background, num_classes, input_format)
 
     reduce_axis = list(range(2, preds.ndim))
     intersection = torch.sum(preds & target, dim=reduce_axis)

--- a/src/torchmetrics/functional/segmentation/mean_iou.py
+++ b/src/torchmetrics/functional/segmentation/mean_iou.py
@@ -50,8 +50,8 @@ def _mean_iou_validate_args(
     input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
 ) -> None:
     """Validate the arguments of the metric."""
-    if input_format in ["index", "mixed"] and num_classes is None:
-        raise ValueError("Argument `num_classes` must be provided when `input_format` is 'index' or 'mixed'.")
+    if input_format in ["index"] and num_classes is None:
+        raise ValueError("Argument `num_classes` must be provided when `input_format` is 'index'.")
     if num_classes is not None and num_classes <= 0:
         raise ValueError(
             f"Expected argument `num_classes` must be `None` or a positive integer, but got {num_classes}."
@@ -110,7 +110,8 @@ def mean_iou(
     Args:
         preds: Predictions from model
         target: Ground truth values
-        num_classes: Number of classes (required when input_format="index", optional when input_format="one-hot")
+        num_classes: Number of classes
+            (required when input_format="index", optional when input_format="one-hot" or "mixed")
         include_background: Whether to include the background class in the computation
         per_class: Whether to compute the IoU for each class separately, else average over all classes
         input_format: What kind of input the function receives.

--- a/src/torchmetrics/segmentation/mean_iou.py
+++ b/src/torchmetrics/segmentation/mean_iou.py
@@ -53,8 +53,8 @@ class MeanIoU(Metric):
           set to ``False``, the output will be a scalar tensor.
 
     Args:
-        num_classes: The number of classes in the segmentation problem. Required when input_format="index" or "mixed",
-            optional when input_format="one-hot".
+        num_classes: The number of classes in the segmentation problem. Required when input_format="index",
+            optional when input_format="one-hot" or "mixed".
         include_background: Whether to include the background class in the computation
         per_class: Whether to compute the IoU for each class separately. If set to ``False``, the metric will
             compute the mean IoU over all classes.
@@ -67,7 +67,7 @@ class MeanIoU(Metric):
         ValueError:
             If ``num_classes`` is not ``None`` or a positive integer
         ValueError:
-            If ``num_classes`` is not provided when ``input_format`` is ``"index"`` or ``"mixed"``
+            If ``num_classes`` is not provided when ``input_format`` is ``"index"``
         ValueError:
             If ``include_background`` is not a boolean
         ValueError:
@@ -132,7 +132,13 @@ class MeanIoU(Metric):
         """Update the state with the new data."""
         if not self._is_initialized:
             try:
-                self.num_classes = preds.shape[1]
+                if self.input_format == "one-hot":
+                    self.num_classes = preds.shape[1]
+                elif self.input_format == "mixed":
+                    if preds.dim() == (target.dim() + 1):
+                        self.num_classes = preds.shape[1]
+                    elif (preds.dim() + 1) == target.dim():
+                        self.num_classes = target.shape[1]
             except IndexError as err:
                 raise IndexError(f"Cannot determine `num_classes` from `preds` tensor: {preds}.") from err
 

--- a/tests/unittests/segmentation/inputs.py
+++ b/tests/unittests/segmentation/inputs.py
@@ -48,3 +48,8 @@ _mixed_input_2 = _Input(
     preds=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32)),
     target=to_one_hot(torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32))),
 )
+
+_mixed_logits_input = _Input(
+    preds=(torch.rand((NUM_BATCHES, BATCH_SIZE, NUM_CLASSES, 32, 32)) * 12 - 6),
+    target=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 32, 32)),
+)

--- a/tests/unittests/segmentation/test_dice.py
+++ b/tests/unittests/segmentation/test_dice.py
@@ -28,6 +28,7 @@ from unittests.segmentation.inputs import (
     _index_input_2,
     _mixed_input_1,
     _mixed_input_2,
+    _mixed_logits_input,
     _one_hot_input_1,
     _one_hot_input_2,
 )
@@ -76,6 +77,7 @@ def _reference_dice_score(
         (_index_input_2.preds, _index_input_2.target, "index"),
         (_mixed_input_1.preds, _mixed_input_1.target, "mixed"),
         (_mixed_input_2.preds, _mixed_input_2.target, "mixed"),
+        (_mixed_logits_input.preds, _mixed_logits_input.target, "mixed"),
     ],
 )
 @pytest.mark.parametrize("include_background", [True, False])

--- a/tests/unittests/segmentation/test_mean_iou.py
+++ b/tests/unittests/segmentation/test_mean_iou.py
@@ -27,6 +27,7 @@ from unittests.segmentation.inputs import (
     _index_input_1,
     _mixed_input_1,
     _mixed_input_2,
+    _mixed_logits_input,
     _one_hot_input_1,
     _one_hot_input_2,
 )
@@ -47,8 +48,14 @@ def _reference_mean_iou(
         target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
     elif input_format == "mixed":
         if preds.dim() == (target.dim() + 1):
+            if torch.is_floating_point(preds):
+                preds = preds.argmax(dim=1)
+                preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
             target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
         elif (preds.dim() + 1) == target.dim():
+            if torch.is_floating_point(target):
+                target = target.argmax(dim=1)
+                target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
             preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
 
     val = compute_iou(preds, target, include_background=include_background)
@@ -69,6 +76,7 @@ def _reference_mean_iou(
         (_index_input_1.preds, _index_input_1.target, "index", None),
         (_mixed_input_1.preds, _mixed_input_1.target, "mixed", NUM_CLASSES),
         (_mixed_input_2.preds, _mixed_input_2.target, "mixed", NUM_CLASSES),
+        (_mixed_logits_input.preds, _mixed_logits_input.target, "mixed", NUM_CLASSES),
     ],
 )
 @pytest.mark.parametrize("include_background", [True, False])

--- a/tests/unittests/segmentation/test_mean_iou.py
+++ b/tests/unittests/segmentation/test_mean_iou.py
@@ -91,7 +91,7 @@ class TestMeanIoU(MetricTester):
         """Test class implementation of metric."""
         if input_format in ["index", "mixed"] and num_classes is None:
             with pytest.raises(
-                ValueError, match="Argument `num_classes` must be provided when `input_format` is 'index' or 'mixed'."
+                ValueError, match="Argument `num_classes` must be provided when `input_format` is 'index'."
             ):
                 MeanIoU(num_classes=None, input_format="index")
             return
@@ -121,7 +121,7 @@ class TestMeanIoU(MetricTester):
         """Test functional implementation of metric."""
         if input_format == "index" and num_classes is None:
             with pytest.raises(
-                ValueError, match="Argument `num_classes` must be provided when `input_format` is 'index' or 'mixed'."
+                ValueError, match="Argument `num_classes` must be provided when `input_format` is 'index'."
             ):
                 mean_iou(preds, target, num_classes=None, input_format="index")
             return


### PR DESCRIPTION
## Problem description

Segmentation metrics do not currently support float inputs, like logits or probabilities. The only [B, C, H, W]-format input that works correctly are one-hot encodings.

In case of MeanIoU passing a float tensor as one of the inputs causes `RuntimeError: "bitwise_and_cpu" not implemented for 'Float'`, and in case of other metrics (lile Dice Score) it won't cause torchmetrics to crash, but the output will probably will be meaningless.

E.g. if `preds` is a logits tensor of a shape [B, C, H, W] and have values like 0.6, 6.1, -3.7 etc and `targets` is a one-hot encoded tensor of the same shape, but with values 0 and 1, the further operations, like calculating intersection:
```py
intersection = torch.sum(preds * target, dim=reduce_axis)
```
will finally result in metric values being out of range [0, 1].

To fix it, classification metrics do:
```py
if preds.ndim == target.ndim + 1 and top_k == 1:
    preds = preds.argmax(dim=1)
```

## What does this PR do?

This PR:

- Adds `_format_logits` function that detects if the input tensor is a floating point tensor (logits or probabilities) and first calculates `argmax` for it to create a segmentation map and then one-hot encodes that segmentation map.

- Moves data preprocessing logic from metrics to a separate function, as that logic is almost the same in every metric, so we get rid of duplicate code

- Adds support for `num_classes=None` to MeanIoU when `input_format="mixed"` 

Fixes #3197

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
