### PR TITLE
revert: MSSSIM and SSIM `dist_reduce_fx`  tests when `reduction=None` for distributed training

### DIFF
--- a/tests/unittests/image/__init__.py
+++ b/tests/unittests/image/__init__.py
@@ -13,23 +13,6 @@
 # limitations under the License.
 import os
 
-import torch
-import torch.distributed as dist
-
 from unittests import _PATH_ALL_TESTS
 
 _SAMPLE_IMAGE = os.path.join(_PATH_ALL_TESTS, "_data", "image", "i01_01_5.bmp")
-
-
-def setup_ddp(rank: int, world_size: int, free_port: int):
-    """Set up DDP with a free port and assign CUDA device to the given rank."""
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = str(free_port)
-    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
-    torch.cuda.set_device(rank)
-
-
-def cleanup_ddp():
-    """Clean up the DDP process group if initialized."""
-    if dist.is_initialized():
-        dist.destroy_process_group()

--- a/tests/unittests/image/test_ms_ssim.py
+++ b/tests/unittests/image/test_ms_ssim.py
@@ -15,7 +15,6 @@
 
 import pytest
 import torch
-import torch.multiprocessing as mp
 from pytorch_msssim import ms_ssim
 
 from torchmetrics.functional.image.ssim import multiscale_structural_similarity_index_measure
@@ -23,8 +22,6 @@ from torchmetrics.image.ssim import MultiScaleStructuralSimilarityIndexMeasure
 from unittests import NUM_BATCHES, _Input
 from unittests._helpers import _IS_WINDOWS, seed_all
 from unittests._helpers.testers import MetricTester
-from unittests.image import cleanup_ddp, setup_ddp
-from unittests.utilities.test_utilities import find_free_port
 
 seed_all(42)
 
@@ -108,35 +105,3 @@ def test_ms_ssim_contrast_sensitivity():
         preds, target, data_range=1.0, kernel_size=3, betas=(1.0, 0.5, 0.25)
     )
     assert isinstance(out, torch.Tensor)
-
-
-def _run_ms_ssim_ddp(rank: int, world_size: int, free_port: int):
-    """Run MSSSIM metric computation in a DDP setup."""
-    try:
-        setup_ddp(rank, world_size, free_port)
-        device = torch.device(f"cuda:{rank}")
-        metric = MultiScaleStructuralSimilarityIndexMeasure(reduction="none").to(device)
-
-        for _ in range(3):
-            x, y = torch.rand(4, 3, 224, 224).to(device).chunk(2)
-            metric.update(x, y)
-
-        result = metric.compute()
-        assert isinstance(result, torch.Tensor), "Expected compute result to be a tensor"
-    finally:
-        cleanup_ddp()
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires cuda")
-@pytest.mark.skipif(_IS_WINDOWS, reason="DDP not supported on Windows")
-def test_ms_ssim_reduction_none_ddp():
-    """Fail when reduction='none' and dist_reduce_fx='cat' used with DDP.
-
-    See issue: https://github.com/Lightning-AI/torchmetrics/issues/3159
-
-    """
-    world_size = 2
-    free_port = find_free_port()
-    if free_port == -1:
-        pytest.skip("No free port available for DDP test.")
-    mp.spawn(_run_ms_ssim_ddp, args=(world_size, free_port), nprocs=world_size, join=True)

--- a/tests/unittests/image/test_ms_ssim.py
+++ b/tests/unittests/image/test_ms_ssim.py
@@ -20,7 +20,7 @@ from pytorch_msssim import ms_ssim
 from torchmetrics.functional.image.ssim import multiscale_structural_similarity_index_measure
 from torchmetrics.image.ssim import MultiScaleStructuralSimilarityIndexMeasure
 from unittests import NUM_BATCHES, _Input
-from unittests._helpers import _IS_WINDOWS, seed_all
+from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
 
 seed_all(42)

--- a/tests/unittests/image/test_ssim.py
+++ b/tests/unittests/image/test_ssim.py
@@ -16,7 +16,6 @@ from functools import partial
 import numpy as np
 import pytest
 import torch
