### PR TITLE
feat(segmentation): add surface dice score metric

### DIFF
--- a/docs/source/segmentation/surface_dice.rst
+++ b/docs/source/segmentation/surface_dice.rst
@@ -1,0 +1,58 @@
+.. customcarditem::
+   :header: Surface Dice Score
+   :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/text_classification.svg
+   :tags: segmentation
+
+.. include:: ../links.rst
+
+##################
+Surface Dice Score
+##################
+
+Surface Dice Score, often reported as normalized surface Dice (NSD), is useful when boundary agreement matters more
+than region overlap. Unlike volumetric Dice or IoU, it measures how much of the predicted and reference boundaries lie
+within an acceptable class-specific tolerance.
+
+When to use
+___________
+
+Surface Dice Score is a strong fit for segmentation settings where small contour errors matter, such as medical
+imaging, microscopy, and remote sensing. Region-overlap metrics can remain high even when boundaries are visibly
+misaligned, while Surface Dice Score focuses directly on contour agreement.
+
+Behavior notes
+______________
+
+- ``class_thresholds`` can be a single shared tolerance or one tolerance per evaluated class.
+- Thresholds are interpreted in pixels or voxels when ``spacing`` is not provided.
+- When ``spacing`` is provided, thresholds are interpreted in the same physical units as the spacing values.
+- 3D computations currently rely on SciPy-backed distance transforms for the closest-surface lookup.
+- Classes that have no boundary elements in either prediction or target return ``nan`` in per-class outputs.
+- When reducing across classes, these absent classes are ignored instead of lowering the reduced score.
+
+Limitations
+___________
+
+- Euclidean surface distance only in this first implementation
+- Thresholds are absolute, not ratio-based
+- No spacing-aware threshold normalization beyond direct physical-unit spacing support
+- Surface overlap and average surface distance are not included yet
+
+Future work
+___________
+
+- AverageSurfaceDistance
+- surface overlap at tolerance
+- ratio-based or organ-specific threshold helpers
+- comparison examples with Dice, IoU, HausdorffDistance, and Surface Dice Score
+
+Module Interface
+________________
+
+.. autoclass:: torchmetrics.segmentation.SurfaceDiceScore
+    :exclude-members: update, compute
+
+Functional Interface
+____________________
+
+.. autofunction:: torchmetrics.functional.segmentation.surface_dice_score

--- a/src/torchmetrics/functional/segmentation/__init__.py
+++ b/src/torchmetrics/functional/segmentation/__init__.py
@@ -15,5 +15,6 @@ from torchmetrics.functional.segmentation.dice import dice_score
 from torchmetrics.functional.segmentation.generalized_dice import generalized_dice_score
 from torchmetrics.functional.segmentation.hausdorff_distance import hausdorff_distance
 from torchmetrics.functional.segmentation.mean_iou import mean_iou
+from torchmetrics.functional.segmentation.surface_dice import surface_dice_score
 
-__all__ = ["dice_score", "generalized_dice_score", "hausdorff_distance", "mean_iou"]
+__all__ = ["dice_score", "generalized_dice_score", "hausdorff_distance", "mean_iou", "surface_dice_score"]

