### PR TITLE
ci: add 2-day package install cooldown (supply-chain guard)

### DIFF
--- a/.github/workflows/ci-integrate.yml
+++ b/.github/workflows/ci-integrate.yml
@@ -37,6 +37,8 @@ jobs:
       UV_TORCH_BACKEND: "cpu"
       # TODO: Remove this - Enable running MPS tests on this platform
       DISABLE_MPS: ${{ startsWith(matrix.os, 'macOS') && '1' || '0' }}
+      # Supply-chain guard: refuse PyPI releases newer than 2 days. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+      UV_EXCLUDE_NEWER: "2 days"
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     # seems that MacOS jobs take much more than orger OS
@@ -69,7 +71,9 @@ jobs:
           # this was updated in `source cashing` by optional oldest
           cat requirements/_integrate.txt
           # to have install pyTorch
-          uv pip install -e . "setuptools==69.5.1" --extra-index-url=${PYTORCH_URL}
+          # --index-strategy unsafe-best-match: PyTorch extra-index mirrors older packages; without this
+          # flag uv won't fall back to PyPI for a newer compatible version under UV_EXCLUDE_NEWER.
+          uv pip install -e . "setuptools==69.5.1" --extra-index-url=${PYTORCH_URL} --index-strategy unsafe-best-match
 
           # adjust version to PT ecosystem based on installed TM
           python -m wget https://raw.githubusercontent.com/Lightning-AI/utilities/main/scripts/adjust-torch-versions.py

--- a/.github/workflows/ci-integrate.yml
+++ b/.github/workflows/ci-integrate.yml
@@ -73,7 +73,7 @@ jobs:
           # to have install pyTorch
           # --index-strategy unsafe-best-match: PyTorch extra-index mirrors older packages; without this
           # flag uv won't fall back to PyPI for a newer compatible version under UV_EXCLUDE_NEWER.
-          uv pip install -e . "setuptools==69.5.1" --extra-index-url=${PYTORCH_URL} --index-strategy unsafe-best-match
+          uv pip install -e . "setuptools==69.5.1" --extra-index-url=${PYTORCH_URL}
 
           # adjust version to PT ecosystem based on installed TM
           python -m wget https://raw.githubusercontent.com/Lightning-AI/utilities/main/scripts/adjust-torch-versions.py

--- a/.github/workflows/ci-integrate.yml
+++ b/.github/workflows/ci-integrate.yml
@@ -71,8 +71,6 @@ jobs:
           # this was updated in `source cashing` by optional oldest
           cat requirements/_integrate.txt
           # to have install pyTorch
-          # --index-strategy unsafe-best-match: PyTorch extra-index mirrors older packages; without this
-          # flag uv won't fall back to PyPI for a newer compatible version under UV_EXCLUDE_NEWER.
           uv pip install -e . "setuptools==69.5.1" --extra-index-url=${PYTORCH_URL}
 
           # adjust version to PT ecosystem based on installed TM

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -71,6 +71,8 @@ jobs:
       # PIP_EXTRA_URL: "--find-links=https://download.pytorch.org/whl/cpu/torch_stable.html"
       UV_TORCH_BACKEND: "cpu"
       UNITTEST_TIMEOUT: "" # by default, it is not set
+      # Supply-chain guard: refuse PyPI releases newer than 2 days. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+      UV_EXCLUDE_NEWER: "2 days"
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     # seems that macOS jobs take much more than orger OS

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -26,6 +26,8 @@ env:
   SPHINX_MOCK_REQUIREMENTS: 0
   SPHINX_FETCH_ASSETS: 0
   SPHINX_PIN_RELEASE_VERSIONS: 0
+  # Supply-chain guard: refuse PyPI releases newer than 2 days. See https://docs.astral.sh/uv/reference/settings/#exclude-newer
+  UV_EXCLUDE_NEWER: "2 days"
 
 jobs:
   docs-make:


### PR DESCRIPTION
## What does this PR do?

Adds a CI-only supply-chain guard: the resolver refuses any PyPI release published within the last **2 days**, so typosquats and malicious uploads that get yanked within ~24 h never land in our CI image.

| Workflow | Env var | Tool |
|---|---|---|
| `ci-tests.yml` (`pytester` job) | `UV_EXCLUDE_NEWER: "2 days"` | uv |
| `ci-integrate.yml` (`pytest` job) | `UV_EXCLUDE_NEWER: "2 days"` | uv |
| `docs-build.yml` (`docs-make` job) | `UV_EXCLUDE_NEWER: "2 days"` | uv |

### Notes
- **Not covered in this PR (follow-ups)**:
  - `_focus-diff.yml` and `docs-build.yml` deploy job — use plain `pip`; need a pip→uv migration first
  - `publish-pkg.yml` — excluded for now; `PIP_UPLOADED_PRIOR_TO` can leak into pip's build-isolation subprocess

Ref: https://github.com/Lightning-AI/pytorch-lightning/pull/21722

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you verify new and **existing tests pass** locally with your changes?

</details>