### PR TITLE
fix: return NaN when no threshold meets min recall/precision in binary metrics

### DIFF
--- a/src/torchmetrics/functional/classification/precision_fixed_recall.py
+++ b/src/torchmetrics/functional/classification/precision_fixed_recall.py
@@ -55,7 +55,7 @@ def _precision_at_recall(
         best_threshold = torch.tensor(0)
 
     if max_precision == 0.0:
-        best_threshold = torch.tensor(1e6, device=thresholds.device, dtype=thresholds.dtype)
+        best_threshold = torch.tensor(float("nan"), device=thresholds.device, dtype=thresholds.dtype)
 
     return max_precision, best_threshold
 

--- a/src/torchmetrics/functional/classification/recall_fixed_precision.py
+++ b/src/torchmetrics/functional/classification/recall_fixed_precision.py
@@ -71,7 +71,7 @@ def _recall_at_precision(
         idx = _lexargmax(zipped_masked)[0]
         max_recall, _, best_threshold = zipped_masked[idx]
     if max_recall == 0.0:
-        best_threshold = torch.tensor(1e6, device=thresholds.device, dtype=thresholds.dtype)
+        best_threshold = torch.tensor(float("nan"), device=thresholds.device, dtype=thresholds.dtype)
 
     return max_recall, best_threshold
 

--- a/tests/unittests/classification/test_precision_fixed_recall.py
+++ b/tests/unittests/classification/test_precision_fixed_recall.py
@@ -49,7 +49,7 @@ def _precision_at_recall_x_multilabel(predictions, targets, min_recall):
         tuple_all = [(p, r, t) for p, r, t in zip(precision, recall, thresholds) if r >= min_recall]
         max_precision, _, best_threshold = max(tuple_all)
     except ValueError:
-        max_precision, best_threshold = 0, 1e6
+        max_precision, best_threshold = 0, float("nan")
 
     return float(max_precision), float(best_threshold)
 
@@ -451,3 +451,15 @@ def test_wrapper_class(metric, kwargs, base_metric=PrecisionAtFixedRecall):
         instance = base_metric(**kwargs)
         assert isinstance(instance, metric)
         assert isinstance(instance, Metric)
+
+
+def test_binary_precision_at_fixed_recall_nan_threshold():
+    """If no threshold meets the min_recall condition, threshold should be NaN."""
+    preds = torch.tensor([0.1, 0.4, 0.9, 0.8])
+    target = torch.tensor([0, 0, 0, 0])
+
+    metric = BinaryPrecisionAtFixedRecall(min_recall=0.5)
+    precision, threshold = metric(preds, target)
+
+    assert precision == 0.0
+    assert torch.isnan(threshold), "Expected NaN when no recall condition is met"


### PR DESCRIPTION
What does this PR do?
Replaces the hardcoded 1e6 threshold value with NaN in BinaryPrecisionAtFixedRecall and BinaryRecallAtFixedPrecision when no threshold satisfies the recall/precision condition.
Also adds tests to ensure NaN is returned in these cases.

Fixes #2873 

<details> <summary>Before submitting</summary>
 Was this discussed/agreed via a Github issue? (not required for minor bug fixes or tests)

 Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?

 Did you make sure to update the docs? (N/A for this PR)

 Did you write any new necessary tests?

</details> <details> <summary>PR review</summary>
Anyone in the community is free to review the PR once the tests have passed.
If this change was not discussed in a Github issue, it may take longer to review.

</details>
Did you have fun?
Yes, as always.