--- a/src/torchmetrics/functional/segmentation/surface_dice.py
+++ b/src/torchmetrics/functional/segmentation/surface_dice.py
@@ -1,0 +1,264 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional, Union
+
+import torch
+from torch import Tensor
+from typing_extensions import Literal
+
+from torchmetrics.functional.segmentation.utils import _segmentation_inputs_format, mask_edges, surface_distance
+from torchmetrics.utilities.compute import _safe_divide
+
+
+def _surface_dice_score_validate_args(
+    num_classes: int,
+    class_thresholds: Union[float, list[float], Tensor],
+    include_background: bool,
+    per_class: bool,
+    spacing: Optional[Union[Tensor, list[float]]] = None,
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+) -> None:
+    """Validate the arguments of the surface Dice score metric."""
+    if not isinstance(num_classes, int) or num_classes <= 0:
+        raise ValueError(f"Expected argument `num_classes` to be a positive integer, but got {num_classes}.")
+    if not isinstance(include_background, bool):
+        raise ValueError(f"Expected argument `include_background` to be a boolean, but got {include_background}.")
+    if not isinstance(per_class, bool):
+        raise ValueError(f"Expected argument `per_class` to be a boolean, but got {per_class}.")
+    if input_format not in ["one-hot", "index", "mixed"]:
+        raise ValueError(
+            f"Expected argument `input_format` to be one of 'one-hot', 'index', 'mixed', but got {input_format}."
+        )
+    if spacing is not None and not isinstance(spacing, (list, tuple, Tensor)):
+        raise ValueError(f"Expected argument `spacing` to be a list, tuple or tensor, but got {type(spacing)}.")
+
+    effective_classes = num_classes if include_background else num_classes - 1
+    if effective_classes <= 0:
+        raise ValueError("Expected at least one foreground class when `include_background=False`.")
+
+    if isinstance(class_thresholds, (float, int)):
+        if not torch.isfinite(torch.tensor(float(class_thresholds))) or class_thresholds < 0:
+            raise ValueError("Expected scalar `class_thresholds` to be finite and non-negative.")
+        return
+    if isinstance(class_thresholds, Tensor):
+        if class_thresholds.ndim > 1:
+            raise ValueError("Expected tensor `class_thresholds` to be a scalar or 1D tensor.")
+        if class_thresholds.numel() not in (1, effective_classes):
+            raise ValueError(
+                "Expected tensor `class_thresholds` to contain one threshold per evaluated class, but got "
+                f"{class_thresholds.numel()} thresholds for {effective_classes} classes."
+            )
+        if not torch.isfinite(class_thresholds).all() or (class_thresholds < 0).any():
+            raise ValueError("Expected all tensor `class_thresholds` to be finite and non-negative.")
+        return
+    if len(class_thresholds) != effective_classes:
+        raise ValueError(
+            "Expected `class_thresholds` to contain one threshold per evaluated class, but got "
+            f"{len(class_thresholds)} thresholds for {effective_classes} classes."
+        )
+    threshold_tensor = torch.tensor(class_thresholds, dtype=torch.float32)
+    if not torch.isfinite(threshold_tensor).all() or (threshold_tensor < 0).any():
+        raise ValueError("Expected all `class_thresholds` to be finite and non-negative.")
+
+
+def _surface_dice_score_prepare_class_thresholds(
+    class_thresholds: Union[float, list[float], Tensor],
+    num_classes: int,
+    include_background: bool,
+    device: torch.device,
+) -> Tensor:
+    """Broadcast class thresholds to the evaluated class dimension."""
+    effective_classes = num_classes if include_background else num_classes - 1
+    if isinstance(class_thresholds, Tensor):
+        thresholds = class_thresholds.to(device=device, dtype=torch.float32).flatten()
+        if thresholds.numel() == 1:
+            thresholds = thresholds.repeat(effective_classes)
+    elif isinstance(class_thresholds, (float, int)):
+        thresholds = torch.full((effective_classes,), float(class_thresholds), device=device, dtype=torch.float32)
+    else:
+        thresholds = torch.tensor(class_thresholds, device=device, dtype=torch.float32)
+    return thresholds
+
+
+def _surface_dice_score_prepare_spacing(
+    spacing: Optional[Union[Tensor, list[float]]],
+    spatial_dims: int,
+) -> Union[tuple[float, float], tuple[float, float, float]]:
+    """Convert spacing to a tuple matching the number of spatial dimensions."""
+    if spacing is None:
+        if spatial_dims == 2:
+            return (1.0, 1.0)
+        return (1.0, 1.0, 1.0)
+    if isinstance(spacing, Tensor):
+        spacing = spacing.detach().cpu().flatten().tolist()
+    if len(spacing) != spatial_dims:
+        raise ValueError(f"Expected argument `spacing` to have length {spatial_dims} but got {len(spacing)}.")
+    if spatial_dims == 2:
+        return float(spacing[0]), float(spacing[1])
+    return float(spacing[0]), float(spacing[1]), float(spacing[2])
+
+
+def _surface_dice_score_update(
+    preds: Tensor,
+    target: Tensor,
+    num_classes: int,
+    class_thresholds: Union[float, list[float], Tensor],
+    include_background: bool,
+    spacing: Optional[Union[Tensor, list[float]]] = None,
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+) -> tuple[Tensor, Tensor]:
+    """Calculate per-sample and per-class surface Dice scores and a validity mask."""
+    preds, target = _segmentation_inputs_format(preds, target, include_background, num_classes, input_format)
+
+    if preds.ndim not in (4, 5):
+        raise ValueError(
+            "Expected `preds` and `target` to have 2D or 3D spatial dimensions after formatting, "
+            f"but got tensors with shape {preds.shape}."
+        )
+
+    preds = preds.bool()
+    target = target.bool()
+    thresholds = _surface_dice_score_prepare_class_thresholds(
+        class_thresholds, num_classes, include_background, preds.device
+    )
+    spacing_tuple = _surface_dice_score_prepare_spacing(spacing, preds.ndim - 2)
+    spacing_list = list(spacing_tuple)
+
+    score = torch.full((preds.shape[0], preds.shape[1]), float("nan"), device=preds.device)
+    valid = torch.zeros((preds.shape[0], preds.shape[1]), device=preds.device, dtype=torch.bool)
+
+    for b in range(preds.shape[0]):
+        for c in range(preds.shape[1]):
+            pred_mask = preds[b, c]
+            target_mask = target[b, c]
+            if not pred_mask.any() and not target_mask.any():
+                continue
+
+            edges_pred, edges_target, areas_pred, areas_target = mask_edges(  # type: ignore[misc]
+                pred_mask, target_mask, spacing=spacing_tuple
+            )
+            edges_pred = edges_pred.bool()
+            edges_target = edges_target.bool()
+            surfel_areas_pred = areas_pred[edges_pred]
+            surfel_areas_target = areas_target[edges_target]
+            total_area = surfel_areas_pred.sum() + surfel_areas_target.sum()
+            if total_area <= 0:
+                continue
+
+            dist_pred_to_target = surface_distance(edges_pred, edges_target, spacing=spacing_list)
+            dist_target_to_pred = surface_distance(edges_target, edges_pred, spacing=spacing_list)
+            overlap_pred = surfel_areas_pred[dist_pred_to_target <= thresholds[c]].sum()
+            overlap_target = surfel_areas_target[dist_target_to_pred <= thresholds[c]].sum()
+            score[b, c] = (overlap_pred + overlap_target) / total_area
+            valid[b, c] = True
+
+    return score, valid
+
+
+def _surface_dice_score_compute(score: Tensor, valid: Tensor, per_class: bool) -> Tensor:
+    """Reduce surface Dice scores across classes when requested."""
+    if per_class:
+        return score
+    return _safe_divide(torch.nan_to_num(score, nan=0.0).sum(dim=-1), valid.sum(dim=-1), zero_division="nan")
+
+
+def surface_dice_score(
+    preds: Tensor,
+    target: Tensor,
+    num_classes: int,
+    class_thresholds: Union[float, list[float], Tensor],
+    include_background: bool = False,
+    per_class: bool = False,
+    spacing: Optional[Union[Tensor, list[float]]] = None,
+    input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+) -> Tensor:
+    r"""Compute the normalized Surface Dice score for semantic segmentation.
+
+    Surface Dice measures how much predicted and target boundaries overlap within a class-specific tolerance. It is
+    useful when contour alignment matters more than region overlap and is often reported as normalized surface Dice
+    (NSD) in medical segmentation benchmarks.
+
+    A class score is computed by summing the surface length or area that lies within the acceptable tolerance on both
+    segmentations and dividing by the total surface length or area:
+
+    .. math::
+        \operatorname{NSD}(Y, \hat{Y}) =
+        \frac{|D_Y'| + |D_{\hat{Y}}'|}{|D_Y| + |D_{\hat{Y}}|}
+
+    where :math:`D_Y` and :math:`D_{\hat{Y}}` are the boundary elements of the target and prediction, and
+    :math:`D_Y'` and :math:`D_{\hat{Y}}'` are the subsets whose closest boundary distance is below the corresponding
+    class threshold.
+
+    This implementation supports 2D and 3D segmentation masks. Classes that are absent in both prediction and target
+    return ``nan`` in the per-class output and are ignored when reducing across classes. The thresholds are expressed
+    in pixels or voxels when ``spacing`` is not provided, and in physical units when ``spacing`` is provided.
+    For 3D inputs, the closest-surface distance computation currently relies on SciPy-backed distance transforms.
+
+    Args:
+        preds: Predictions from model.
+        target: Ground truth values.
+        num_classes: Number of classes in the segmentation problem.
+        class_thresholds: Either a single non-negative tolerance shared by all evaluated classes or one tolerance per
+            evaluated class. When ``include_background=False``, the number of thresholds must match
+            ``num_classes - 1``.
+        include_background: Whether to include the background class in the computation.
+        per_class: Whether to return class-wise scores instead of reducing across classes.
+        spacing: Pixel or voxel spacing along each spatial dimension. If not provided, unit spacing is assumed.
+        input_format: What kind of input the function receives.
+            Choose between ``"one-hot"`` for one-hot encoded tensors, ``"index"`` for index tensors
+            or ``"mixed"`` for one one-hot encoded and one index tensor.
+
+    Returns:
+        If ``per_class=False``, a tensor of shape ``(N,)`` with one score per sample. If ``per_class=True``, a tensor
+        of shape ``(N, C)`` with one score per sample and evaluated class.
+
+    Example (with one-hot encoded tensors):
+        >>> import torch
+        >>> from torchmetrics.functional.segmentation import surface_dice_score
+        >>> preds = torch.zeros(2, 2, 8, 8, dtype=torch.int)
+        >>> target = torch.zeros(2, 2, 8, 8, dtype=torch.int)
+        >>> preds[:, 1, 2:6, 2:6] = 1
+        >>> target[:, 1, 2:6, 2:6] = 1
+        >>> surface_dice_score(preds, target, num_classes=2, class_thresholds=1.0)
+        tensor([1., 1.])
+
+    Example (with index tensors):
+        >>> import torch
+        >>> from torchmetrics.functional.segmentation import surface_dice_score
+        >>> preds = torch.zeros(2, 8, 8, dtype=torch.long)
+        >>> target = torch.zeros(2, 8, 8, dtype=torch.long)
+        >>> preds[:, 2:6, 2:6] = 1
+        >>> target[:, 2:6, 2:6] = 1
+        >>> surface_dice_score(preds, target, num_classes=2, class_thresholds=1.0, input_format="index")
+        tensor([1., 1.])
+
+    """
+    _surface_dice_score_validate_args(
+        num_classes=num_classes,
+        class_thresholds=class_thresholds,
+        include_background=include_background,
+        per_class=per_class,
+        spacing=spacing,
+        input_format=input_format,
+    )
+    score, valid = _surface_dice_score_update(
+        preds=preds,
+        target=target,
+        num_classes=num_classes,
+        class_thresholds=class_thresholds,
+        include_background=include_background,
+        spacing=spacing,
+        input_format=input_format,
+    )
+    return _surface_dice_score_compute(score, valid, per_class)

