### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/pull-caches/action.yml
+++ b/.github/actions/pull-caches/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Cache Torch & HF
       if: inputs.cache-torch-HF == 'true' # since the input is string
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         enableCrossOsArchive: true
         path: ${{ env.CACHES_DIR }}
@@ -66,7 +66,7 @@ runs:
       # do not use this cache for dispatch and crone, to enable rebuild caches if needed
       if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && inputs.cache-references == 'true'
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: tests/_cache-references
         key: cache-references

--- a/.github/actions/push-caches/action.yml
+++ b/.github/actions/push-caches/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Cache Torch & HF
       if: inputs.cache-torch-HF == 'true' # since the input is string
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         enableCrossOsArchive: true
         path: ${{ env.CACHES_DIR }}
@@ -31,7 +31,7 @@ runs:
     - name: Cache references
       if: inputs.cache-references == 'true' # since the input is string
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         #enableCrossOsArchive: true
         path: tests/_cache-references

--- a/.github/workflows/_focus-diff.yml
+++ b/.github/workflows/_focus-diff.yml
@@ -16,8 +16,8 @@ jobs:
     outputs:
       focus: ${{ steps.diff-domains.outputs.focus }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
       - name: Get PR diff
         id: diff-domains

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -13,20 +13,20 @@ concurrency:
 
 jobs:
   check-code:
-    uses: Lightning-AI/utilities/.github/workflows/check-typing.yml@v0.15.2
+    uses: Lightning-AI/utilities/.github/workflows/check-typing.yml@2094525f99d94e25998563f5f7c960d48c12dc87 # v0.15.2
     with:
       actions-ref: v0.15.2
       extra-typing: "typing"
 
   check-schema:
-    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@v0.15.2
+    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@2094525f99d94e25998563f5f7c960d48c12dc87 # v0.15.2
     with:
       actions-ref: v0.15.2
       azure-schema-version: "v1.208.0"
 
   check-package:
     if: github.event.pull_request.draft == false
-    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@v0.15.3
+    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       actions-ref: v0.15.2
       artifact-name: dist-packages-${{ github.sha }}
@@ -38,7 +38,7 @@ jobs:
         }
 
   check-md-links:
-    uses: Lightning-AI/utilities/.github/workflows/check-md-links.yml@v0.15.2
+    uses: Lightning-AI/utilities/.github/workflows/check-md-links.yml@2094525f99d94e25998563f5f7c960d48c12dc87 # v0.15.2
     with:
       base-branch: master
       config-file: ".github/markdown-links-config.json"

--- a/.github/workflows/ci-integrate.yml
+++ b/.github/workflows/ci-integrate.yml
@@ -43,10 +43,10 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: ${{ matrix.python-version }}
           # TODO: Avoid activating environment like this

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -77,10 +77,10 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: ${{ matrix.python-version }}
           # TODO: Avoid activating environment like this
@@ -224,7 +224,7 @@ jobs:
       - name: Upload coverage to Codecov
         # skip for PR if there is nothing to test, note that outside PR there is default 'unittests'
         if: ${{ env.TEST_DIRS != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "tests/coverage.xml"

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   cron-clear:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
-    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@v0.15.2
+    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@2094525f99d94e25998563f5f7c960d48c12dc87 # v0.15.2
     with:
       scripts-ref: v0.15.2
       dry-run: ${{ github.event_name == 'pull_request' }}
@@ -32,7 +32,7 @@ jobs:
 
   direct-clear:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
-    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@v0.15.2
+    uses: Lightning-AI/utilities/.github/workflows/cleanup-caches.yml@2094525f99d94e25998563f5f7c960d48c12dc87 # v0.15.2
     with:
       scripts-ref: v0.15.2
       dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/cmd-help.yml
+++ b/.github/workflows/cmd-help.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update with comment
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.PAT_GHOST }}
           reaction-token: ${{ secrets.PAT_GHOST }}

