### PR TITLE
fix: add tuple cast to avoid nd slicing deprecation warning

### DIFF
--- a/src/torchmetrics/utilities/distributed.py
+++ b/src/torchmetrics/utilities/distributed.py
@@ -19,7 +19,7 @@ from torch.nn import functional as F  # noqa: N812
 from typing_extensions import Literal
 
 
-def reduce(x: Tensor, reduction: Literal["elementwise_mean", "sum", "none", None]) -> Tensor:
+def reduce(x: Tensor, reduction: Optional[Literal["elementwise_mean", "sum", "none"]]) -> Tensor:
     """Reduces a given tensor by a given reduction method.
 
     Args:
@@ -46,7 +46,7 @@ def class_reduce(
     num: Tensor,
     denom: Tensor,
     weights: Tensor,
-    class_reduction: Literal["micro", "macro", "weighted", "none", None] = "none",
+    class_reduction: Optional[Literal["micro", "macro", "weighted", "none"]] = "none",
 ) -> Tensor:
     """Reduce classification metrics of the form ``num / denom * weights``.
 
@@ -147,7 +147,7 @@ def gather_all_tensors(result: Tensor, group: Optional[Any] = None) -> List[Tens
         torch.distributed.all_gather(gathered_result, result_padded, group)
         for idx, item_size in enumerate(local_sizes):
             slice_param = [slice(dim_size) for dim_size in item_size]
-            gathered_result[idx] = gathered_result[idx][slice_param]
+            gathered_result[idx] = gathered_result[idx][tuple(slice_param)]
     # to propagate autograd graph from local rank
     gathered_result[torch.distributed.get_rank(group)] = result
     return gathered_result


### PR DESCRIPTION
Signed-off-by: Kyle Mylonakis <kyle@protopia.ai>

## What does this PR do?

Duplicates https://github.com/Lightning-AI/torchmetrics/pull/3277 which was abandoned.

Fixes #3275

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR Summary</summary>

Fixes UserWarning raised when using non-tuple sequence for multidimensional indexing.

Previously:

gathered_result[idx] = gathered_result[idx][slice_param]
Now:

gathered_result[idx] = gathered_result[idx][tuple(slice_param)]
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged

</details>

## Did you have fun?
Yup

