### PR TITLE
fix(image): lazy-import torchvision in arniqa and dists modules

### DIFF
--- a/src/torchmetrics/functional/image/arniqa.py
+++ b/src/torchmetrics/functional/image/arniqa.py
@@ -27,10 +27,6 @@ from typing_extensions import Literal
 
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_2, _TORCHVISION_AVAILABLE
 
-if _TORCHVISION_AVAILABLE:
-    from torchvision import transforms
-    from torchvision.models import resnet50
-
 _AVAILABLE_REGRESSOR_DATASETS = {
     "kadid10k": (1, 5),
     "koniq10k": (1, 100),
@@ -64,6 +60,8 @@ class _ARNIQA(nn.Module):
                 "ARNIQA metric requires that torchvision is installed."
                 " Either install as `pip install torchmetrics[image]` or `pip install torchvision`."
             )
+
+        from torchvision.models import resnet50
 
         valid_regressor_datasets = _AVAILABLE_REGRESSOR_DATASETS.keys()
         if regressor_dataset not in valid_regressor_datasets:
@@ -116,6 +114,8 @@ class _ARNIQA(nn.Module):
         Obtains the half-scale version of the input image and applies normalization if needed.
 
         """
+        from torchvision import transforms
+
         h, w = img.shape[-2:]
         img_ds = transforms.Resize((h // 2, w // 2))(img)  # get the half-scale version of the image
         if normalize:

--- a/src/torchmetrics/functional/image/dists.py
+++ b/src/torchmetrics/functional/image/dists.py
@@ -47,8 +47,6 @@ from torchmetrics.utilities.imports import _TORCHVISION_AVAILABLE
 
 if not _TORCHVISION_AVAILABLE:
     __doctest_skip__ = ["deep_image_structure_and_texture_similarity"]
-else:
-    from torchvision.models import VGG16_Weights, vgg16
 
 _PATH_WEIGHT_DISTS = Path(__file__).resolve().parent / "dists_models" / "weights.pt"
 
@@ -90,6 +88,8 @@ class DISTSNetwork(torch.nn.Module):
             raise ModuleNotFoundError(
                 "DISTS requires torchvision to be installed. Please install it with `pip install torchvision`."
             )
+
+        from torchvision.models import VGG16_Weights, vgg16
 
         vgg_pretrained_features = vgg16(weights=VGG16_Weights.DEFAULT).features
         self.stage1 = torch.nn.Sequential()


### PR DESCRIPTION
## Summary

`arniqa.py` and `dists.py` imported symbols from `torchvision` at module load
time inside an `if _TORCHVISION_AVAILABLE:` / `else:` guard.  Because that
block executes unconditionally when torchvision *is* installed, it triggered
torchvision's own `__init__` chain the moment `torchmetrics.functional.image`
was imported.  In environments where torchvision's initialisation races with
itself (e.g. Kaggle's GPU runtime, or any build where
`torchvision._meta_registrations` tries to import `torchvision.extension`
before `torchvision` itself is fully loaded), the eager import raised an
`AttributeError: partially initialized module 'torchvision' has no attribute
'extension'`, breaking `from torchmetrics.image.lpip import
LearnedPerceptualImagePatchSimilarity` and every other top-level import of
`torchmetrics`.

The fix moves the `from torchvision import ...` / `from torchvision.models
import ...` statements inside the class constructors and methods that actually
use them, matching the lazy-import pattern that `lpips.py` already uses
(`import torchvision` inside `_get_tv_model_features`).  The `if not
_TORCHVISION_AVAILABLE: raise ModuleNotFoundError` guard already runs first, so
behaviour is unchanged when torchvision is absent.

## Issue

Fixes #3314

## Local verification

```
$ cd /tmp/torchmetrics
$ ruff check src/torchmetrics/functional/image/arniqa.py \
             src/torchmetrics/functional/image/dists.py
All checks passed!

$ python3 -m pytest tests/unittests/image/test_arniqa.py::test_error_on_wrong_init \
                    tests/unittests/image/test_arniqa.py::test_error_on_wrong_input_shape \
                    tests/unittests/image/test_arniqa.py::test_error_on_wrong_normalize_value \
                    tests/unittests/image/test_arniqa.py::test_check_for_backprop -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
plugins: rerunfailures-16.1, plus-0.8.1, xdist-3.8.0, doctestplus-1.7.1
collected 4 items

tests/unittests/image/test_arniqa.py::test_error_on_wrong_init PASSED   [ 25%]
tests/unittests/image/test_arniqa.py::test_error_on_wrong_input_shape PASSED   [ 50%]
tests/unittests/image/test_arniqa.py::test_error_on_wrong_normalize_value PASSED   [ 75%]
tests/unittests/image/test_arniqa.py::test_check_for_backprop PASSED    [100%]

======================== 4 passed, 8 warnings in 4.39s =========================

$ python3 -c "
import sys
for mod in list(sys.modules.keys()):
    if 'torchmetrics' in mod or 'torchvision' in mod:
        del sys.modules[mod]

import builtins; orig = builtins.__import__
eager = []
def tracing(name, g=None, l=None, fl=(), lv=0):
    if 'torchvision' in name and not name.startswith('torchvision'):
        import traceback
        for fr in reversed(traceback.extract_stack()[:-2]):
            if 'torchmetrics' in (fr.filename or '') and 'arniqa' in fr.filename:
                eager.append(name)
                break
            if 'torchmetrics' in (fr.filename or '') and 'dists' in fr.filename:
                eager.append(name)
                break
    return orig(name, g, l, fl, lv)
builtins.__import__ = tracing

import torchmetrics.functional.image
builtins.__import__ = orig
print('eager torchvision imports from arniqa/dists:', eager)
assert not eager, 'still importing torchvision eagerly!'
print('PASS')
"
eager torchvision imports from arniqa/dists: []
PASS
=== LOCAL_TEST_PASSED ===
```

## Risk

The change only affects import time: symbols that were previously imported once
at module load are now imported on first use inside their respective
constructor/method.  Python caches modules in `sys.modules`, so the runtime
cost per call is negligible (a dict lookup).  The `lpips.py` module already
uses this pattern successfully, confirming it is safe within this code base.
Users who do not have torchvision installed will continue to see the existing
`ModuleNotFoundError` on first instantiation.


<!-- readthedocs-preview torchmetrics start -->
----
📚 Documentation preview 📚: https://torchmetrics--3373.org.readthedocs.build/en/3373/

<!-- readthedocs-preview torchmetrics end -->