### PR TITLE
Changing tensor copy to remove user warning in `logAUC`

### DIFF
--- a/src/torchmetrics/functional/classification/logauc.py
+++ b/src/torchmetrics/functional/classification/logauc.py
@@ -49,7 +49,7 @@ def _binary_logauc_compute(
     fpr = torch.cat([fpr, fpr_range]).sort().values
 
     log_fpr = torch.log10(fpr)
-    bounds = torch.log10(torch.tensor(fpr_range))
+    bounds = torch.log10(fpr_range.detach().clone())
 
     lower_bound_idx = torch.where(log_fpr == bounds[0])[0][-1]
     upper_bound_idx = torch.where(log_fpr == bounds[1])[0][-1]


### PR DESCRIPTION
## What does this PR do?

Fixes #3278

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Modified the line that raises userwarning in _binary_logauc_compute function.

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3295.org.readthedocs.build/en/3295/

<!-- readthedocs-preview torchmetrics end -->