### PR TITLE
feat(segmentation): add boundary f-score metric

### DIFF
--- a/docs/source/segmentation/boundary_f_score.rst
+++ b/docs/source/segmentation/boundary_f_score.rst
@@ -12,6 +12,35 @@ Boundary F-score
 Boundary F-score is useful when contour alignment matters more than region overlap. Unlike Dice or IoU, it evaluates
 whether predicted and target boundaries match within a configurable pixel tolerance.
 
+When to use
+___________
+
+Boundary F-score is a good fit when small contour shifts matter. Region-overlap metrics such as Dice or IoU can stay
+high even when object outlines are visibly misaligned, while Boundary F-score focuses directly on boundary agreement.
+
+Behavior notes
+______________
+
+- ``boundary_width`` is an integer pixel tolerance for 2D masks and an integer voxel tolerance for 3D volumes.
+- Classes that have no boundary pixels in either prediction or target return ``nan`` in per-class outputs.
+- When reducing across classes, these absent classes are ignored instead of lowering the reduced score.
+
+Limitations
+___________
+
+- integer pixel/voxel tolerance only
+- no spacing-aware tolerance yet
+- no ratio-based tolerance yet
+- no BoundaryIoU yet
+
+Future work
+___________
+
+- BoundaryIoU
+- ratio-based tolerance
+- spacing-aware tolerance
+- comparison examples with Dice, IoU, HausdorffDistance, and Boundary F-score
+
 Module Interface
 ________________
 

--- a/docs/source/segmentation/boundary_f_score.rst
+++ b/docs/source/segmentation/boundary_f_score.rst
@@ -1,0 +1,24 @@
+.. customcarditem::
+   :header: Boundary F-score
+   :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/text_classification.svg
+   :tags: segmentation
+
+.. include:: ../links.rst
+
+################
+Boundary F-score
+################
+
+Boundary F-score is useful when contour alignment matters more than region overlap. Unlike Dice or IoU, it evaluates
+whether predicted and target boundaries match within a configurable pixel tolerance.
+
+Module Interface
+________________
+
+.. autoclass:: torchmetrics.segmentation.BoundaryFScore
+    :exclude-members: update, compute
+
+Functional Interface
+____________________
+
+.. autofunction:: torchmetrics.functional.segmentation.boundary_f_score

--- a/src/torchmetrics/functional/segmentation/__init__.py
+++ b/src/torchmetrics/functional/segmentation/__init__.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from torchmetrics.functional.segmentation.boundary_f_score import boundary_f_score
 from torchmetrics.functional.segmentation.dice import dice_score
 from torchmetrics.functional.segmentation.generalized_dice import generalized_dice_score
 from torchmetrics.functional.segmentation.hausdorff_distance import hausdorff_distance
 from torchmetrics.functional.segmentation.mean_iou import mean_iou
 
-__all__ = ["dice_score", "generalized_dice_score", "hausdorff_distance", "mean_iou"]
+__all__ = ["boundary_f_score", "dice_score", "generalized_dice_score", "hausdorff_distance", "mean_iou"]

