### PR TITLE
Fix RetrievalPrecisionRecallCurve axis labels and swap axis

### DIFF
--- a/src/torchmetrics/retrieval/precision_recall_curve.py
+++ b/src/torchmetrics/retrieval/precision_recall_curve.py
@@ -287,9 +287,9 @@ class RetrievalPrecisionRecallCurve(Metric):
         """
         curve = curve or self.compute()
         return plot_curve(
-            curve,
+            (curve[1], curve[0], curve[2]),
             ax=ax,
-            label_names=("Precision", "Recall"),
+            label_names=("Recall", "Precision"),
             name=self.__class__.__name__,
         )
 

--- a/src/torchmetrics/retrieval/precision_recall_curve.py
+++ b/src/torchmetrics/retrieval/precision_recall_curve.py
@@ -289,7 +289,7 @@ class RetrievalPrecisionRecallCurve(Metric):
         return plot_curve(
             curve,
             ax=ax,
-            label_names=("False positive rate", "True positive rate"),
+            label_names=("Precision", "Recall"),
             name=self.__class__.__name__,
         )
 

--- a/src/torchmetrics/retrieval/precision_recall_curve.py
+++ b/src/torchmetrics/retrieval/precision_recall_curve.py
@@ -285,9 +285,11 @@ class RetrievalPrecisionRecallCurve(Metric):
             >>> fig_, ax_ = metric.plot()
 
         """
-        curve = curve or self.compute()
+        curve_computed = curve or self.compute()
+        # switch order as the standard way is recall along x-axis and precision along y-axis
+        curve_computed = (curve_computed[1], curve_computed[0], curve_computed[2])
         return plot_curve(
-            (curve[1], curve[0], curve[2]),
+            curve_computed,
             ax=ax,
             label_names=("Recall", "Precision"),
             name=self.__class__.__name__,

--- a/tests/unittests/retrieval/test_precision_recall_curve.py
+++ b/tests/unittests/retrieval/test_precision_recall_curve.py
@@ -191,6 +191,8 @@ class TestRetrievalPrecisionRecallCurve(RetrievalPrecisionRecallCurveTester):
 def test_plot_axis_labels() -> None:
     """Assert RetrievalPrecisionRecallCurve.plot() uses Recall on x-axis and Precision on y-axis."""
     pytest.importorskip("matplotlib")
+    import matplotlib.axes
+
     metric = RetrievalPrecisionRecallCurve()
     metric.update(
         torch.rand(10),
@@ -198,5 +200,6 @@ def test_plot_axis_labels() -> None:
         indexes=torch.randint(2, (10,)),
     )
     _, ax = metric.plot()
+    assert isinstance(ax, matplotlib.axes.Axes)
     assert ax.get_xlabel() == "Recall"
     assert ax.get_ylabel() == "Precision"

--- a/tests/unittests/retrieval/test_precision_recall_curve.py
+++ b/tests/unittests/retrieval/test_precision_recall_curve.py
@@ -186,3 +186,17 @@ class TestRetrievalPrecisionRecallCurve(RetrievalPrecisionRecallCurveTester):
             reference_metric=_compute_precision_recall_curve,
             metric_args=metric_args,
         )
+
+
+def test_plot_axis_labels() -> None:
+    """Assert RetrievalPrecisionRecallCurve.plot() uses Recall on x-axis and Precision on y-axis."""
+    pytest.importorskip("matplotlib")
+    metric = RetrievalPrecisionRecallCurve()
+    metric.update(
+        torch.rand(10),
+        torch.randint(2, (10,)),
+        indexes=torch.randint(2, (10,)),
+    )
+    _, ax = metric.plot()
+    assert ax.get_xlabel() == "Recall"
+    assert ax.get_ylabel() == "Precision"


### PR DESCRIPTION
## What does this PR do?

Fixes #3403 .

Somehow, the plots for retrieval precision recall curves evolved to label the axis True and False positive rates (TPR and FPR). These are the same labels used in ROCs. There are three isues: the label FPR is wrong (precision and FPR are not the same thing), it is weird to use TPR (TPR and Recall are the same) as label name if the other label name is Precision, it is odd to use Precision on the x axis. This PR addresses the three things (the first two issues in the first commit), the third issue in the second commit).

I think the reason we ended up in this situation is (repeated here from the commit messages in this PR):

> It seems this issue was originally introduced as part of #1623 when
> the plot method was first added using `plot_binary_roc_curve`.  ROCs do
> plot TPR against FPR.  I'm guessing that when `plot_binary_roc_curve`
> was replaced with `plot_curve` in #1660, those wrong labels were kept.

and

> It is standard to use Recall on the x axis and Precision on the y axis
> but the current implementation has it flipped.  This is possibly
> because the implementation evolved (incorrectly) from ROCs where TPR
> (aka Recall) is on the y axis and FPR on the x axis.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section? yes
- [x] Did you make sure to **update the docs**? There are no associated docs.
- [x] Did you write any new **necessary tests**? There are no associated tests.

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>