### PR TITLE
Fix: Use tuple for multidimensional indexing in distributed.py

### DIFF
--- a/src/torchmetrics/utilities/distributed.py
+++ b/src/torchmetrics/utilities/distributed.py
@@ -147,7 +147,7 @@ def gather_all_tensors(result: Tensor, group: Optional[Any] = None) -> List[Tens
         torch.distributed.all_gather(gathered_result, result_padded, group)
         for idx, item_size in enumerate(local_sizes):
             slice_param = [slice(dim_size) for dim_size in item_size]
-            gathered_result[idx] = gathered_result[idx][slice_param]
+            gathered_result[idx] = gathered_result[idx][tuple(slice_param)]
     # to propagate autograd graph from local rank
     gathered_result[torch.distributed.get_rank(group)] = result
     return gathered_result


### PR DESCRIPTION
## What does this PR do?

Fixes #3275

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

<br>Fixes UserWarning raised when using non-tuple sequence for multidimensional indexing. <br>
Previously: 
```
gathered_result[idx] = gathered_result[idx][slice_param]
```
Now:
```
gathered_result[idx] = gathered_result[idx][tuple(slice_param)]
```

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3277.org.readthedocs.build/en/3277/

<!-- readthedocs-preview torchmetrics end -->