### PR TITLE
docs: add AGENTS.md agent guide for torchmetrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,31 @@
-# AGENTS.md - TorchMetrics
+# AGENTS.md — TorchMetrics
 
-AI coding agent guide. For contribution process, coding style, and PR workflow see
-[CONTRIBUTING.md](.github/CONTRIBUTING.md).
+AI coding agent guide. Contribution process, coding style, PR workflow → [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ______________________________________________________________________
 
-## Essential commands
+## Commands
 
 ```bash
-# Install (editable + all dev deps)
+# Install
 pip install -e . -r requirements/_devel.txt
 
-# Download sample data required by audio/image/detection tests
+# Sample data (audio/image/detection tests)
 make data
 
-# Lint and format (ruff, docformatter, codespell -- via pre-commit)
+# Lint/format via pre-commit (ruff, docformatter, codespell)
 pre-commit run --all-files
-# Type check (mypy is NOT in pre-commit -- run separately)
+# Type check — not in pre-commit, run separately
 mypy src/torchmetrics/
 
-# Tests -- two separate steps (src layout)
+# Tests
 python -m pytest src/torchmetrics     # doctests inside package
 python -m pytest tests/ -v            # unit tests
+pytest tests/unittests/classification/ -v   # single domain
+USE_PYTEST_POOL="1" pytest -m DDP tests/    # DDP tests
 
-# Single domain (run from repo root)
-pytest tests/unittests/classification/ -v
-
-# DDP tests
-USE_PYTEST_POOL="1" pytest -m DDP tests/
-
-# Docs
-make docs    # output: docs/build/html/index.html
+# Docs → docs/build/html/index.html
+make docs
 ```
 
 ______________________________________________________________________
@@ -39,122 +34,108 @@ ______________________________________________________________________
 
 ```
 src/torchmetrics/
-  metric.py            # Metric base class
-  collections.py       # MetricCollection
-  aggregation.py       # MeanMetric, SumMetric, MinMetric, MaxMetric, CatMetric
-  wrappers/            # BootStrapper, ClasswiseWrapper, Running, MetricTracker, ...
-  utilities/           # imports.py, data.py, distributed.py, checks.py, plot.py
-  <domain>/            # audio, classification, clustering, detection, image,
-                       # multimodal, nominal, regression, retrieval,
-                       # segmentation, shape, text, video
-    __init__.py
-    <metric>.py        # module-based Metric subclass
-  functional/
-    <domain>/          # pure-function counterparts; also includes pairwise/
-                       # (pairwise has functional API only, no module package)
+├── metric.py            # Metric base class
+├── collections.py       # MetricCollection
+├── aggregation.py       # MeanMetric, SumMetric, MinMetric, MaxMetric, CatMetric
+├── wrappers/            # BootStrapper, ClasswiseWrapper, Running, MetricTracker, …
+├── utilities/           # imports.py, data.py, distributed.py, checks.py, plot.py
+├── functional/
+│   └── <domain>/        # pure-function counterparts; pairwise/ has functional API only
+└── <domain>/            # audio, classification, clustering, detection, image,
+                         # multimodal, nominal, regression, retrieval,
+                         # segmentation, shape, text, video
+    ├── __init__.py
+    └── <metric>.py      # module-based Metric subclass
 
 tests/
-  _cache-references/   # created during tests; cachier-backed reference output cache (configurable via PYTEST_REFERENCE_CACHE)
-  unittests/
-    _helpers/testers.py   # MetricTester -- base for all metric tests
-    text/_helpers.py      # TextTester -- specialised base for text domain tests
-    conftest.py           # BATCH_SIZE=32, NUM_BATCHES=2 * NUM_PROCESSES, NUM_CLASSES=5, NUM_PROCESSES=2
-    <domain>/             # mirrors src/torchmetrics/<domain>/; pairwise/ present here too
+├── _cache-references/   # cachier-backed ref output cache (env: PYTEST_REFERENCE_CACHE)
+└── unittests/
+    ├── _helpers/testers.py   # MetricTester — base for all metric tests
+    ├── text/_helpers.py      # TextTester — text domain specialisation
+    ├── conftest.py           # BATCH_SIZE=32, NUM_BATCHES=2*NUM_PROCESSES, NUM_CLASSES=5, NUM_PROCESSES=2
+    └── <domain>/             # mirrors src/torchmetrics/<domain>/; pairwise/ present too
 ```
 
 ______________________________________________________________________
 
 ## Metric base class contract
 
-Every metric subclasses `torchmetrics.Metric` (which subclasses `torch.nn.Module`).
+Every metric subclasses `torchmetrics.Metric` (→ `torch.nn.Module`).
 
 ```python
 class MyMetric(Metric):
-    is_differentiable: bool = False  # class-level, not instance
+    is_differentiable: bool = False
     higher_is_better: bool = True
-    full_state_update: bool = False  # set True only if update needs full history
+    full_state_update: bool = False  # True only if update needs full history
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # Register ALL persistent state here -- nowhere else
+        # ALL persistent state registered here — nowhere else
         self.add_state("correct", default=torch.tensor(0), dist_reduce_fx="sum")
         self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
 
     def update(self, preds: Tensor, target: Tensor) -> None:
-        # Accumulate into self.* state -- no return value
+        # Accumulate into self.* state — no return value
         self.correct += (preds == target).sum()
         self.total += target.numel()
 
     def compute(self) -> Tensor:
-        # Reduce accumulated state to scalar/tensor -- no side effects
+        # Reduce accumulated state — no side effects
         return self.correct.float() / self.total
 ```
 
-Avoid overriding `reset()` or `forward()` for ordinary metrics -- the base class owns
-them. Wrappers (`wrappers/`) may override both; rare metrics with non-default reset
-logic may override `reset()` (e.g. `image/fid.py`).
-
-`dist_reduce_fx` options: `"sum"`, `"mean"`, `"cat"`, `"min"`, `"max"`, or a callable.
-List states (append-style) use `dist_reduce_fx="cat"`.
+- Never override `reset()` or `forward()` on plain metrics — base class owns them
+- Wrappers (`wrappers/`) may override both; rare metrics may override `reset()` (e.g. `image/fid.py`)
+- `dist_reduce_fx` options: `"sum"`, `"mean"`, `"cat"`, `"min"`, `"max"`, or callable
+- List (append-style) states use `dist_reduce_fx="cat"`
 
 ______________________________________________________________________
 
-## Adding a new metric -- checklist
+## Adding a new metric
 
-1. **Functional helpers** -- `src/torchmetrics/functional/<domain>/<metric>.py`
-   (most metrics; skip for complex stateful metrics like FID/KID that are module-only)
+1. **Functional helpers** — `src/torchmetrics/functional/<domain>/<metric>.py`
+   - `_<metric>_update(...)` → intermediate tensors (tp, fp, …)
+   - `_<metric>_compute(...)` / `_<metric>_reduce(...)` → final value
+   - `_<metric>_arg_validation(...)` / `_<metric>_tensor_validation(...)` for input checks
+   - Skip for module-only metrics (FID/KID style — intentionally no functional layer)
 
-   - `_<metric>_update(...)` -> returns intermediate tensors (tp, fp, ...)
-   - `_<metric>_compute(...)` or `_<metric>_reduce(...)` -> returns final value
-   - Input validation in `_<metric>_arg_validation(...)` / `_<metric>_tensor_validation(...)`
-
-2. **Module class** -- `src/torchmetrics/<domain>/<metric>.py`
-
+2. **Module class** — `src/torchmetrics/<domain>/<metric>.py`
    - Subclass `Metric`; call functional helpers from `update()` and `compute()`
 
-3. **Classification task variants** -- classification metrics use task-specific subclasses.
-   Most implement all three: `BinaryXxx`, `MulticlassXxx`, `MultilabelXxx`.
-   Some support only a subset when a task is semantically inapplicable (e.g. `CohenKappa`
-   has no multilabel variant; `ExactMatch` has no binary variant). A public wrapper class
-   (e.g. `Accuracy`) inherits `_ClassificationTaskWrapper` and overrides `__new__` to
-   dispatch on `task: Literal["binary","multiclass","multilabel"]`.
+3. **Classification task variants** — implement `BinaryXxx`, `MulticlassXxx`, `MultilabelXxx`
+   unless a task is semantically inapplicable (e.g. `CohenKappa` has no multilabel;
+   `ExactMatch` has no binary). Public wrapper (e.g. `Accuracy`) inherits
+   `_ClassificationTaskWrapper`, overrides `__new__` to dispatch on
+   `task: Literal["binary","multiclass","multilabel"]`.
 
-4. **Exports** -- add to all that apply:
-
+4. **Exports** — add to all applicable:
    - `src/torchmetrics/<domain>/__init__.py`
    - `src/torchmetrics/functional/<domain>/__init__.py`
-   - `src/torchmetrics/__init__.py` (top-level, for metrics exposed at package root)
+   - `src/torchmetrics/__init__.py` (top-level)
 
-5. **Optional dependencies** -- gate with `RequirementCache` from
-   `torchmetrics.utilities.imports`; add `__doctest_skip__` at module level:
-
+5. **Optional dependencies** — gate with `RequirementCache`; add `__doctest_skip__`:
    ```python
    if not _MATPLOTLIB_AVAILABLE:
        __doctest_skip__ = ["MyMetric.plot"]
    ```
+   See [Optional dependency pattern](#optional-dependency-pattern).
 
-6. **Docs page** -- `docs/source/<domain>/<metric>.rst` following the domain pattern
+6. **Docs page** — `docs/source/<domain>/<metric>.rst`
 
-7. **Tests** -- `tests/unittests/<domain>/test_<metric>.py`:
-
-   - Use `MetricTester` as base class for all domains
-   - **Exception**: text metrics must subclass `TextTester` from
-     `tests/unittests/text/_helpers.py` -- it adds string/DDP handling
+7. **Tests** — `tests/unittests/<domain>/test_<metric>.py`
+   - All domains: subclass `MetricTester`
+   - Text domain only: subclass `TextTester` from `tests/unittests/text/_helpers.py`
 
 ______________________________________________________________________
 
 ## Testing with MetricTester
 
-`MetricTester` (in `tests/unittests/_helpers/testers.py`) compares metric output
-against a reference implementation (scikit-learn/scipy), checks pickling, and optionally
-runs DDP synchronization. Tests can be run from repo root (`pytest tests/...`) or from the `tests/` directory (`cd tests && python -m pytest unittests/...`); import accordingly:
+`MetricTester` compares against a reference (scikit-learn/scipy), checks pickling, optionally runs DDP sync.
 
 ```python
 # run as: cd tests && python -m pytest unittests/...
-import pytest
 from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests._helpers.testers import MetricTester
-
 
 class TestMyMetric(MetricTester):
     @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
@@ -169,21 +150,22 @@ class TestMyMetric(MetricTester):
         )
 ```
 
-DDP mode only runs when `USE_PYTEST_POOL=1` is set; the `pytest.mark.DDP` marker gates
-it. Reference outputs are cached by `cachier` under `tests/_cache-references/` by default (configurable via `PYTEST_REFERENCE_CACHE`) -- delete
-that dir to force recomputation.
+Two equivalent invocation styles:
+- `cd tests && python -m pytest unittests/...`
+- `pytest tests/...` from repo root
+
+DDP runs only when `USE_PYTEST_POOL=1`; `pytest.mark.DDP` gates the parametrize value.
+Reference cache at `tests/_cache-references/` (or `$PYTEST_REFERENCE_CACHE`) — delete to force recompute.
 
 ______________________________________________________________________
 
 ## Optional dependency pattern
 
 ```python
-# src/torchmetrics/utilities/imports.py -- add RequirementCache entry
-from lightning_utilities.core.imports import RequirementCache
-
+# src/torchmetrics/utilities/imports.py — add entry
 _SCIPY_AVAILABLE = RequirementCache("scipy")
 
-# In metric file -- guard import and doctest skip
+# In metric file
 from torchmetrics.utilities.imports import _SCIPY_AVAILABLE
 
 if not _SCIPY_AVAILABLE:
@@ -194,42 +176,25 @@ ______________________________________________________________________
 
 ## Docstring format
 
-Google-style, enforced by Napoleon + docformatter. Target style for new code:
+Google style enforced by Napoleon + docformatter — see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+Agent-critical rules (commonly missed):
 
-```python
-def update(self, preds: Tensor, target: Tensor) -> None:
-    """One-line summary.
-
-    Args:
-        preds: shape ``(N, C)`` predictions.
-        target: shape ``(N,)`` ground truth.
-
-    Raises:
-        ValueError: If shapes mismatch.
-
-    Example:
-        >>> metric = MyMetric()
-        >>> metric.update(preds, target)
-    """
-```
-
-Key rules: `Returns:` (plural, not `Return:`), line length 120, f-strings everywhere
-except `logging.*` calls (use `%`-style there). Existing code uses `Optional[float]` from `typing`; prefer that style for consistency.
+- `Returns:` plural — not `Return:`
+- Line length 120
+- f-strings everywhere except `logging.*` calls (use `%`-style there)
+- `Optional[float]` from `typing` — keep consistent with existing code
 
 ______________________________________________________________________
 
-## Common mistakes to avoid
+## Common pitfalls
 
-| Mistake                                             | Correct pattern                                                                                  |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Override `reset()` on plain metric                  | Only wrappers and rare special cases do this                                                     |
-| Override `forward()`                                | Don't -- base class calls `update()` + `compute()`                                               |
-| Call `add_state()` outside `__init__`               | Only in `__init__`                                                                               |
-| Return value from `update()`                        | `update()` returns `None`; mutate state in-place                                                 |
-| `Return:` in docstring                              | Use `Returns:`                                                                                   |
-| Export only in one `__init__.py`                    | Export in domain + functional + top-level as applicable                                          |
-| Use `MetricTester` for text metrics                 | Text domain uses `TextTester` from `text/_helpers.py`                                            |
-| Add functional helpers for module-only metrics      | FID/KID-style metrics intentionally skip this step                                               |
-| Hardcode task triple when subset applies            | Check existing metrics -- some omit inapplicable tasks                                           |
-| Run `python -m pytest unittests/...` from repo root | Either `cd tests` for `python -m pytest unittests/...`, or run `pytest tests/...` from repo root |
-| `import *`                                          | Explicit imports only                                                                            |
+- Override `reset()`/`forward()` on plain metric → only wrappers and rare special cases
+- Call `add_state()` outside `__init__` → register state only in `__init__`
+- Return value from `update()` → returns `None`; mutate state in-place
+- `import *` → explicit imports only
+- Export in one `__init__.py` only → export in domain + functional + top-level
+- Use `MetricTester` for text metrics → text domain needs `TextTester` from `text/_helpers.py`
+- Add functional helpers for module-only metrics → FID/KID intentionally skips that step
+- Hardcode all 3 task variants → check existing metrics; some omit inapplicable tasks
+- `Return:` in docstring → use `Returns:`
+- Run `python -m pytest unittests/...` from repo root → `cd tests` first, or use `pytest tests/...`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,16 +223,16 @@ ______________________________________________________________________
 
 ## Common mistakes to avoid
 
-| Mistake                                        | Correct pattern                                         |
-| ---------------------------------------------- | ------------------------------------------------------- |
-| Override `reset()` on plain metric             | Only wrappers and rare special cases do this            |
-| Override `forward()`                           | Don't -- base class calls `update()` + `compute()`      |
-| Call `add_state()` outside `__init__`          | Only in `__init__`                                      |
-| Return value from `update()`                   | `update()` returns `None`; mutate state in-place        |
-| `Return:` in docstring                         | Use `Returns:`                                          |
-| Export only in one `__init__.py`               | Export in domain + functional + top-level as applicable |
-| Use `MetricTester` for text metrics            | Text domain uses `TextTester` from `text/_helpers.py`   |
-| Add functional helpers for module-only metrics | FID/KID-style metrics intentionally skip this step      |
-| Hardcode task triple when subset applies       | Check existing metrics -- some omit inapplicable tasks  |
+| Mistake                                             | Correct pattern                                                                                  |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Override `reset()` on plain metric                  | Only wrappers and rare special cases do this                                                     |
+| Override `forward()`                                | Don't -- base class calls `update()` + `compute()`                                               |
+| Call `add_state()` outside `__init__`               | Only in `__init__`                                                                               |
+| Return value from `update()`                        | `update()` returns `None`; mutate state in-place                                                 |
+| `Return:` in docstring                              | Use `Returns:`                                                                                   |
+| Export only in one `__init__.py`                    | Export in domain + functional + top-level as applicable                                          |
+| Use `MetricTester` for text metrics                 | Text domain uses `TextTester` from `text/_helpers.py`                                            |
+| Add functional helpers for module-only metrics      | FID/KID-style metrics intentionally skip this step                                               |
+| Hardcode task triple when subset applies            | Check existing metrics -- some omit inapplicable tasks                                           |
 | Run `python -m pytest unittests/...` from repo root | Either `cd tests` for `python -m pytest unittests/...`, or run `pytest tests/...` from repo root |
-| `import *`                                     | Explicit imports only                                   |
+| `import *`                                          | Explicit imports only                                                                            |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ pre-commit run --all-files
 mypy src/torchmetrics/
 
 # Tests -- two separate steps (src layout)
-cd src && python -m pytest torchmetrics          # doctests inside package
-cd tests && python -m pytest unittests -v        # unit tests
+python -m pytest src/torchmetrics     # doctests inside package
+python -m pytest tests/ -v            # unit tests
 
 # Single domain (run from repo root)
 pytest tests/unittests/classification/ -v
@@ -54,7 +54,7 @@ src/torchmetrics/
                        # (pairwise has functional API only, no module package)
 
 tests/
-  _cache-references/   # cachier-backed reference output cache
+  _cache-references/   # created during tests; cachier-backed reference output cache (configurable via PYTEST_REFERENCE_CACHE)
   unittests/
     _helpers/testers.py   # MetricTester -- base for all metric tests
     text/_helpers.py      # TextTester -- specialised base for text domain tests
@@ -147,7 +147,7 @@ ______________________________________________________________________
 
 `MetricTester` (in `tests/unittests/_helpers/testers.py`) compares metric output
 against a reference implementation (scikit-learn/scipy), checks pickling, and optionally
-runs DDP synchronization. Run tests from the `tests/` directory; import accordingly:
+runs DDP synchronization. Tests can be run from repo root (`pytest tests/...`) or from the `tests/` directory (`cd tests && python -m pytest unittests/...`); import accordingly:
 
 ```python
 # run as: cd tests && python -m pytest unittests/...
@@ -172,7 +172,7 @@ class TestMyMetric(MetricTester):
 ```
 
 DDP mode only runs when `USE_PYTEST_POOL=1` is set; the `pytest.mark.DDP` marker gates
-it. Reference outputs are cached by `cachier` in `tests/_cache-references/` -- delete
+it. Reference outputs are cached by `cachier` under `tests/_cache-references/` by default (configurable via `PYTEST_REFERENCE_CACHE`) -- delete
 that dir to force recomputation.
 
 ______________________________________________________________________
@@ -234,5 +234,5 @@ ______________________________________________________________________
 | Use `MetricTester` for text metrics            | Text domain uses `TextTester` from `text/_helpers.py`   |
 | Add functional helpers for module-only metrics | FID/KID-style metrics intentionally skip this step      |
 | Hardcode task triple when subset applies       | Check existing metrics -- some omit inapplicable tasks  |
-| Run tests from repo root without `cd tests`    | Import paths assume `tests/` as working directory       |
+| Run `python -m pytest unittests/...` from repo root | Either `cd tests` for `python -m pytest unittests/...`, or run `pytest tests/...` from repo root |
 | `import *`                                     | Explicit imports only                                   |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,12 +94,14 @@ ______________________________________________________________________
 ## Adding a new metric
 
 1. **Functional helpers** — `src/torchmetrics/functional/<domain>/<metric>.py`
+
    - `_<metric>_update(...)` → intermediate tensors (tp, fp, …)
    - `_<metric>_compute(...)` / `_<metric>_reduce(...)` → final value
    - `_<metric>_arg_validation(...)` / `_<metric>_tensor_validation(...)` for input checks
    - Skip for module-only metrics (FID/KID style — intentionally no functional layer)
 
 2. **Module class** — `src/torchmetrics/<domain>/<metric>.py`
+
    - Subclass `Metric`; call functional helpers from `update()` and `compute()`
 
 3. **Classification task variants** — implement `BinaryXxx`, `MulticlassXxx`, `MultilabelXxx`
@@ -109,20 +111,24 @@ ______________________________________________________________________
    `task: Literal["binary","multiclass","multilabel"]`.
 
 4. **Exports** — add to all applicable:
+
    - `src/torchmetrics/<domain>/__init__.py`
    - `src/torchmetrics/functional/<domain>/__init__.py`
    - `src/torchmetrics/__init__.py` (top-level)
 
 5. **Optional dependencies** — gate with `RequirementCache`; add `__doctest_skip__`:
+
    ```python
    if not _MATPLOTLIB_AVAILABLE:
        __doctest_skip__ = ["MyMetric.plot"]
    ```
+
    See [Optional dependency pattern](#optional-dependency-pattern).
 
 6. **Docs page** — `docs/source/<domain>/<metric>.rst`
 
 7. **Tests** — `tests/unittests/<domain>/test_<metric>.py`
+
    - All domains: subclass `MetricTester`
    - Text domain only: subclass `TextTester` from `tests/unittests/text/_helpers.py`
 
@@ -136,6 +142,7 @@ ______________________________________________________________________
 # run as: cd tests && python -m pytest unittests/...
 from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests._helpers.testers import MetricTester
+
 
 class TestMyMetric(MetricTester):
     @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
@@ -151,6 +158,7 @@ class TestMyMetric(MetricTester):
 ```
 
 Two equivalent invocation styles:
+
 - `cd tests && python -m pytest unittests/...`
 - `pytest tests/...` from repo root
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,8 +156,6 @@ from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests._helpers.testers import MetricTester
 
 
-
-
 class TestMyMetric(MetricTester):
     @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
     @pytest.mark.parametrize("preds, target", [...])

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ tests/
   unittests/
     _helpers/testers.py   # MetricTester -- base for all metric tests
     text/_helpers.py      # TextTester -- specialised base for text domain tests
-    conftest.py           # BATCH_SIZE=32, NUM_BATCHES=8, NUM_CLASSES=5, NUM_PROCESSES=2
+    conftest.py           # BATCH_SIZE=32, NUM_BATCHES=2 * NUM_PROCESSES, NUM_CLASSES=5, NUM_PROCESSES=2
     <domain>/             # mirrors src/torchmetrics/<domain>/; pairwise/ present here too
 ```
 
@@ -152,10 +152,10 @@ runs DDP synchronization. Tests can be run from repo root (`pytest tests/...`) o
 ```python
 # run as: cd tests && python -m pytest unittests/...
 import pytest
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests._helpers.testers import MetricTester
 
-NUM_BATCHES = 8  # or import from unittests (re-exported by tests/unittests/__init__.py)
-BATCH_SIZE = 32
+
 
 
 class TestMyMetric(MetricTester):
@@ -216,8 +216,7 @@ def update(self, preds: Tensor, target: Tensor) -> None:
 ```
 
 Key rules: `Returns:` (plural, not `Return:`), line length 120, f-strings everywhere
-except `logging.*` calls (use `%`-style there). Existing code uses `Optional[float]`
-from `typing`; new code may use `float | None` (Python 3.10+).
+except `logging.*` calls (use `%`-style there). Existing code uses `Optional[float]` from `typing`; prefer that style for consistency.
 
 ______________________________________________________________________
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,238 @@
+# AGENTS.md - TorchMetrics
+
+AI coding agent guide. For contribution process, coding style, and PR workflow see
+[CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+______________________________________________________________________
+
+## Essential commands
+
+```bash
+# Install (editable + all dev deps)
+pip install -e . -r requirements/_devel.txt
+
+# Download sample data required by audio/image/detection tests
+make data
+
+# Lint and format (ruff, docformatter, codespell -- via pre-commit)
+pre-commit run --all-files
+# Type check (mypy is NOT in pre-commit -- run separately)
+mypy src/torchmetrics/
+
+# Tests -- two separate steps (src layout)
+cd src && python -m pytest torchmetrics          # doctests inside package
+cd tests && python -m pytest unittests -v        # unit tests
+
+# Single domain (run from repo root)
+pytest tests/unittests/classification/ -v
+
+# DDP tests
+USE_PYTEST_POOL="1" pytest -m DDP tests/
+
+# Docs
+make docs    # output: docs/build/html/index.html
+```
+
+______________________________________________________________________
+
+## Source layout
+
+```
+src/torchmetrics/
+  metric.py            # Metric base class
+  collections.py       # MetricCollection
+  aggregation.py       # MeanMetric, SumMetric, MinMetric, MaxMetric, CatMetric
+  wrappers/            # BootStrapper, ClasswiseWrapper, Running, MetricTracker, ...
+  utilities/           # imports.py, data.py, distributed.py, checks.py, plot.py
+  <domain>/            # audio, classification, clustering, detection, image,
+                       # multimodal, nominal, regression, retrieval,
+                       # segmentation, shape, text, video
+    __init__.py
+    <metric>.py        # module-based Metric subclass
+  functional/
+    <domain>/          # pure-function counterparts; also includes pairwise/
+                       # (pairwise has functional API only, no module package)
+
+tests/
+  _cache-references/   # cachier-backed reference output cache
+  unittests/
+    _helpers/testers.py   # MetricTester -- base for all metric tests
+    text/_helpers.py      # TextTester -- specialised base for text domain tests
+    conftest.py           # BATCH_SIZE=32, NUM_BATCHES=8, NUM_CLASSES=5, NUM_PROCESSES=2
+    <domain>/             # mirrors src/torchmetrics/<domain>/; pairwise/ present here too
+```
+
+______________________________________________________________________
+
+## Metric base class contract
+
+Every metric subclasses `torchmetrics.Metric` (which subclasses `torch.nn.Module`).
+
+```python
+class MyMetric(Metric):
+    is_differentiable: bool = False  # class-level, not instance
+    higher_is_better: bool = True
+    full_state_update: bool = False  # set True only if update needs full history
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Register ALL persistent state here -- nowhere else
+        self.add_state("correct", default=torch.tensor(0), dist_reduce_fx="sum")
+        self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")
+
+    def update(self, preds: Tensor, target: Tensor) -> None:
+        # Accumulate into self.* state -- no return value
+        self.correct += (preds == target).sum()
+        self.total += target.numel()
+
+    def compute(self) -> Tensor:
+        # Reduce accumulated state to scalar/tensor -- no side effects
+        return self.correct.float() / self.total
+```
+
+Avoid overriding `reset()` or `forward()` for ordinary metrics -- the base class owns
+them. Wrappers (`wrappers/`) may override both; rare metrics with non-default reset
+logic may override `reset()` (e.g. `image/fid.py`).
+
+`dist_reduce_fx` options: `"sum"`, `"mean"`, `"cat"`, `"min"`, `"max"`, or a callable.
+List states (append-style) use `dist_reduce_fx="cat"`.
+
+______________________________________________________________________
+
+## Adding a new metric -- checklist
+
+1. **Functional helpers** -- `src/torchmetrics/functional/<domain>/<metric>.py`
+   (most metrics; skip for complex stateful metrics like FID/KID that are module-only)
+
+   - `_<metric>_update(...)` -> returns intermediate tensors (tp, fp, ...)
+   - `_<metric>_compute(...)` or `_<metric>_reduce(...)` -> returns final value
+   - Input validation in `_<metric>_arg_validation(...)` / `_<metric>_tensor_validation(...)`
+
+2. **Module class** -- `src/torchmetrics/<domain>/<metric>.py`
+
+   - Subclass `Metric`; call functional helpers from `update()` and `compute()`
+
+3. **Classification task variants** -- classification metrics use task-specific subclasses.
+   Most implement all three: `BinaryXxx`, `MulticlassXxx`, `MultilabelXxx`.
+   Some support only a subset when a task is semantically inapplicable (e.g. `CohenKappa`
+   has no multilabel variant; `ExactMatch` has no binary variant). A public wrapper class
+   (e.g. `Accuracy`) inherits `_ClassificationTaskWrapper` and overrides `__new__` to
+   dispatch on `task: Literal["binary","multiclass","multilabel"]`.
+
+4. **Exports** -- add to all that apply:
+
+   - `src/torchmetrics/<domain>/__init__.py`
+   - `src/torchmetrics/functional/<domain>/__init__.py`
+   - `src/torchmetrics/__init__.py` (top-level, for metrics exposed at package root)
+
+5. **Optional dependencies** -- gate with `RequirementCache` from
+   `torchmetrics.utilities.imports`; add `__doctest_skip__` at module level:
+
+   ```python
+   if not _MATPLOTLIB_AVAILABLE:
+       __doctest_skip__ = ["MyMetric.plot"]
+   ```
+
+6. **Docs page** -- `docs/source/<domain>/<metric>.rst` following the domain pattern
+
+7. **Tests** -- `tests/unittests/<domain>/test_<metric>.py`:
+
+   - Use `MetricTester` as base class for all domains
+   - **Exception**: text metrics must subclass `TextTester` from
+     `tests/unittests/text/_helpers.py` -- it adds string/DDP handling
+
+______________________________________________________________________
+
+## Testing with MetricTester
+
+`MetricTester` (in `tests/unittests/_helpers/testers.py`) compares metric output
+against a reference implementation (scikit-learn/scipy), checks pickling, and optionally
+runs DDP synchronization. Run tests from the `tests/` directory; import accordingly:
+
+```python
+# run as: cd tests && python -m pytest unittests/...
+import pytest
+from unittests._helpers.testers import MetricTester
+
+NUM_BATCHES = 8  # or import from unittests (re-exported by tests/unittests/__init__.py)
+BATCH_SIZE = 32
+
+
+class TestMyMetric(MetricTester):
+    @pytest.mark.parametrize("ddp", [pytest.param(True, marks=pytest.mark.DDP), False])
+    @pytest.mark.parametrize("preds, target", [...])
+    def test_my_metric_class(self, preds, target, ddp):
+        self.run_class_metric_test(
+            ddp=ddp,
+            preds=preds,
+            target=target,
+            metric_class=MyMetric,
+            reference_metric=sklearn_reference,
+        )
+```
+
+DDP mode only runs when `USE_PYTEST_POOL=1` is set; the `pytest.mark.DDP` marker gates
+it. Reference outputs are cached by `cachier` in `tests/_cache-references/` -- delete
+that dir to force recomputation.
+
+______________________________________________________________________
+
+## Optional dependency pattern
+
+```python
+# src/torchmetrics/utilities/imports.py -- add RequirementCache entry
+from lightning_utilities.core.imports import RequirementCache
+
+_SCIPY_AVAILABLE = RequirementCache("scipy")
+
+# In metric file -- guard import and doctest skip
+from torchmetrics.utilities.imports import _SCIPY_AVAILABLE
+
+if not _SCIPY_AVAILABLE:
+    __doctest_skip__ = ["MyMetric", "MyMetric.compute"]
+```
+
+______________________________________________________________________
+
+## Docstring format
+
+Google-style, enforced by Napoleon + docformatter. Target style for new code:
+
+```python
+def update(self, preds: Tensor, target: Tensor) -> None:
+    """One-line summary.
+
+    Args:
+        preds: shape ``(N, C)`` predictions.
+        target: shape ``(N,)`` ground truth.
+
+    Raises:
+        ValueError: If shapes mismatch.
+
+    Example:
+        >>> metric = MyMetric()
+        >>> metric.update(preds, target)
+    """
+```
+
+Key rules: `Returns:` (plural, not `Return:`), line length 120, f-strings everywhere
+except `logging.*` calls (use `%`-style there). Existing code uses `Optional[float]`
+from `typing`; new code may use `float | None` (Python 3.10+).
+
+______________________________________________________________________
+
+## Common mistakes to avoid
+
+| Mistake                                        | Correct pattern                                         |
+| ---------------------------------------------- | ------------------------------------------------------- |
+| Override `reset()` on plain metric             | Only wrappers and rare special cases do this            |
+| Override `forward()`                           | Don't -- base class calls `update()` + `compute()`      |
+| Call `add_state()` outside `__init__`          | Only in `__init__`                                      |
+| Return value from `update()`                   | `update()` returns `None`; mutate state in-place        |
+| `Return:` in docstring                         | Use `Returns:`                                          |
+| Export only in one `__init__.py`               | Export in domain + functional + top-level as applicable |
+| Use `MetricTester` for text metrics            | Text domain uses `TextTester` from `text/_helpers.py`   |
+| Add functional helpers for module-only metrics | FID/KID-style metrics intentionally skip this step      |
+| Hardcode task triple when subset applies       | Check existing metrics -- some omit inapplicable tasks  |
+| Run tests from repo root without `cd tests`    | Import paths assume `tests/` as working directory       |
+| `import *`                                     | Explicit imports only                                   |


### PR DESCRIPTION
## What does this PR do?

Covers commands, src layout, Metric base class contract, new-metric checklist (functional helpers, task variants, exports, optional deps, docs page, tests), MetricTester/TextTester usage with DDP parametrize, optional dependency pattern, docstring target style, and common mistakes table. References CONTRIBUTING.md to avoid duplication.

Co-reviewed with Codex; findings applied: corrected import paths for tests/ working directory, added make data bootstrap step, documented pairwise as functional-only domain, qualified functional helpers as non-mandatory for module-only metrics (FID/KID), added TextTester exception for text domain, softened "exact sections" docstring claim.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