-import torch.multiprocessing as mp
 from pytorch_msssim import ssim
 from skimage.metrics import structural_similarity
 from torch import Tensor
@@ -26,8 +25,6 @@ from torchmetrics.image import StructuralSimilarityIndexMeasure
 from unittests import NUM_BATCHES, _Input
 from unittests._helpers import _IS_WINDOWS, seed_all
 from unittests._helpers.testers import MetricTester
-from unittests.image import cleanup_ddp, setup_ddp
-from unittests.utilities.test_utilities import find_free_port
 
 seed_all(42)
 
@@ -363,35 +360,3 @@ def test_ssim_for_correct_padding():
     target[:, :, :, 0] = 0
     target[:, :, :, -1] = 0
     assert structural_similarity_index_measure(preds, target) < 1.0
-
-
-def _run_ssim_ddp(rank: int, world_size: int, free_port: int):
-    """Run SSIM metric computation in a DDP setup."""
-    try:
-        setup_ddp(rank, world_size, free_port)
-        device = torch.device(f"cuda:{rank}")
-        metric = StructuralSimilarityIndexMeasure(reduction="none").to(device)
-
-        for _ in range(3):
-            x, y = torch.rand(4, 3, 224, 224).to(device).chunk(2)
-            metric.update(x, y)
-
-        result = metric.compute()
-        assert isinstance(result, torch.Tensor), "Expected compute result to be a tensor"
-    finally:
-        cleanup_ddp()
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires cuda")
-@pytest.mark.skipif(_IS_WINDOWS, reason="DDP not supported on Windows")
-def test_ssim_reduction_none_ddp():
-    """Fail when reduction='none' and dist_reduce_fx='cat' used with DDP.
-
-    See issue: https://github.com/Lightning-AI/torchmetrics/issues/3159
-
-    """
-    world_size = 2
-    free_port = find_free_port()
-    if free_port == -1:
-        pytest.skip("No free port available for DDP test.")
-    mp.spawn(_run_ssim_ddp, args=(world_size, free_port), nprocs=world_size, join=True)

--- a/tests/unittests/image/test_ssim.py
+++ b/tests/unittests/image/test_ssim.py
@@ -23,7 +23,7 @@ from torch import Tensor
 from torchmetrics.functional import structural_similarity_index_measure
 from torchmetrics.image import StructuralSimilarityIndexMeasure
 from unittests import NUM_BATCHES, _Input
-from unittests._helpers import _IS_WINDOWS, seed_all
+from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
 
 seed_all(42)

--- a/tests/unittests/utilities/test_utilities.py
+++ b/tests/unittests/utilities/test_utilities.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import socket
 import sys
 
 import numpy as np
@@ -20,7 +19,6 @@ import torch
 from lightning_utilities.test.warning import no_warning_call
 from torch import tensor
 from unittests._helpers import _IS_WINDOWS
-from unittests.conftest import MAX_PORT, START_PORT
 
 from torchmetrics.regression import MeanSquaredError, PearsonCorrCoef
 from torchmetrics.utilities import check_forward_full_state_property, rank_zero_debug, rank_zero_info, rank_zero_warn
@@ -240,15 +238,3 @@ def test_half_precision_top_k_cpu_raises_error():
     x = torch.randn(100, 10, dtype=torch.half)
     with pytest.raises(RuntimeError, match="\"topk_cpu\" not implemented for 'Half'"):
         torch.topk(x, k=3, dim=1)
-
-
-def find_free_port(start=START_PORT, end=MAX_PORT):
-    """Returns an available localhost port in the given range or returns -1 if no port available."""
-    for port in range(start, end + 1):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            try:
-                s.bind(("localhost", port))
-                return port
-            except OSError:
-                continue
-    return -1


### PR DESCRIPTION

## What does this PR do?

Reverts the tests introduced in https://github.com/Lightning-AI/torchmetrics/pull/3166 and unblocks the CI.
Ref: https://github.com/Lightning-AI/torchmetrics/pull/3298
@Borda @SkafteNicki @lantiga @justusschock 

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3315.org.readthedocs.build/en/3315/

<!-- readthedocs-preview torchmetrics end -->