--- a/.github/workflows/cmd-rebase.yml
+++ b/.github/workflows/cmd-rebase.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pull request
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.PAT_GHOST }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
@@ -30,7 +30,7 @@ jobs:
           git push --force-with-lease
 
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.PAT_GHOST }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.PAT_GHOST }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,18 +38,18 @@ jobs:
         python: ["3.10", "3.11"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to DockerHub
         if: env.PUSH_DOCKERHUB == 'true' && github.repository_owner == 'Lightning-AI'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build (and Push) Devcontainer
         # publish master/release
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           build-args: |
             VARIANT=${{ matrix.python }}
@@ -83,10 +83,10 @@ jobs:
           - { python: "3.12", pytorch: "2.10.0", cuda: "12.8.1", ubuntu: "24.04" }
           #- { python: "3.13", pytorch: "2.8.0", cuda: "12.6.3", ubuntu: "24.04" }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         if: env.PUSH_DOCKERHUB == 'true' && github.repository_owner == 'Lightning-AI'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -99,7 +99,7 @@ jobs:
           echo "PT_VERSION=$pt_version" >> $GITHUB_ENV
 
       - name: Build (and Push) runner
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu }}

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -37,10 +37,10 @@ jobs:
         target: [html, doctest, linkcheck]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv and set Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.10"
           # TODO: Avoid activating environment like this
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload built docs
         if: ${{ matrix.target == 'html' && github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docs-${{ matrix.target }}-${{ github.sha }}
           path: docs/build/
@@ -103,17 +103,17 @@ jobs:
     env:
       GCP_TARGET: "gs://lightning-docs-metrics"
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: docs-html-${{ github.sha }}
           path: docs/build/
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCS_SA_KEY }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           project_id: ${{ secrets.GCS_PROJECT }}
 

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 
@@ -31,7 +31,7 @@ jobs:
           python setup.py sdist bdist_wheel
           ls -lh dist/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
@@ -42,14 +42,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
       - run: ls -lh dist/
 
       - name: Upload to release
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         with:
           files: "dist/*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -60,14 +60,14 @@ jobs:
   #   runs-on: ubuntu-latest
   #   timeout-minutes: 5
   #   steps:
-  #     - uses: actions/download-artifact@v5
+  #     - uses: actions/download-artifact@<COMMIT_SHA>  # repo pins SHAs, not tags; last tag in use: v5
   #       with:
   #         name: pypi-packages-${{ github.sha }}
   #         path: dist
   #     - run: ls -lh dist/
   #     # We do this, since failures on test.pypi aren't that bad
   #     - name: Publish to Test PyPI
-  #       uses: pypa/gh-action-pypi-publish@v1.13.0
+  #       uses: pypa/gh-action-pypi-publish@<COMMIT_SHA>  # repo pins SHAs, not tags; last tag in use: v1.13.0
   #       with:
   #         user: __token__
   #         password: ${{ secrets.test_pypi_password }}
@@ -78,7 +78,7 @@ jobs:
   #   needs: publish-pypi-test
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: juliangruber/sleep-action@v2
+  #     - uses: juliangruber/sleep-action@<COMMIT_SHA>  # repo pins SHAs, not tags; last tag in use: v2
   #       with:
   #         time: 5m
 
@@ -90,10 +90,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: pypi-packages-${{ github.sha }}
           path: dist
       - run: ls -lh dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/slash-cmd-dispatch.yml
+++ b/.github/workflows/slash-cmd-dispatch.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v4.0.0
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0
         with:
           token: ${{ secrets.PAT_GHOST }}
           reaction-token: ${{ secrets.PAT_GHOST }}


### PR DESCRIPTION
## What does this PR do?

Pins all GitHub Actions and reusable-workflow references to immutable commit SHAs - as agreed with @justusschock in [this comment](https://github.com/Lightning-AI/torchmetrics/pull/3365#issuecomment-4505284245) on #3365.

This covers 41 references across 13 files (11 workflows + 2 composite actions). Each action is pinned to the commit its current tag resolves to, with the release version kept as a trailing comment (e.g. `actions/checkout@de0fac2… # v6.0.2`), the format Dependabot recognises, so it keeps the SHAs current going forward. No behaviour change as every pin points at the same commit the tag already ran.

A few notes for the reviewer:

- `greetings.yml` is intentionally excluded, it's pinned separately in #3365.
- The 3 commented-out `uses:` lines in `publish-pkg.yml` aren't pinned as they are inactive. Their tags were replaced with a `@<COMMIT_SHA>` placeholder plus a note that the repo now pins SHAs, recording the last tag in use.
- Open Dependabot PRs #3369, #3368, #3301 and #3370 bump some of these actions. As this PR pins them at their current versions, those will conflict on merge, but Dependabot auto-rebases tag bumps into SHA bumps once an action is SHA-pinned, so the upgrades aren't lost, only re-sequenced. (#3281 seems to be stale as it bumps `actions/labeler`, which is already removed by #3382)
- Incidental finding while doing this: the slash-command workflows (`slash-cmd-dispatch`, `cmd-help`, `cmd-rebase`) are currently non-functional. `slash-cmd-dispatch` fails on every run because the `PAT_GHOST` secret is empty, so `/rebase` and `/help` never dispatch. ~~Will fill this as a separate issue~~ Filed at #3393.

<details>
  <summary>Before submitting</summary>

- [x] **(agreed in [this comment](https://github.com/Lightning-AI/torchmetrics/pull/3365#issuecomment-4505284245) on #3365)** Was this **discussed/agreed** via a Github issue?
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] **(Not required, CI-only config change)** Did you make sure to **update the docs**?
- [ ] **(Not required, CI-only config change)** Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Oh yes, preventing a `tj-actions/changed-files` style supply chain attack sure is fun.