### PR TITLE
docs: skip `SPHINX_PIN_RELEASE_VERSIONS` for PR

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -24,7 +24,7 @@ env:
   TOKENIZERS_PARALLELISM: false
   SPHINX_MOCK_REQUIREMENTS: 0
   SPHINX_FETCH_ASSETS: 0
-  SPHINX_PIN_RELEASE_VERSIONS: 1
+  SPHINX_PIN_RELEASE_VERSIONS: 0
 
 jobs:
   docs-make:
@@ -56,15 +56,16 @@ jobs:
       - run: pip list
       - name: Full build for deployment
         if: github.event_name != 'pull_request'
-        run: echo "SPHINX_FETCH_ASSETS=1" >> $GITHUB_ENV
+        run: |
+          echo "SPHINX_FETCH_ASSETS=1" >> $GITHUB_ENV
+          echo "SPHINX_PIN_RELEASE_VERSIONS=1" >> $GITHUB_ENV
       - name: Disable Gallery build
         if: matrix.target != 'html'
         run: echo "SPHINX_ENABLE_GALLERY=0" >> $GITHUB_ENV
       - name: make ${{ matrix.target }}
         working-directory: ./docs
         run: |
-          pwd
-          ls -la
+          pwd && ls -la
           make ${{ matrix.target }} --debug --jobs $(nproc) SPHINXOPTS="-W --keep-going"
 
       - name: Upload built docs


### PR DESCRIPTION
## What does this PR do?

this shall be rather fixed but for now lets do not do this replacement:
```
(  pages/overview: line  238) broken    https://pytorch.org/docs/2.8/_modules/torch/nn/parallel/distributed.html#DistributedDataParallel.join - 404 Client Error: Not Found for url: https://docs.pytorch.org/docs/2.8/_modules/torch/nn/parallel/distributed.html
(  pages/overview: line  232) redirect  https://pytorch.org/docs/2.8/generated/torch.nn.parallel.DistributedDataParallel.html - permanently to https://docs.pytorch.org/docs/2.8/generated/torch.nn.parallel.DistributedDataParallel.html
```
in https://github.com/Lightning-AI/torchmetrics/actions/runs/16780583243/job/47517884966?pr=3196
also, the confusing part is why it is replaced with `2.8` for `stable` when installed is `torch 2.7.1+cpu`

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3211.org.readthedocs.build/en/3211/

<!-- readthedocs-preview torchmetrics end -->