### PR TITLE
docker: build image for latest `Torch==2.8`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -75,6 +75,7 @@ jobs:
           - { python: "3.11", pytorch: "2.5.1", cuda: "12.1.1", ubuntu: "22.04" }
           - { python: "3.11", pytorch: "2.6.0", cuda: "12.4.1", ubuntu: "22.04" }
           - { python: "3.11", pytorch: "2.7.1", cuda: "12.6.3", ubuntu: "22.04" }
+          - { python: "3.11", pytorch: "2.8.0", cuda: "12.6.3", ubuntu: "22.04" }
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What does this PR do?

following release https://github.com/pytorch/pytorch/releases/tag/v2.8.0

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3212.org.readthedocs.build/en/3212/

<!-- readthedocs-preview torchmetrics end -->