### PR TITLE
Feature/brier score

### DIFF
--- a/src/torchmetrics/classification/__init__.py
+++ b/src/torchmetrics/classification/__init__.py
@@ -20,8 +20,8 @@ from torchmetrics.classification.average_precision import (
     MultilabelAveragePrecision,
 )
 from torchmetrics.classification.brier import (
-    Brier,
     BinaryBrier,
+    Brier,
     MulticlassBrier,
     MultilabelBrier,
 )

--- a/src/torchmetrics/classification/brier.py
+++ b/src/torchmetrics/classification/brier.py
@@ -18,14 +18,17 @@ from torch import Tensor
 from typing_extensions import Literal
 
 from torchmetrics.classification.base import _ClassificationTaskWrapper
+from torchmetrics.functional.classification.brier import (
+    _binary_brier_format,
+    _mean_brier_score_and_decomposition,
+    _multiclass_brier_format,
+)
 from torchmetrics.functional.classification.confusion_matrix import (
     _binary_confusion_matrix_arg_validation,
-    _binary_confusion_matrix_compute,
     _binary_confusion_matrix_format,
     _binary_confusion_matrix_tensor_validation,
     _binary_confusion_matrix_update,
     _multiclass_confusion_matrix_arg_validation,
-    _multiclass_confusion_matrix_compute,
     _multiclass_confusion_matrix_format,
     _multiclass_confusion_matrix_tensor_validation,
     _multiclass_confusion_matrix_update,
@@ -35,16 +38,11 @@ from torchmetrics.functional.classification.confusion_matrix import (
     _multilabel_confusion_matrix_tensor_validation,
     _multilabel_confusion_matrix_update,
 )
-from torchmetrics.functional.classification.brier import (
-    _mean_brier_score_and_decomposition,
-    _binary_brier_format,
-    _multiclass_brier_format,
-)
 from torchmetrics.metric import Metric
+from torchmetrics.utilities.data import dim_zero_cat
 from torchmetrics.utilities.enums import ClassificationTask
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _CMAP_TYPE, _PLOT_OUT_TYPE, plot_confusion_matrix
-from torchmetrics.utilities.data import dim_zero_cat
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = [

--- a/src/torchmetrics/functional/classification/brier.py
+++ b/src/torchmetrics/functional/classification/brier.py
@@ -12,21 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Sequence
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import torch
-from torch import Tensor, tensor
-from torch.nn import functional as F  # noqa: N812
+from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.utilities.checks import _check_same_shape
-from torchmetrics.utilities.compute import _safe_divide, interp, normalize_logits_if_needed
-from torchmetrics.utilities.data import _bincount, _cumsum
-from torchmetrics.utilities.enums import ClassificationTask
-from torchmetrics.utilities.prints import rank_zero_warn
-import torch
-import torch.nn.functional as F
+from torchmetrics.utilities.compute import normalize_logits_if_needed
 
 
 def _brier_decomposition(
@@ -62,6 +54,7 @@ def _brier_decomposition(
       resolution: Tensor, scalar, the resolution component of the decomposition.
       reliability: Tensor, scalar, the reliability component of the
         decomposition.
+
     """
     n, nlabels = probabilities.shape  # Implicit rank check.
 
@@ -109,8 +102,8 @@ def _mean_brier_score(labels: torch.Tensor, probabilities: torch.Tensor = None) 
     Returns:
         torch.Tensor: Tensor of shape [N1, N2, ...] consisting of the Brier score contribution
         from each element. The full-dataset Brier score is the average of these values.
-    """
 
+    """
     nlabels = probabilities.shape[-1]
     flat_probabilities = probabilities.view(-1, nlabels)
     flat_labels = labels.view(-1)

--- a/tests/unittests/classification/test_brier.py
+++ b/tests/unittests/classification/test_brier.py
@@ -11,21 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from functools import partial
 
-import numpy as np
-import pytest
-import torch
-from scipy.special import expit as sigmoid
 
 # from sklearn.metrics import brier as sk_brier
 from torch import tensor
 
 from torchmetrics.classification.brier import (
     BinaryBrier,
-    Brier,
     MulticlassBrier,
-    MultilabelBrier,
 )
 
 # from torchmetrics.functional.classification.brier import (
@@ -33,12 +26,8 @@ from torchmetrics.classification.brier import (
 #    multiclass_brier,
 #    multilabel_brier,
 # )
-from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
-from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
-from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
-from unittests.classification._inputs import _binary_cases, _multiclass_cases, _multilabel_cases
+from unittests._helpers.testers import MetricTester
 
 seed_all(42)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2196

Implement Brier score and it's decomposition

- The ECE and other similar calibration metrics such as the TACE, are not proper scoring rules. In particular, an untrained model with no predictive accuracy will minimize the ECE. This pathological behaviour can be fixed by using a proper scoring rule such as the Brier score.
- The Brier score can be decomposed into Uncertainty, Reliability and Resolution. Reliability measures the model's calibration why Resolution correlates with model accuracy. Uncertainty, is the inherent difficulty of the problem.
- The Brier score is used in many papers that evaluate the calibration of classification models. ex https://arxiv.org/abs/2302.04019 https://arxiv.org/abs/2002.06470

I followed the original paper describing the decomposition of the Brier score into resolution, reliability and uncertainty

https://journals.ametsoc.org/view/journals/apme/12/4/1520-0450_1973_012_0595_anvpot_2_0_co_2.xml

and specifically the implementation found in 

https://github.com/google-research/google-research/blob/master/uq_benchmark_2019/metrics_lib.py
and the paper
https://arxiv.org/abs/1906.02530

State of the PR
I added some rudimentary "tests" and the code seems to work for the Binary and Multiclass settings.

@SkafteNicki 

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3270.org.readthedocs.build/en/3270/

<!-- readthedocs-preview torchmetrics end -->