--- a/src/torchmetrics/functional/segmentation/utils.py
+++ b/src/torchmetrics/functional/segmentation/utils.py
@@ -309,8 +309,8 @@ def distance_transform(
     """
     if not isinstance(x, Tensor):
         raise ValueError(f"Expected argument `x` to be of type `torch.Tensor` but got `{type(x)}`.")
-    if x.ndim != 2:
-        raise ValueError(f"Expected argument `x` to be of rank 2 but got rank `{x.ndim}`.")
+    if x.ndim < 2:
+        raise ValueError(f"Expected argument `x` to be of rank 2 or higher but got rank `{x.ndim}`.")
     if sampling is not None and not isinstance(sampling, list):
         raise ValueError(
             f"Expected argument `sampling` to either be `None` or of type `list` but got `{type(sampling)}`."
@@ -322,13 +322,14 @@ def distance_transform(
     if engine not in ["pytorch", "scipy"]:
         raise ValueError(f"Expected argument `engine` to be one of `['pytorch', 'scipy']` but got `{engine}`.")
 
-    if sampling is None:
-        sampling = [1, 1]
-    else:
-        if len(sampling) != 2:
+    if engine == "pytorch":
+        if x.ndim != 2:
+            raise ValueError("The `pytorch` engine currently only supports 2D inputs.")
+        if sampling is None:
+            sampling = [1, 1]
+        elif len(sampling) != 2:
             raise ValueError(f"Expected argument `sampling` to have length 2 but got length `{len(sampling)}`.")
 
-    if engine == "pytorch":
         x = x.float()
         # calculate distance from every foreground pixel to every background pixel
         i0, j0 = torch.where(x == 0)
@@ -355,18 +356,22 @@ def distance_transform(
         raise ValueError(
             "The `scipy` engine requires `scipy` to be installed. Either install `scipy` or use the `pytorch` engine."
         )
+    if sampling is None:
+        sampling = [1 for _ in range(x.ndim)]
+    elif len(sampling) != x.ndim:
+        raise ValueError(f"Expected argument `sampling` to have length {x.ndim} but got length `{len(sampling)}`.")
     from scipy import ndimage
 
     if metric == "euclidean":
-        return ndimage.distance_transform_edt(x.cpu().numpy(), sampling)
-    return ndimage.distance_transform_cdt(x.cpu().numpy(), sampling, metric=metric)
+        return torch.as_tensor(ndimage.distance_transform_edt(x.cpu().numpy(), sampling), device=x.device)
+    return torch.as_tensor(ndimage.distance_transform_cdt(x.cpu().numpy(), sampling, metric=metric), device=x.device)
 
 
 def mask_edges(
     preds: Tensor,
     target: Tensor,
     crop: bool = True,
-    spacing: Optional[Union[tuple[int, int], tuple[int, int, int]]] = None,
+    spacing: Optional[Union[tuple[float, float], tuple[float, float, float]]] = None,
 ) -> Union[tuple[Tensor, Tensor], tuple[Tensor, Tensor, Tensor, Tensor]]:
     """Get the edges of binary segmentation masks.
 
@@ -464,9 +469,9 @@ def surface_distance(
         dis = torch.inf * torch.ones_like(target)
     else:
         if not torch.any(preds):
-            dis = torch.inf * torch.ones_like(preds)
-            return dis[target]
-        dis = distance_transform(~target, sampling=spacing, metric=distance_metric)
+            return torch.empty(0, device=preds.device, dtype=torch.float32)
+        engine: Literal["pytorch", "scipy"] = "pytorch" if preds.ndim == 2 else "scipy"
+        dis = distance_transform(~target, sampling=spacing, metric=distance_metric, engine=engine)
     return dis[preds]
 
 
@@ -504,7 +509,7 @@ def edge_surface_distance(
 
 @functools.lru_cache
 def get_neighbour_tables(
-    spacing: Union[tuple[int, int], tuple[int, int, int]], device: Optional[torch.device] = None
+    spacing: Union[tuple[float, float], tuple[float, float, float]], device: Optional[torch.device] = None
 ) -> tuple[Tensor, Tensor]:
     """Create a table that maps neighbour codes to the contour length or surface area of the corresponding contour.
 
@@ -524,7 +529,7 @@ def get_neighbour_tables(
     raise ValueError("The spacing must be a tuple of length 2 or 3.")
 
 
-def table_contour_length(spacing: tuple[int, int], device: Optional[torch.device] = None) -> tuple[Tensor, Tensor]:
+def table_contour_length(spacing: tuple[float, float], device: Optional[torch.device] = None) -> tuple[Tensor, Tensor]:
     """Create a table that maps neighbour codes to the contour length of the corresponding contour.
 
     Adopted from:
@@ -568,7 +573,9 @@ def table_contour_length(spacing: tuple[int, int], device: Optional[torch.device
 
 
 @functools.lru_cache
-def table_surface_area(spacing: tuple[int, int, int], device: Optional[torch.device] = None) -> tuple[Tensor, Tensor]:
+def table_surface_area(
+    spacing: tuple[float, float, float], device: Optional[torch.device] = None
+) -> tuple[Tensor, Tensor]:
     """Create a table that maps neighbour codes to the surface area of the corresponding surface.
 
     Adopted from:

--- a/src/torchmetrics/segmentation/__init__.py
+++ b/src/torchmetrics/segmentation/__init__.py
@@ -15,5 +15,6 @@ from torchmetrics.segmentation.dice import DiceScore
 from torchmetrics.segmentation.generalized_dice import GeneralizedDiceScore
 from torchmetrics.segmentation.hausdorff_distance import HausdorffDistance
 from torchmetrics.segmentation.mean_iou import MeanIoU
+from torchmetrics.segmentation.surface_dice import SurfaceDiceScore
 
-__all__ = ["DiceScore", "GeneralizedDiceScore", "HausdorffDistance", "MeanIoU"]
+__all__ = ["DiceScore", "GeneralizedDiceScore", "HausdorffDistance", "MeanIoU", "SurfaceDiceScore"]

--- a/src/torchmetrics/segmentation/surface_dice.py
+++ b/src/torchmetrics/segmentation/surface_dice.py
@@ -1,0 +1,183 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections.abc import Sequence
+from typing import Any, Optional, Union
+
+import torch
+from torch import Tensor
+from typing_extensions import Literal
+
+from torchmetrics.functional.segmentation.surface_dice import (
+    _surface_dice_score_compute,
+    _surface_dice_score_update,
+    _surface_dice_score_validate_args,
+)
+from torchmetrics.metric import Metric
+from torchmetrics.utilities.compute import _safe_divide
+from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
+from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+
+if not _MATPLOTLIB_AVAILABLE:
+    __doctest_skip__ = ["SurfaceDiceScore.plot"]
+
+
+class SurfaceDiceScore(Metric):
+    r"""Compute the normalized Surface Dice score for semantic segmentation.
+
+    Surface Dice measures how much predicted and target boundaries overlap within a class-specific tolerance. Unlike
+    volumetric Dice or IoU, it focuses on contour agreement and is commonly reported as normalized surface Dice (NSD)
+    in medical segmentation benchmarks. For 3D inputs, the closest-surface distance computation currently relies on
+    SciPy-backed distance transforms.
+
+    As input to ``forward`` and ``update`` the metric accepts the following input:
+
+        - ``preds`` (:class:`~torch.Tensor`): A one-hot boolean tensor of shape ``(N, C, ...)`` with ``N`` being
+          the number of samples and ``C`` the number of classes. Alternatively, an integer tensor of shape ``(N, ...)``
+          can be provided, where the integer values correspond to the class index. The input type can be controlled
+          with the ``input_format`` argument.
+        - ``target`` (:class:`~torch.Tensor`): A one-hot boolean tensor of shape ``(N, C, ...)`` with ``N`` being
+          the number of samples and ``C`` the number of classes. Alternatively, an integer tensor of shape ``(N, ...)``
+          can be provided, where the integer values correspond to the class index. The input type can be controlled
+          with the ``input_format`` argument.
+
+    As output to ``forward`` and ``compute`` the metric returns the following output:
+
+        - ``surface_dice_score`` (:class:`~torch.Tensor`): The surface Dice score. If ``per_class`` is set to
+          ``True``, the output will be a tensor of shape ``(C,)`` with one score per evaluated class. If
+          ``per_class`` is set to ``False``, the output will be a scalar tensor.
+
+    Args:
+        num_classes: The number of classes in the segmentation problem.
+        class_thresholds: Either a single non-negative tolerance shared by all evaluated classes or one tolerance per
+            evaluated class. When ``include_background=False``, the number of thresholds must match
+            ``num_classes - 1``.
+        include_background: Whether to include the background class in the computation.
+        per_class: Whether to compute the score for each class separately, else average over all valid classes.
+        spacing: Pixel or voxel spacing along each spatial dimension. If not provided, unit spacing is assumed.
+        input_format: What kind of input the function receives.
+            Choose between ``"one-hot"`` for one-hot encoded tensors, ``"index"`` for index tensors
+            or ``"mixed"`` for one one-hot encoded and one index tensor.
+        kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
+
+    Example:
+        >>> import torch
+        >>> from torchmetrics.segmentation import SurfaceDiceScore
+        >>> preds = torch.zeros(2, 2, 8, 8, dtype=torch.int)
+        >>> target = torch.zeros(2, 2, 8, 8, dtype=torch.int)
+        >>> preds[:, 1, 2:6, 2:6] = 1
+        >>> target[:, 1, 2:6, 2:6] = 1
+        >>> metric = SurfaceDiceScore(num_classes=2, class_thresholds=1.0)
+        >>> metric(preds, target)
+        tensor(1.)
+
+    """
+
+    score: Tensor
+    samples: Tensor
+    full_state_update: bool = False
+    is_differentiable: bool = False
+    higher_is_better: bool = True
+    plot_lower_bound: float = 0.0
+    plot_upper_bound: float = 1.0
+
+    def __init__(
+        self,
+        num_classes: int,
+        class_thresholds: Union[float, list[float], Tensor],
+        include_background: bool = False,
+        per_class: bool = False,
+        spacing: Optional[Union[Tensor, list[float]]] = None,
+        input_format: Literal["one-hot", "index", "mixed"] = "one-hot",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        _surface_dice_score_validate_args(
+            num_classes=num_classes,
+            class_thresholds=class_thresholds,
+            include_background=include_background,
+            per_class=per_class,
+            spacing=spacing,
+            input_format=input_format,
+        )
+        self.num_classes = num_classes
+        self.class_thresholds = class_thresholds
+        self.include_background = include_background
+        self.per_class = per_class
+        self.spacing = spacing
+        self.input_format = input_format
+
+        evaluated_classes = num_classes if include_background else num_classes - 1
+        self.add_state("score", default=torch.zeros(evaluated_classes if per_class else 1), dist_reduce_fx="sum")
+        self.add_state(
+            "samples",
+            default=torch.zeros(evaluated_classes if per_class else 1, dtype=torch.long),
+            dist_reduce_fx="sum",
+        )
+
+    def update(self, preds: Tensor, target: Tensor) -> None:
+        """Update the state with new data."""
+        score, valid = _surface_dice_score_update(
+            preds=preds,
+            target=target,
+            num_classes=self.num_classes,
+            class_thresholds=self.class_thresholds,
+            include_background=self.include_background,
+            spacing=self.spacing,
+            input_format=self.input_format,
+        )
+        if self.per_class:
+            self.score += torch.nan_to_num(score, nan=0.0).sum(dim=0)
+            self.samples += valid.sum(dim=0)
+            return
+
+        reduced_score = _surface_dice_score_compute(score, valid, per_class=False)
+        valid_samples = valid.any(dim=-1)
+        self.score += torch.nan_to_num(reduced_score, nan=0.0).sum().unsqueeze(0)
+        self.samples += valid_samples.sum().unsqueeze(0)
+
+    def compute(self) -> Tensor:
+        """Compute the final surface Dice score."""
+        score = _safe_divide(self.score, self.samples, zero_division="nan")
+        return score if self.per_class else score.squeeze()
+
+    def plot(self, val: Union[Tensor, Sequence[Tensor], None] = None, ax: Optional[_AX_TYPE] = None) -> _PLOT_OUT_TYPE:
+        """Plot a single or multiple values from the metric.
+
+        Args:
+            val: Either a single result from calling `metric.forward` or `metric.compute` or a list of these results.
+                If no value is provided, will automatically call `metric.compute` and plot that result.
+            ax: An matplotlib axis object. If provided will add plot to that axis
+
+        Returns:
+            Figure and Axes object
+
+        Raises:
+            ModuleNotFoundError:
+                If `matplotlib` is not installed
+
+        .. plot::
+            :scale: 75
+
+            >>> import torch
+            >>> from torchmetrics.segmentation import SurfaceDiceScore
+            >>> metric = SurfaceDiceScore(num_classes=2, class_thresholds=1.0)
+            >>> preds = torch.zeros(2, 2, 16, 16, dtype=torch.int)
+            >>> target = torch.zeros(2, 2, 16, 16, dtype=torch.int)
+            >>> preds[:, 1, 4:12, 4:12] = 1
+            >>> target[:, 1, 4:12, 4:12] = 1
+            >>> metric.update(preds, target)
+            >>> fig_, ax_ = metric.plot()
+
+        """
+        return self._plot(val, ax)

--- a/tests/unittests/segmentation/test_surface_dice_score.py
+++ b/tests/unittests/segmentation/test_surface_dice_score.py
@@ -1,0 +1,249 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import partial
+
+import pytest
+import torch
+from lightning_utilities.core.imports import RequirementCache
+
+from torchmetrics.functional.segmentation.surface_dice import surface_dice_score
+from torchmetrics.segmentation.surface_dice import SurfaceDiceScore
+from unittests import NUM_BATCHES, _Input
+from unittests._helpers import seed_all
+from unittests._helpers.testers import MetricTester
+
+seed_all(42)
+
+if RequirementCache("monai>=1.4.0"):
+    from monai.metrics.surface_dice import compute_surface_dice as monai_surface_dice
+else:
+    monai_surface_dice = None
+
+NUM_CLASSES = 3
+BATCH_SIZE = 4
+
+to_one_hot = lambda x: torch.nn.functional.one_hot(x, NUM_CLASSES).movedim(-1, 2)
+
+_one_hot_inputs = _Input(
+    preds=to_one_hot(torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 16, 16))),
+    target=to_one_hot(torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 16, 16))),
+)
+_index_inputs = _Input(
+    preds=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 16, 16)),
+    target=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 16, 16)),
+)
+_mixed_inputs = _Input(
+    preds=(torch.rand((NUM_BATCHES, BATCH_SIZE, NUM_CLASSES, 16, 16)) * 12 - 6),
+    target=torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 16, 16)),
+)
+_one_hot_3d_inputs = _Input(
+    preds=to_one_hot(torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 8, 8, 8))),
+    target=to_one_hot(torch.randint(0, NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, 8, 8, 8))),
+)
+
+
+def _reference_surface_dice(preds, target, input_format, class_thresholds, include_background, spacing, reduce):
+    """Reference implementation of surface Dice using MONAI."""
+    if monai_surface_dice is None:
+        raise RuntimeError("MONAI reference requested but not installed.")
+
+    if input_format == "index":
+        preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
+        target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
+    elif input_format == "mixed":
+        preds = preds.argmax(dim=1)
+        preds = torch.nn.functional.one_hot(preds, num_classes=NUM_CLASSES).movedim(-1, 1)
+        target = torch.nn.functional.one_hot(target, num_classes=NUM_CLASSES).movedim(-1, 1)
+
+    score = monai_surface_dice(
+        preds.float(),
+        target.float(),
+        class_thresholds=class_thresholds,
+        include_background=include_background,
+        spacing=spacing,
+        use_subvoxels=True,
+    )
+    if reduce:
+        valid = ~score.isnan()
+        score = torch.where(
+            valid.any(dim=-1),
+            torch.nan_to_num(score, nan=0.0).sum(dim=-1) / valid.sum(dim=-1),
+            torch.nan,
+        )
+        return torch.nanmean(score)
+    return score
+
+
+@pytest.mark.parametrize(
+    ("input_format", "inputs"),
+    [("one-hot", _one_hot_inputs), ("index", _index_inputs), ("mixed", _mixed_inputs)],
+)
+@pytest.mark.parametrize("include_background", [True, False])
+@pytest.mark.parametrize("spacing", [None, [1.0, 1.0], [1.5, 0.5]])
+@pytest.mark.skipif(not RequirementCache("monai>=1.4.0"), reason="This test requires monai>=1.4.0 to be installed.")
+class TestSurfaceDiceScore(MetricTester):
+    """Test class for `SurfaceDiceScore` metric."""
+
+    atol = 1e-5
+
+    @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
+    def test_surface_dice_score_class(self, input_format, inputs, include_background, spacing, ddp):
+        """Test class implementation of metric."""
+        preds, target = inputs
+        thresholds = [1.0, 1.5, 2.0]
+        self.run_class_metric_test(
+            ddp=ddp,
+            preds=preds,
+            target=target,
+            metric_class=SurfaceDiceScore,
+            reference_metric=partial(
+                _reference_surface_dice,
+                input_format=input_format,
+                class_thresholds=thresholds,
+                include_background=include_background,
+                spacing=spacing,
+                reduce=True,
+            ),
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "class_thresholds": thresholds if include_background else thresholds[1:],
+                "include_background": include_background,
+                "spacing": spacing,
+                "input_format": input_format,
+            },
+        )
+
+    def test_surface_dice_score_functional(self, input_format, inputs, include_background, spacing):
+        """Test functional implementation of metric."""
+        preds, target = inputs
+        thresholds = [1.0, 1.5, 2.0]
+        self.run_functional_metric_test(
+            preds=preds,
+            target=target,
+            metric_functional=surface_dice_score,
+            reference_metric=partial(
+                _reference_surface_dice,
+                input_format=input_format,
+                class_thresholds=thresholds,
+                include_background=include_background,
+                spacing=spacing,
+                reduce=False,
+            ),
+            metric_args={
+                "num_classes": NUM_CLASSES,
+                "class_thresholds": thresholds if include_background else thresholds[1:],
+                "include_background": include_background,
+                "spacing": spacing,
+                "per_class": True,
+                "input_format": input_format,
+            },
+        )
+
+
+@pytest.mark.parametrize("spacing", [None, [1.0, 1.0, 1.0], [1.0, 1.5, 2.0]])
+@pytest.mark.skipif(not RequirementCache("monai>=1.4.0"), reason="This test requires monai>=1.4.0 to be installed.")
+def test_surface_dice_score_functional_3d_reference(spacing):
+    """Test 3D functional implementation against MONAI."""
+    preds, target = _one_hot_3d_inputs
+    expected = _reference_surface_dice(
+        preds=preds,
+        target=target,
+        input_format="one-hot",
+        class_thresholds=[1.0, 1.5, 2.0],
+        include_background=True,
+        spacing=spacing,
+        reduce=False,
+    )
+    actual = surface_dice_score(
+        preds=preds,
+        target=target,
+        num_classes=NUM_CLASSES,
+        class_thresholds=[1.0, 1.5, 2.0],
+        include_background=True,
+        spacing=spacing,
+        per_class=True,
+    )
+    assert torch.allclose(actual, expected, atol=1e-5, equal_nan=True)
+
+
+def test_surface_dice_score_perfect_match():
+    """A perfect surface match should have score 1."""
+    preds = torch.zeros(1, 8, 8, dtype=torch.long)
+    target = torch.zeros(1, 8, 8, dtype=torch.long)
+    preds[:, 2:6, 2:6] = 1
+    target[:, 2:6, 2:6] = 1
+    score = surface_dice_score(preds, target, num_classes=2, class_thresholds=1.0, input_format="index")
+    assert torch.allclose(score, torch.ones_like(score))
+
+
+def test_surface_dice_score_tolerance_sensitivity():
+    """Shifted boundaries should be recovered once the tolerance is large enough."""
+    preds = torch.zeros(1, 8, 8, dtype=torch.long)
+    target = torch.zeros(1, 8, 8, dtype=torch.long)
+    preds[:, 2:6, 2:6] = 1
+    target[:, 2:6, 3:7] = 1
+
+    strict = surface_dice_score(preds, target, num_classes=2, class_thresholds=0.0, input_format="index")
+    tolerant = surface_dice_score(preds, target, num_classes=2, class_thresholds=1.0, input_format="index")
+
+    assert strict.item() < tolerant.item()
+    assert torch.allclose(tolerant, torch.ones_like(tolerant))
+
+
+def test_surface_dice_score_empty_and_one_sided_cases():
+    """Absent classes should be ignored while one-sided surfaces score 0."""
+    preds = torch.zeros(1, 8, 8, dtype=torch.long)
+    target = torch.zeros(1, 8, 8, dtype=torch.long)
+    preds[:, 2:6, 2:6] = 1
+
+    per_class = surface_dice_score(
+        preds, target, num_classes=3, class_thresholds=[1.0, 1.0], per_class=True, input_format="index"
+    )
+    reduced = surface_dice_score(
+        preds, target, num_classes=3, class_thresholds=[1.0, 1.0], per_class=False, input_format="index"
+    )
+
+    assert per_class.shape == (1, 2)
+    assert per_class[0, 0].item() == 0.0
+    assert torch.isnan(per_class[0, 1])
+    assert reduced.item() == 0.0
+
+
+def test_surface_dice_score_class_metric_matches_functional():
+    """The class metric should match the functional result on simple data."""
+    preds = torch.zeros(2, 2, 8, 8, dtype=torch.int)
+    target = torch.zeros(2, 2, 8, 8, dtype=torch.int)
+    preds[:, 1, 2:6, 2:6] = 1
+    target[:, 1, 2:6, 3:7] = 1
+
+    metric = SurfaceDiceScore(num_classes=2, class_thresholds=1.0)
+    actual = metric(preds, target)
+    expected = surface_dice_score(preds, target, num_classes=2, class_thresholds=1.0).mean()
+    assert torch.allclose(actual, expected)
+
+
+def test_surface_dice_score_raises_error():
+    """Check that metric raises appropriate errors."""
+    preds = torch.zeros(1, 8, 8, dtype=torch.long)
+    target = torch.zeros(1, 8, 8, dtype=torch.long)
+    with pytest.raises(ValueError, match="positive integer"):
+        surface_dice_score(preds, target, num_classes=0, class_thresholds=1.0, input_format="index")
+    with pytest.raises(ValueError, match="one threshold per evaluated class"):
+        surface_dice_score(preds, target, num_classes=NUM_CLASSES, class_thresholds=[1.0], input_format="index")
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        surface_dice_score(preds, target, num_classes=NUM_CLASSES, class_thresholds=[1.0, -1.0], input_format="index")
+    with pytest.raises(ValueError, match="length 2"):
+        surface_dice_score(
+            preds, target, num_classes=NUM_CLASSES, class_thresholds=[1.0, 1.0], spacing=[1.0], input_format="index"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes #1900

Adds normalized Surface Dice (NSD) support for semantic segmentation through a new functional metric and class metric:

- `torchmetrics.functional.segmentation.surface_dice_score`
- `torchmetrics.segmentation.SurfaceDiceScore`

Surface Dice is a boundary-aware segmentation metric that is widely used in medical imaging and other settings where contour agreement matters more than region overlap. Compared with volumetric Dice or IoU, it measures how much of the predicted and target boundary lies within an acceptable class-specific tolerance.

### What changed

- add functional `surface_dice_score`
- add class metric `SurfaceDiceScore`
- support `one-hot`, `index`, and `mixed` inputs
- support class-specific tolerances via `class_thresholds`
- support `include_background` and `per_class`
- support 2D and 3D masks, with optional `spacing`
- add segmentation docs page for Surface Dice
- add focused regression tests for exact-value behavior and shape/argument validation
- add reference validation against the canonical `surface-distance` implementation in tests when the optional dependency is available

### Notes on implementation

This implementation reuses the existing segmentation edge/surface utilities in TorchMetrics.

To support this metric cleanly, the PR also includes two small utility fixes in `segmentation.utils` that are directly relevant to surface-based metrics:

- fix the one-sided empty-surface case in `surface_distance`
- allow SciPy-backed distance transforms to operate on higher-dimensional inputs for the new 3D surface metric path

### Validation

Targeted checks run locally:

- `python -m ruff check src/torchmetrics/functional/segmentation/utils.py src/torchmetrics/functional/segmentation/surface_dice.py src/torchmetrics/segmentation/surface_dice.py tests/unittests/segmentation/test_surface_dice_score.py src/torchmetrics/functional/segmentation/__init__.py src/torchmetrics/segmentation/__init__.py`
- `python -m mypy src/torchmetrics/functional/segmentation/surface_dice.py src/torchmetrics/segmentation/surface_dice.py src/torchmetrics/functional/segmentation/utils.py`
- `python -m pytest tests/unittests/segmentation/test_surface_dice_score.py -q`
- `python -m pytest src/torchmetrics/functional/segmentation/surface_dice.py src/torchmetrics/segmentation/surface_dice.py tests/unittests/segmentation/test_surface_dice_score.py -q`

I also ran direct sanity checks against the published `surface-distance` package for binary 2D, binary 3D, and multiclass per-class examples.

### Limitations

- this first PR adds Surface Dice only, not average surface distance or surface overlap at tolerance
- the metric uses Euclidean closest-surface distance only
- 3D closest-surface distance currently relies on SciPy-backed distance transforms

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Yes