--- a/src/torchmetrics/functional/segmentation/boundary_f_score.py
+++ b/src/torchmetrics/functional/segmentation/boundary_f_score.py
@@ -130,7 +130,8 @@ def boundary_f_score(
     final score is the harmonic mean of boundary precision and boundary recall.
 
     This implementation supports 2D and 3D segmentation masks. Classes that are absent in both prediction and target
-    return ``nan`` in the per-class output and are ignored when reducing across classes.
+    return ``nan`` in the per-class output and are ignored when reducing across classes. The tolerance is expressed in
+    pixels for 2D masks and voxels for 3D volumes.
 
     Args:
         preds: Predictions from model.
@@ -166,6 +167,18 @@ def boundary_f_score(
         >>> target[:, 2:6, 2:6] = 1
         >>> boundary_f_score(preds, target, num_classes=2, input_format="index")
         tensor([1., 1.])
+
+    Example (tolerance sensitivity):
+        >>> import torch
+        >>> from torchmetrics.functional.segmentation import boundary_f_score
+        >>> preds = torch.zeros(1, 8, 8, dtype=torch.long)
+        >>> target = torch.zeros(1, 8, 8, dtype=torch.long)
+        >>> preds[:, 2:6, 2:6] = 1
+        >>> target[:, 2:6, 3:7] = 1
+        >>> strict = boundary_f_score(preds, target, num_classes=2, input_format="index", boundary_width=0)
+        >>> tolerant = boundary_f_score(preds, target, num_classes=2, input_format="index", boundary_width=1)
+        >>> bool(strict.item() < tolerant.item())
+        True
 
     """
     _boundary_f_score_validate_args(num_classes, include_background, per_class, boundary_width, input_format)

--- a/src/torchmetrics/functional/segmentation/boundary_f_score.py
+++ b/src/torchmetrics/functional/segmentation/boundary_f_score.py
@@ -1,0 +1,182 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from torch import Tensor
+from torch.nn.functional import max_pool2d, max_pool3d
+from typing_extensions import Literal
+
+from torchmetrics.functional.segmentation.utils import _segmentation_inputs_format, binary_erosion
+from torchmetrics.utilities.compute import _safe_divide
+
+
+def _boundary_f_score_validate_args(
+    num_classes: int,
+    include_background: bool,
+    per_class: bool,
+    boundary_width: int,
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+) -> None:
+    """Validate the arguments of the boundary F-score metric."""
+    if not isinstance(num_classes, int) or num_classes <= 0:
+        raise ValueError(f"Expected argument `num_classes` to be a positive integer, but got {num_classes}.")
+    if not isinstance(include_background, bool):
+        raise ValueError(f"Expected argument `include_background` to be a boolean, but got {include_background}.")
+    if not isinstance(per_class, bool):
+        raise ValueError(f"Expected argument `per_class` to be a boolean, but got {per_class}.")
+    if not isinstance(boundary_width, int) or boundary_width < 0:
+        raise ValueError(
+            f"Expected argument `boundary_width` to be a non-negative integer, but got {boundary_width}."
+        )
+    if input_format not in ["one-hot", "index", "mixed"]:
+        raise ValueError(
+            f"Expected argument `input_format` to be one of 'one-hot', 'index', 'mixed', but got {input_format}."
+        )
+
+
+def _boundary_f_score_extract_boundaries(mask: Tensor) -> Tensor:
+    """Extract mask boundaries using binary erosion."""
+    spatial_shape = mask.shape[2:]
+    mask = mask.bool()
+    eroded = binary_erosion(mask.reshape(-1, 1, *spatial_shape).byte()).reshape_as(mask).bool()
+    return mask & ~eroded
+
+
+def _boundary_f_score_dilate_boundaries(boundaries: Tensor, boundary_width: int) -> Tensor:
+    """Dilate boundaries by a pixel tolerance."""
+    if boundary_width == 0:
+        return boundaries
+
+    kernel_size = 2 * boundary_width + 1
+    if boundaries.ndim == 4:
+        return max_pool2d(boundaries.float(), kernel_size=kernel_size, stride=1, padding=boundary_width) > 0
+    if boundaries.ndim == 5:
+        return max_pool3d(boundaries.float(), kernel_size=kernel_size, stride=1, padding=boundary_width) > 0
+    raise ValueError(
+        "Expected `preds` and `target` to have 2D or 3D spatial dimensions after formatting, "
+        f"but got tensors with shape {boundaries.shape}."
+    )
+
+
+def _boundary_f_score_update(
+    preds: Tensor,
+    target: Tensor,
+    num_classes: int,
+    include_background: bool,
+    boundary_width: int,
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+) -> tuple[Tensor, Tensor]:
+    """Calculate per-sample and per-class boundary F-scores and a validity mask."""
+    preds, target = _segmentation_inputs_format(preds, target, include_background, num_classes, input_format)
+
+    if preds.ndim not in (4, 5):
+        raise ValueError(
+            "Expected `preds` and `target` to have 2D or 3D spatial dimensions after formatting, "
+            f"but got tensors with shape {preds.shape}."
+        )
+
+    preds = preds.bool()
+    target = target.bool()
+
+    pred_boundaries = _boundary_f_score_extract_boundaries(preds)
+    target_boundaries = _boundary_f_score_extract_boundaries(target)
+
+    dilated_pred_boundaries = _boundary_f_score_dilate_boundaries(pred_boundaries, boundary_width)
+    dilated_target_boundaries = _boundary_f_score_dilate_boundaries(target_boundaries, boundary_width)
+
+    reduce_axis = tuple(range(2, preds.ndim))
+    pred_boundary_area = pred_boundaries.sum(dim=reduce_axis)
+    target_boundary_area = target_boundaries.sum(dim=reduce_axis)
+    matched_pred_boundary = (pred_boundaries & dilated_target_boundaries).sum(dim=reduce_axis)
+    matched_target_boundary = (target_boundaries & dilated_pred_boundaries).sum(dim=reduce_axis)
+
+    precision = _safe_divide(matched_pred_boundary, pred_boundary_area, zero_division=0.0)
+    recall = _safe_divide(matched_target_boundary, target_boundary_area, zero_division=0.0)
+    score = _safe_divide(2 * precision * recall, precision + recall, zero_division=0.0)
+
+    valid = (pred_boundary_area > 0) | (target_boundary_area > 0)
+    score = score.masked_fill(~valid, float("nan"))
+    return score, valid
+
+
+def _boundary_f_score_compute(score: Tensor, valid: Tensor, per_class: bool) -> Tensor:
+    """Reduce boundary F-scores across classes when requested."""
+    if per_class:
+        return score
+    return _safe_divide(torch.nan_to_num(score, nan=0.0).sum(dim=-1), valid.sum(dim=-1), zero_division="nan")
+
+
+def boundary_f_score(
+    preds: Tensor,
+    target: Tensor,
+    num_classes: int,
+    include_background: bool = True,
+    per_class: bool = False,
+    boundary_width: int = 1,
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+) -> Tensor:
+    """Compute the Boundary F-score for semantic segmentation.
+
+    Boundary F-score evaluates how well predicted object contours align with target contours. A predicted boundary
+    pixel counts as correct if a target boundary pixel exists within ``boundary_width`` pixels, and vice versa. The
+    final score is the harmonic mean of boundary precision and boundary recall.
+
+    This implementation supports 2D and 3D segmentation masks. Classes that are absent in both prediction and target
+    return ``nan`` in the per-class output and are ignored when reducing across classes.
+
+    Args:
+        preds: Predictions from model.
+        target: Ground truth values.
+        num_classes: Number of classes in the segmentation problem.
+        include_background: Whether to include the background class in the computation.
+        per_class: Whether to return class-wise scores instead of reducing across classes.
+        boundary_width: Integer pixel tolerance used when matching predicted and target boundaries.
+        input_format: What kind of input the function receives.
+            Choose between ``"one-hot"`` for one-hot encoded tensors, ``"index"`` for index tensors
+            or ``"mixed"`` for one one-hot encoded and one index tensor.
+
+    Returns:
+        If ``per_class=False``, a tensor of shape ``(N,)`` with one score per sample. If ``per_class=True``, a tensor
+        of shape ``(N, C)`` with one score per sample and class.
+
+    Example (with one-hot encoded tensors):
+        >>> import torch
+        >>> from torchmetrics.functional.segmentation import boundary_f_score
+        >>> preds = torch.zeros(2, 3, 8, 8, dtype=torch.int)
+        >>> target = torch.zeros(2, 3, 8, 8, dtype=torch.int)
+        >>> preds[:, 1, 2:6, 2:6] = 1
+        >>> target[:, 1, 2:6, 2:6] = 1
+        >>> boundary_f_score(preds, target, num_classes=3)
+        tensor([1., 1.])
+
+    Example (with index tensors):
+        >>> import torch
+        >>> from torchmetrics.functional.segmentation import boundary_f_score
+        >>> preds = torch.zeros(2, 8, 8, dtype=torch.long)
+        >>> target = torch.zeros(2, 8, 8, dtype=torch.long)
+        >>> preds[:, 2:6, 2:6] = 1
+        >>> target[:, 2:6, 2:6] = 1
+        >>> boundary_f_score(preds, target, num_classes=2, input_format="index")
+        tensor([1., 1.])
+
+    """
+    _boundary_f_score_validate_args(num_classes, include_background, per_class, boundary_width, input_format)
+    score, valid = _boundary_f_score_update(
+        preds,
+        target,
+        num_classes=num_classes,
+        include_background=include_background,
+        boundary_width=boundary_width,
+        input_format=input_format,
+    )
+    return _boundary_f_score_compute(score, valid, per_class)

--- a/src/torchmetrics/functional/segmentation/boundary_f_score.py
+++ b/src/torchmetrics/functional/segmentation/boundary_f_score.py
@@ -35,9 +35,7 @@ def _boundary_f_score_validate_args(
     if not isinstance(per_class, bool):
         raise ValueError(f"Expected argument `per_class` to be a boolean, but got {per_class}.")
     if not isinstance(boundary_width, int) or boundary_width < 0:
-        raise ValueError(
-            f"Expected argument `boundary_width` to be a non-negative integer, but got {boundary_width}."
-        )
+        raise ValueError(f"Expected argument `boundary_width` to be a non-negative integer, but got {boundary_width}.")
     if input_format not in ["one-hot", "index", "mixed"]:
         raise ValueError(
             f"Expected argument `input_format` to be one of 'one-hot', 'index', 'mixed', but got {input_format}."

--- a/src/torchmetrics/segmentation/__init__.py
+++ b/src/torchmetrics/segmentation/__init__.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from torchmetrics.segmentation.boundary_f_score import BoundaryFScore
 from torchmetrics.segmentation.dice import DiceScore
 from torchmetrics.segmentation.generalized_dice import GeneralizedDiceScore
 from torchmetrics.segmentation.hausdorff_distance import HausdorffDistance
 from torchmetrics.segmentation.mean_iou import MeanIoU
 
-__all__ = ["DiceScore", "GeneralizedDiceScore", "HausdorffDistance", "MeanIoU"]
+__all__ = ["BoundaryFScore", "DiceScore", "GeneralizedDiceScore", "HausdorffDistance", "MeanIoU"]

--- a/src/torchmetrics/segmentation/boundary_f_score.py
+++ b/src/torchmetrics/segmentation/boundary_f_score.py
@@ -37,7 +37,9 @@ class BoundaryFScore(Metric):
 
     Boundary F-score evaluates how well predicted object contours align with target contours. A predicted boundary
     pixel counts as correct if a target boundary pixel exists within ``boundary_width`` pixels, and vice versa. The
-    final score is the harmonic mean of boundary precision and boundary recall.
+    final score is the harmonic mean of boundary precision and boundary recall. The tolerance is expressed in pixels
+    for 2D masks and voxels for 3D volumes. Classes that are absent in both prediction and target are ignored in
+    reduced outputs and return ``nan`` when reported per class.
 
     As input to ``forward`` and ``update`` the metric accepts the following input:
 

--- a/src/torchmetrics/segmentation/boundary_f_score.py
+++ b/src/torchmetrics/segmentation/boundary_f_score.py
@@ -1,0 +1,169 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections.abc import Sequence
+from typing import Any, Optional, Union
+
+import torch
+from torch import Tensor
+from typing_extensions import Literal
+
+from torchmetrics.functional.segmentation.boundary_f_score import (
+    _boundary_f_score_compute,
+    _boundary_f_score_update,
+    _boundary_f_score_validate_args,
+)
+from torchmetrics.metric import Metric
+from torchmetrics.utilities.compute import _safe_divide
+from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
+from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+
+if not _MATPLOTLIB_AVAILABLE:
+    __doctest_skip__ = ["BoundaryFScore.plot"]
+
+
+class BoundaryFScore(Metric):
+    r"""Compute the Boundary F-score for semantic segmentation.
+
+    Boundary F-score evaluates how well predicted object contours align with target contours. A predicted boundary
+    pixel counts as correct if a target boundary pixel exists within ``boundary_width`` pixels, and vice versa. The
+    final score is the harmonic mean of boundary precision and boundary recall.
+
+    As input to ``forward`` and ``update`` the metric accepts the following input:
+
+        - ``preds`` (:class:`~torch.Tensor`): An one-hot boolean tensor of shape ``(N, C, ...)`` with ``N`` being
+          the number of samples and ``C`` the number of classes. Alternatively, an integer tensor of shape ``(N, ...)``
+          can be provided, where the integer values correspond to the class index. The input type can be controlled
+          with the ``input_format`` argument.
+        - ``target`` (:class:`~torch.Tensor`): An one-hot boolean tensor of shape ``(N, C, ...)`` with ``N`` being
+          the number of samples and ``C`` the number of classes. Alternatively, an integer tensor of shape ``(N, ...)``
+          can be provided, where the integer values correspond to the class index. The input type can be controlled
+          with the ``input_format`` argument.
+
+    As output to ``forward`` and ``compute`` the metric returns the following output:
+
+        - ``boundary_f_score`` (:class:`~torch.Tensor`): The boundary F-score. If ``per_class`` is set to ``True``,
+          the output will be a tensor of shape ``(C,)`` with one score per class. If ``per_class`` is set to
+          ``False``, the output will be a scalar tensor.
+
+    Args:
+        num_classes: The number of classes in the segmentation problem.
+        include_background: Whether to include the background class in the computation.
+        per_class: Whether to compute the score for each class separately, else average over all valid classes.
+        boundary_width: Integer pixel tolerance used when matching predicted and target boundaries.
+        input_format: What kind of input the function receives.
+            Choose between ``"one-hot"`` for one-hot encoded tensors, ``"index"`` for index tensors
+            or ``"mixed"`` for one one-hot encoded and one index tensor.
+        kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
+
+    Example:
+        >>> import torch
+        >>> from torchmetrics.segmentation import BoundaryFScore
+        >>> preds = torch.zeros(2, 3, 8, 8, dtype=torch.int)
+        >>> target = torch.zeros(2, 3, 8, 8, dtype=torch.int)
+        >>> preds[:, 1, 2:6, 2:6] = 1
+        >>> target[:, 1, 2:6, 2:6] = 1
+        >>> metric = BoundaryFScore(num_classes=3)
+        >>> metric(preds, target)
+        tensor(1.)
+
+    """
+
+    score: Tensor
+    samples: Tensor
+    full_state_update: bool = False
+    is_differentiable: bool = False
+    higher_is_better: bool = True
+    plot_lower_bound: float = 0.0
+    plot_upper_bound: float = 1.0
+
+    def __init__(
+        self,
+        num_classes: int,
+        include_background: bool = True,
+        per_class: bool = False,
+        boundary_width: int = 1,
+        input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        _boundary_f_score_validate_args(num_classes, include_background, per_class, boundary_width, input_format)
+        self.num_classes = num_classes
+        self.include_background = include_background
+        self.per_class = per_class
+        self.boundary_width = boundary_width
+        self.input_format = input_format
+
+        num_classes = num_classes - 1 if not include_background else num_classes
+        self.add_state("score", default=torch.zeros(num_classes if per_class else 1), dist_reduce_fx="sum")
+        self.add_state(
+            "samples",
+            default=torch.zeros(num_classes if per_class else 1, dtype=torch.long),
+            dist_reduce_fx="sum",
+        )
+
+    def update(self, preds: Tensor, target: Tensor) -> None:
+        """Update the state with new data."""
+        score, valid = _boundary_f_score_update(
+            preds,
+            target,
+            num_classes=self.num_classes,
+            include_background=self.include_background,
+            boundary_width=self.boundary_width,
+            input_format=self.input_format,
+        )
+        if self.per_class:
+            self.score += torch.nan_to_num(score, nan=0.0).sum(dim=0)
+            self.samples += valid.sum(dim=0)
+            return
+
+        reduced_score = _boundary_f_score_compute(score, valid, per_class=False)
+        valid_samples = valid.any(dim=-1)
+        self.score += torch.nan_to_num(reduced_score, nan=0.0).sum().unsqueeze(0)
+        self.samples += valid_samples.sum().unsqueeze(0)
+
+    def compute(self) -> Tensor:
+        """Compute the final boundary F-score."""
+        score = _safe_divide(self.score, self.samples, zero_division="nan")
+        return score if self.per_class else score.squeeze()
+
+    def plot(self, val: Union[Tensor, Sequence[Tensor], None] = None, ax: Optional[_AX_TYPE] = None) -> _PLOT_OUT_TYPE:
+        """Plot a single or multiple values from the metric.
+
+        Args:
+            val: Either a single result from calling `metric.forward` or `metric.compute` or a list of these results.
+                If no value is provided, will automatically call `metric.compute` and plot that result.
+            ax: An matplotlib axis object. If provided will add plot to that axis
+
+        Returns:
+            Figure and Axes object
+
+        Raises:
+            ModuleNotFoundError:
+                If `matplotlib` is not installed
+
+        .. plot::
+            :scale: 75
+
+            >>> import torch
+            >>> from torchmetrics.segmentation import BoundaryFScore
+            >>> metric = BoundaryFScore(num_classes=2)
+            >>> preds = torch.zeros(2, 2, 16, 16, dtype=torch.int)
+            >>> target = torch.zeros(2, 2, 16, 16, dtype=torch.int)
+            >>> preds[:, 1, 4:12, 4:12] = 1
+            >>> target[:, 1, 4:12, 4:12] = 1
+            >>> metric.update(preds, target)
+            >>> fig_, ax_ = metric.plot()
+
+        """
+        return self._plot(val, ax)

--- a/tests/unittests/segmentation/test_boundary_f_score.py
+++ b/tests/unittests/segmentation/test_boundary_f_score.py
@@ -1,0 +1,291 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import partial
+
+import numpy as np
+import pytest
+import torch
+from scipy.ndimage import binary_dilation, binary_erosion, generate_binary_structure
+
+from torchmetrics.functional.segmentation.boundary_f_score import boundary_f_score
+from torchmetrics.segmentation.boundary_f_score import BoundaryFScore
+from unittests import NUM_CLASSES
+from unittests._helpers import seed_all
+from unittests._helpers.testers import MetricTester
+from unittests.segmentation.inputs import (
+    _index_input_1,
+    _mixed_input_1,
+    _mixed_input_2,
+    _mixed_logits_input,
+    _one_hot_input_1,
+    _one_hot_input_2,
+)
+
+seed_all(42)
+
+
+def _format_reference_inputs(
+    preds: torch.Tensor,
+    target: torch.Tensor,
+    input_format: str,
+    num_classes: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Format predictions and targets to one-hot tensors for the reference implementation."""
+    if input_format == "one-hot":
+        if torch.is_floating_point(preds):
+            preds = preds.argmax(dim=1)
+            preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
+        if torch.is_floating_point(target):
+            target = target.argmax(dim=1)
+            target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+        return preds, target
+
+    if input_format == "index":
+        preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
+        target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+        return preds, target
+
+    if preds.dim() == (target.dim() + 1):
+        if torch.is_floating_point(preds):
+            preds = preds.argmax(dim=1)
+            preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
+        target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+        return preds, target
+
+    if torch.is_floating_point(target):
+        target = target.argmax(dim=1)
+        target = torch.nn.functional.one_hot(target, num_classes=num_classes).movedim(-1, 1)
+    preds = torch.nn.functional.one_hot(preds, num_classes=num_classes).movedim(-1, 1)
+    return preds, target
+
+
+def _reference_boundary_score_for_mask(
+    pred_mask: np.ndarray,
+    target_mask: np.ndarray,
+    boundary_width: int,
+) -> float:
+    """Reference boundary F-score for a single binary mask pair."""
+    structure = generate_binary_structure(pred_mask.ndim, 1)
+    pred_boundary = pred_mask & ~binary_erosion(pred_mask, structure=structure)
+    target_boundary = target_mask & ~binary_erosion(target_mask, structure=structure)
+
+    pred_boundary_area = pred_boundary.sum()
+    target_boundary_area = target_boundary.sum()
+    if pred_boundary_area == 0 and target_boundary_area == 0:
+        return float("nan")
+
+    if boundary_width > 0:
+        dilation_structure = np.ones((2 * boundary_width + 1,) * pred_mask.ndim, dtype=bool)
+        pred_neighborhood = binary_dilation(pred_boundary, structure=dilation_structure)
+        target_neighborhood = binary_dilation(target_boundary, structure=dilation_structure)
+    else:
+        pred_neighborhood = pred_boundary
+        target_neighborhood = target_boundary
+
+    matched_pred = np.logical_and(pred_boundary, target_neighborhood).sum()
+    matched_target = np.logical_and(target_boundary, pred_neighborhood).sum()
+
+    precision = matched_pred / pred_boundary_area if pred_boundary_area > 0 else 0.0
+    recall = matched_target / target_boundary_area if target_boundary_area > 0 else 0.0
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _reference_boundary_f_score(
+    preds: torch.Tensor,
+    target: torch.Tensor,
+    input_format: str,
+    num_classes: int,
+    include_background: bool = True,
+    per_class: bool = True,
+    boundary_width: int = 1,
+    reduce: bool = True,
+) -> torch.Tensor:
+    """Reference implementation of the boundary F-score."""
+    preds, target = _format_reference_inputs(preds, target, input_format, num_classes)
+    if not include_background:
+        preds = preds[:, 1:]
+        target = target[:, 1:]
+
+    preds = preds.bool().cpu().numpy()
+    target = target.bool().cpu().numpy()
+
+    scores = torch.tensor(
+        [
+            [
+                _reference_boundary_score_for_mask(pred_mask, target_mask, boundary_width)
+                for pred_mask, target_mask in zip(pred_sample, target_sample)
+            ]
+            for pred_sample, target_sample in zip(preds, target)
+        ],
+        dtype=torch.float32,
+    )
+
+    if not per_class:
+        scores = torch.nanmean(scores, dim=-1)
+
+    return torch.nanmean(scores, dim=0) if reduce else scores
+
+
+@pytest.mark.parametrize(
+    ("preds", "target", "input_format"),
+    [
+        (_one_hot_input_1.preds, _one_hot_input_1.target, "one-hot"),
+        (_one_hot_input_2.preds, _one_hot_input_2.target, "one-hot"),
+        (_index_input_1.preds, _index_input_1.target, "index"),
+        (_mixed_input_1.preds, _mixed_input_1.target, "mixed"),
+        (_mixed_input_2.preds, _mixed_input_2.target, "mixed"),
+        (_mixed_logits_input.preds, _mixed_logits_input.target, "mixed"),
+    ],
+)
+@pytest.mark.parametrize("include_background", [True, False])
+@pytest.mark.parametrize("per_class", [True, False])
+@pytest.mark.parametrize("boundary_width", [0, 1])
+class TestBoundaryFScore(MetricTester):
+    """Test class for `BoundaryFScore` metric."""
+
+    atol = 1e-4
+
+    @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
+    def test_boundary_f_score_class(
+        self, preds, target, input_format, include_background, per_class, boundary_width, ddp
+    ):
+        """Test class implementation of metric."""
+        self.run_class_metric_test(
+            ddp=ddp,
+            preds=preds,
+            target=target,
+            metric_class=BoundaryFScore,
+            reference_metric=partial(
+                _reference_boundary_f_score,
+                input_format=input_format,
+                num_classes=NUM_CLASSES,
+                include_background=include_background,
+                per_class=per_class,
+                boundary_width=boundary_width,
+                reduce=True,
+            ),
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "include_background": include_background,
+                "per_class": per_class,
+                "boundary_width": boundary_width,
+                "input_format": input_format,
+            },
+        )
+
+    def test_boundary_f_score_functional(
+        self, preds, target, input_format, include_background, per_class, boundary_width
+    ):
+        """Test functional implementation of metric."""
+        self.run_functional_metric_test(
+            preds=preds,
+            target=target,
+            metric_functional=boundary_f_score,
+            reference_metric=partial(
+                _reference_boundary_f_score,
+                input_format=input_format,
+                num_classes=NUM_CLASSES,
+                include_background=include_background,
+                per_class=per_class,
+                boundary_width=boundary_width,
+                reduce=False,
+            ),
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "include_background": include_background,
+                "per_class": per_class,
+                "boundary_width": boundary_width,
+                "input_format": input_format,
+            },
+        )
+
+
+def test_boundary_f_score_perfect_match() -> None:
+    """Test that a perfect boundary match gives a score of one."""
+    preds = torch.zeros(1, 2, 8, 8, dtype=torch.int)
+    target = torch.zeros(1, 2, 8, 8, dtype=torch.int)
+    preds[:, 1, 2:6, 2:6] = 1
+    target[:, 1, 2:6, 2:6] = 1
+    score = boundary_f_score(preds, target, num_classes=2, include_background=False, per_class=True)
+    assert torch.allclose(score, torch.tensor([[1.0]]))
+
+
+def test_boundary_f_score_mismatch() -> None:
+    """Test that completely mismatched non-empty boundaries score zero."""
+    preds = torch.zeros(1, 2, 8, 8, dtype=torch.int)
+    target = torch.zeros(1, 2, 8, 8, dtype=torch.int)
+    preds[:, 1, :3, :3] = 1
+    target[:, 1, 5:, 5:] = 1
+    score = boundary_f_score(preds, target, num_classes=2, include_background=False)
+    assert score.item() == 0.0
+
+
+def test_boundary_f_score_respects_tolerance() -> None:
+    """Test that larger tolerance accepts slightly shifted boundaries."""
+    preds = torch.zeros(1, 2, 10, 10, dtype=torch.int)
+    target = torch.zeros(1, 2, 10, 10, dtype=torch.int)
+    preds[:, 1, 2:6, 2:6] = 1
+    target[:, 1, 2:6, 3:7] = 1
+
+    small_tolerance = boundary_f_score(preds, target, num_classes=2, include_background=False, boundary_width=0)
+    large_tolerance = boundary_f_score(preds, target, num_classes=2, include_background=False, boundary_width=1)
+
+    assert small_tolerance.item() < 1.0
+    assert large_tolerance.item() == 1.0
+
+
+@pytest.mark.parametrize(
+    ("preds", "target", "expected"),
+    [
+        (torch.zeros(1, 2, 8, 8, dtype=torch.int), torch.zeros(1, 2, 8, 8, dtype=torch.int), float("nan")),
+        (
+            torch.zeros(1, 2, 8, 8, dtype=torch.int),
+            torch.nn.functional.one_hot(torch.ones(1, 8, 8, dtype=torch.long), num_classes=2).movedim(-1, 1),
+            0.0,
+        ),
+        (
+            torch.nn.functional.one_hot(torch.ones(1, 8, 8, dtype=torch.long), num_classes=2).movedim(-1, 1),
+            torch.zeros(1, 2, 8, 8, dtype=torch.int),
+            0.0,
+        ),
+    ],
+)
+def test_boundary_f_score_empty_boundary_cases(preds: torch.Tensor, target: torch.Tensor, expected: float) -> None:
+    """Test empty-boundary behavior."""
+    score = boundary_f_score(preds, target, num_classes=2, include_background=False)
+    expected_tensor = torch.tensor(expected)
+    assert torch.allclose(score, expected_tensor, equal_nan=True)
+
+
+def test_boundary_f_score_supports_3d_inputs() -> None:
+    """Test that the metric supports volumetric masks."""
+    preds = torch.zeros(1, 2, 6, 6, 6, dtype=torch.int)
+    target = torch.zeros(1, 2, 6, 6, 6, dtype=torch.int)
+    preds[:, 1, 1:5, 1:5, 1:5] = 1
+    target[:, 1, 1:5, 1:5, 1:5] = 1
+    metric = BoundaryFScore(num_classes=2, include_background=False)
+    assert metric(preds, target).item() == 1.0
+
+
+def test_boundary_f_score_invalid_args_and_shapes() -> None:
+    """Test argument and shape validation."""
+    with pytest.raises(ValueError, match="Expected argument `boundary_width` to be a non-negative integer"):
+        BoundaryFScore(num_classes=2, boundary_width=-1)
+
+    preds = torch.randint(0, 2, (2, 3, 8), dtype=torch.int)
+    target = torch.randint(0, 2, (2, 3, 8), dtype=torch.int)
+    with pytest.raises(ValueError, match="Expected `preds` and `target` to have 2D or 3D spatial dimensions"):
+        boundary_f_score(preds, target, num_classes=3)


### PR DESCRIPTION
## What does this PR do?

Fixes #1500

Adds a first boundary-aware segmentation metric to TorchMetrics: `BoundaryFScore`.

Boundary F-score is useful when contour alignment matters more than region overlap. Compared with Dice or IoU, it measures whether predicted and target boundaries match within a configurable pixel tolerance.

### Summary
- add `torchmetrics.functional.segmentation.boundary_f_score`
- add `torchmetrics.segmentation.BoundaryFScore`
- support `one-hot`, `index`, and `mixed` segmentation inputs
- support `include_background`, `per_class`, 2D masks, and 3D volumetric masks
- add focused tests for correctness, tolerance handling, empty-boundary behavior, and functional/class consistency
- add docs for the new metric

### Limitations
- integer pixel tolerance only
- no spacing-aware or ratio-based tolerance yet
- no Boundary IoU in this PR
- this PR focuses on semantic segmentation-style inputs

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Yes