### PR TITLE
Fix memory issues when computing retrieval metrics with high-valued indices

### DIFF
--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -231,7 +231,7 @@ def _flexible_bincount(x: Tensor) -> Tensor:
 
     """
     unique_x, inverse_indices = torch.unique(x, return_inverse=True)
-    return _bincount(inverse_indices, minlength=len(unique_x))  # type: ignore[arg-type]
+    return _bincount(inverse_indices, minlength=len(unique_x))
 
 
 def allclose(tensor1: Tensor, tensor2: Tensor) -> bool:


### PR DESCRIPTION
## What does this PR do?

Fixes #3290. No update to the docs or new test are required, as far as I can tell. Tests are passing.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Memory usage is now independent of the values of the indices.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3291.org.readthedocs.build/en/3291/

<!-- readthedocs-preview torchmetrics end -->