### PR TITLE
fix(clip_score): unwrap dataclass output from get_image/text_features

### DIFF
--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -130,7 +130,8 @@ def _get_features(
     if modality == "image":
         image_data = [i for i in data if isinstance(i, Tensor)]  # Add type checking for images
         processed = processor(images=[i.cpu() for i in image_data], return_tensors="pt", padding=True)
-        return model.get_image_features(processed["pixel_values"].to(device))
+        features = model.get_image_features(processed["pixel_values"].to(device))
+        return features.pooler_output if hasattr(features, 'pooler_output') else features
     if modality == "text":
         processed = processor(text=data, return_tensors="pt", padding=True)
         if hasattr(model.config, "text_config") and hasattr(model.config.text_config, "max_position_embeddings"):
@@ -144,7 +145,8 @@ def _get_features(
                 )
                 processed["attention_mask"] = processed["attention_mask"][..., :max_position_embeddings]
                 processed["input_ids"] = processed["input_ids"][..., :max_position_embeddings]
-        return model.get_text_features(processed["input_ids"].to(device), processed["attention_mask"].to(device))
+        features = model.get_text_features(processed["input_ids"].to(device), processed["attention_mask"].to(device))
+        return features.pooler_output if hasattr(features, 'pooler_output') else features
     raise ValueError(f"invalid modality {modality}")
 
 

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -130,9 +130,9 @@ def _get_features(
     if modality == "image":
         image_data = [i for i in data if isinstance(i, Tensor)]  # Add type checking for images
         processed = processor(images=[i.cpu() for i in image_data], return_tensors="pt", padding=True)
-features = model.get_image_features(processed["pixel_values"].to(device))
-pooled = getattr(features, "pooler_output", None)
-return pooled if pooled is not None else features
+        features = model.get_image_features(processed["pixel_values"].to(device))
+        pooled = getattr(features, "pooler_output", None)
+        return pooled if pooled is not None else features
     if modality == "text":
         processed = processor(text=data, return_tensors="pt", padding=True)
         if hasattr(model.config, "text_config") and hasattr(model.config.text_config, "max_position_embeddings"):
@@ -147,7 +147,8 @@ return pooled if pooled is not None else features
                 processed["attention_mask"] = processed["attention_mask"][..., :max_position_embeddings]
                 processed["input_ids"] = processed["input_ids"][..., :max_position_embeddings]
         features = model.get_text_features(processed["input_ids"].to(device), processed["attention_mask"].to(device))
-        return features.pooler_output if hasattr(features, "pooler_output") else features
+        pooled = getattr(features, "pooler_output", None)
+        return pooled if pooled is not None else features
     raise ValueError(f"invalid modality {modality}")
 
 

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -131,7 +131,7 @@ def _get_features(
         image_data = [i for i in data if isinstance(i, Tensor)]  # Add type checking for images
         processed = processor(images=[i.cpu() for i in image_data], return_tensors="pt", padding=True)
         features = model.get_image_features(processed["pixel_values"].to(device))
-        return features.pooler_output if hasattr(features, 'pooler_output') else features
+        return features.pooler_output if hasattr(features, "pooler_output") else features
     if modality == "text":
         processed = processor(text=data, return_tensors="pt", padding=True)
         if hasattr(model.config, "text_config") and hasattr(model.config.text_config, "max_position_embeddings"):
@@ -146,7 +146,7 @@ def _get_features(
                 processed["attention_mask"] = processed["attention_mask"][..., :max_position_embeddings]
                 processed["input_ids"] = processed["input_ids"][..., :max_position_embeddings]
         features = model.get_text_features(processed["input_ids"].to(device), processed["attention_mask"].to(device))
-        return features.pooler_output if hasattr(features, 'pooler_output') else features
+        return features.pooler_output if hasattr(features, "pooler_output") else features
     raise ValueError(f"invalid modality {modality}")
 
 

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -130,8 +130,9 @@ def _get_features(
     if modality == "image":
         image_data = [i for i in data if isinstance(i, Tensor)]  # Add type checking for images
         processed = processor(images=[i.cpu() for i in image_data], return_tensors="pt", padding=True)
-        features = model.get_image_features(processed["pixel_values"].to(device))
-        return features.pooler_output if hasattr(features, "pooler_output") else features
+features = model.get_image_features(processed["pixel_values"].to(device))
+pooled = getattr(features, "pooler_output", None)
+return pooled if pooled is not None else features
     if modality == "text":
         processed = processor(text=data, return_tensors="pt", padding=True)
         if hasattr(model.config, "text_config") and hasattr(model.config.text_config, "max_position_embeddings"):

--- a/tests/unittests/multimodal/test_clip_score.py
+++ b/tests/unittests/multimodal/test_clip_score.py
@@ -23,6 +23,7 @@ from torch import Tensor
 from torchmetrics.functional.multimodal.clip_score import (
     _detect_modality,
     _get_clip_model_and_processor,
+    _get_features,
     _process_image_data,
     _process_text_data,
     clip_score,
@@ -307,3 +308,40 @@ def test_process_text_data(texts, expected_len):
     assert isinstance(processed, list)
     assert len(processed) == expected_len
     assert all(isinstance(text, str) for text in processed)
+
+
+def test_clip_score_handles_dataclass_output():
+    """Test that _get_features handles BaseModelOutputWithPooling from transformers >= 5.0."""
+    from unittest.mock import MagicMock
+
+    from transformers.modeling_outputs import BaseModelOutputWithPooling
+
+    pooled = torch.randn(1, 512)
+    dataclass_output = BaseModelOutputWithPooling(
+        last_hidden_state=torch.randn(1, 10, 512),
+        pooler_output=pooled,
+    )
+
+    model = MagicMock()
+    model.get_image_features.return_value = dataclass_output
+    model.get_text_features.return_value = dataclass_output
+    model.config = MagicMock(spec=[])  # no text_config
+
+    processor = MagicMock()
+    processor.return_value = {
+        "pixel_values": torch.randn(2, 3, 64, 64),
+        "input_ids": torch.randint(100, (2, 5)),
+        "attention_mask": torch.ones(2, 5),
+    }
+
+    device = torch.device("cpu")
+    images = list(_random_input.images[0])
+    texts = captions[0:2]
+
+    image_features = _get_features(images, "image", device, model, processor)
+    text_features = _get_features(texts, "text", device, model, processor)
+
+    assert isinstance(image_features, Tensor)
+    assert isinstance(text_features, Tensor)
+    assert torch.equal(image_features, pooled)
+    assert torch.equal(text_features, pooled)

--- a/tests/unittests/multimodal/test_clip_score.py
+++ b/tests/unittests/multimodal/test_clip_score.py
@@ -309,7 +309,7 @@ def test_process_text_data(texts, expected_len):
     assert len(processed) == expected_len
     assert all(isinstance(text, str) for text in processed)
 
-
+@pytest.mark.skipif(not _TRANSFORMERS_GREATER_EQUAL_4_10, reason="test requires transformers>=4.10")
 def test_clip_score_handles_dataclass_output():
     """Test that _get_features handles BaseModelOutputWithPooling from transformers >= 5.0."""
     from unittest.mock import MagicMock

--- a/tests/unittests/multimodal/test_clip_score.py
+++ b/tests/unittests/multimodal/test_clip_score.py
@@ -309,6 +309,7 @@ def test_process_text_data(texts, expected_len):
     assert len(processed) == expected_len
     assert all(isinstance(text, str) for text in processed)
 
+
 @pytest.mark.skipif(not _TRANSFORMERS_GREATER_EQUAL_4_10, reason="test requires transformers>=4.10")
 def test_clip_score_handles_dataclass_output():
     """Test that _get_features handles BaseModelOutputWithPooling from transformers >= 5.0."""


### PR DESCRIPTION
# What does this PR do?

Fixes #3407 

Fixes a compatibility issue where `_get_features` in `clip_score.py` would fail when `get_image_features` or `get_text_features` returns a `BaseModelOutputWithPooling` dataclass (transformers >= 5.0) instead of a plain `Tensor`. The fix extracts `pooler_output` when the return value has that attribute, maintaining backward compatibility with older transformers versions.
 
---
 
## Before submitting checklist
 
- [ ] Was this discussed/agreed via a Github issue? — check if there's an existing issue, otherwise leave as is
- [x] Did you read the contributor guideline? — yes
- [x] Did you make sure to update the docs? — no doc changes needed for this fix
- [x] Did you write any new necessary tests? — yes, `test_clip_score_handles_dataclass_output`
---
 
## Did you have fun?
 
Yes! 🙃
