### PR TITLE
Fix _sync_dist deadlock for dist_reduce_fx=None list states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed `_sync_dist` deadlock for `dist_reduce_fx=None` list states when ranks have different list lengths ([#3336](https://github.com/Lightning-AI/torchmetrics/issues/3336))
 
 
 ---

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -503,7 +503,7 @@ class Metric(Module, ABC):
         if ref is not None:
             if ref.ndim == 0:
                 return torch.zeros(0, device=self.device, dtype=ref.dtype)
-            return torch.zeros((0,) + ref.shape[1:], device=self.device, dtype=ref.dtype)
+            return torch.zeros((0, *ref.shape[1:]), device=self.device, dtype=ref.dtype)
         if ndim <= 1:
             return torch.zeros(0, device=self.device, dtype=self.dtype)
         pad_shape = [0] + [int(tail_shape_vec[i].item()) for i in range(ndim - 1)]

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -570,11 +570,7 @@ class Metric(Module, ABC):
                 input_dict[attr] = [torch.tensor([], device=self.device, dtype=self.dtype)]
 
             # equalize list lengths for dist_reduce_fx=None to prevent deadlocks in apply_to_collection
-            if (
-                self._TORCH_GREATER_EQUAL_2_1
-                and reduction_fn is None
-                and isinstance(input_dict[attr], list)
-            ):
+            if self._TORCH_GREATER_EQUAL_2_1 and reduction_fn is None and isinstance(input_dict[attr], list):
                 input_dict[attr] = self._equalize_none_reduction_list(input_dict[attr], group)
 
         if jit_distributed_available():

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -498,7 +498,61 @@ class Metric(Module, ABC):
                 raise TypeError(f"Unsupported reduce_fn: {reduce_fn}")
             setattr(self, attr, reduced)
 
+    def _make_empty_pad_tensor(self, ref: Optional[Tensor], ndim: int, tail_shape_vec: Tensor) -> Tensor:
+        """Create an empty tensor with the same trailing dimensions as ``ref`` for list-state padding."""
+        if ref is not None:
+            if ref.ndim == 0:
+                return torch.zeros(0, device=self.device, dtype=ref.dtype)
+            return torch.zeros((0,) + ref.shape[1:], device=self.device, dtype=ref.dtype)
+        if ndim <= 1:
+            return torch.zeros(0, device=self.device, dtype=self.dtype)
+        pad_shape = [0] + [int(tail_shape_vec[i].item()) for i in range(ndim - 1)]
+        return torch.zeros(pad_shape, device=self.device, dtype=self.dtype)
+
+    def _equalize_none_reduction_list(self, state: list, process_group: Optional[Any] = None) -> list:
+        """Pad ``dist_reduce_fx=None`` list states so all ranks perform the same number of collectives."""
+        if not isinstance(state, list) or not jit_distributed_available():
+            return state
+
+        group = process_group or self.process_group
+        world_size = torch.distributed.get_world_size(group)
+        local_len = len(state)
+
+        local_len_t = torch.tensor([local_len], device=self.device, dtype=torch.long)
+        all_lens = [torch.zeros_like(local_len_t) for _ in range(world_size)]
+        torch.distributed.all_gather(all_lens, local_len_t, group=group)
+        max_len = max(int(t.item()) for t in all_lens)
+
+        if max_len == 0:
+            return state
+
+        local_ndim = state[0].ndim if local_len > 0 else 0
+        ndim_t = torch.tensor([local_ndim], device=self.device, dtype=torch.long)
+        torch.distributed.all_reduce(ndim_t, op=torch.distributed.ReduceOp.MAX, group=group)
+        ndim = int(ndim_t.item())
+
+        max_tail_dims = 7
+        tail_shape_vec = torch.zeros(max_tail_dims, device=self.device, dtype=torch.long)
+        if local_len > 0:
+            for i, dim_size in enumerate(state[0].shape[1:]):
+                tail_shape_vec[i] = dim_size
+        torch.distributed.all_reduce(tail_shape_vec, op=torch.distributed.ReduceOp.MAX, group=group)
+
+        if local_len == max_len:
+            return state
+
+        while len(state) < max_len:
+            ref = state[-1] if state else None
+            state.append(self._make_empty_pad_tensor(ref, ndim, tail_shape_vec))
+        return state
+
     def _sync_dist(self, dist_sync_fn: Callable = gather_all_tensors, process_group: Optional[Any] = None) -> None:
+        group = process_group or self.process_group
+        if jit_distributed_available():
+            torch.distributed.barrier(group=group)
+
+        input_dict = {attr: getattr(self, attr) for attr in self._reductions}
+
         input_dict = {attr: getattr(self, attr) for attr in self._reductions}
 
         for attr, reduction_fn in self._reductions.items():
@@ -514,6 +568,17 @@ class Metric(Module, ABC):
                 and len(input_dict[attr]) == 0
             ):
                 input_dict[attr] = [torch.tensor([], device=self.device, dtype=self.dtype)]
+
+            # equalize list lengths for dist_reduce_fx=None to prevent deadlocks in apply_to_collection
+            if (
+                self._TORCH_GREATER_EQUAL_2_1
+                and reduction_fn is None
+                and isinstance(input_dict[attr], list)
+            ):
+                input_dict[attr] = self._equalize_none_reduction_list(input_dict[attr], group)
+
+        if jit_distributed_available():
+            torch.distributed.barrier(group=group)
 
         output_dict = apply_to_collection(
             input_dict,

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -49,6 +49,24 @@ def jit_distributed_available() -> bool:
     return torch.distributed.is_available() and torch.distributed.is_initialized()
 
 
+# Dtypes that a list state can hold, indexed so ranks can agree on one over a collective without
+# sending a Python object. Order is fixed: an index is only meaningful against this exact tuple.
+_DTYPE_CODES: tuple[torch.dtype, ...] = (
+    torch.bool,
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+    torch.float64,
+    torch.complex64,
+    torch.complex128,
+)
+
+
 class Metric(Module, ABC):
     """Base class for all metrics present in the Metrics API.
 
@@ -498,20 +516,34 @@ class Metric(Module, ABC):
                 raise TypeError(f"Unsupported reduce_fn: {reduce_fn}")
             setattr(self, attr, reduced)
 
-    def _make_empty_pad_tensor(self, ref: Optional[Tensor], ndim: int, tail_shape_vec: Tensor) -> Tensor:
-        """Create an empty tensor with the same trailing dimensions as ``ref`` for list-state padding."""
+    def _make_empty_pad_tensor(
+        self, ref: Optional[Tensor], ndim: int, tail_shape_vec: Tensor, dtype: torch.dtype
+    ) -> Tensor:
+        """Create an empty tensor with the same trailing dimensions as ``ref`` for list-state padding.
+
+        ``dtype`` is the dtype agreed across ranks, which is not necessarily ``self.dtype``: list
+        states are commonly integer typed (``MeanAveragePrecision`` labels, for example) while the
+        metric dtype is floating point. A rank holding no elements has no ``ref`` to copy from, so
+        padding with ``self.dtype`` there would make the collectives disagree on dtype.
+        """
         if ref is not None:
             if ref.ndim == 0:
                 return torch.zeros(0, device=self.device, dtype=ref.dtype)
             return torch.zeros((0, *ref.shape[1:]), device=self.device, dtype=ref.dtype)
         if ndim <= 1:
-            return torch.zeros(0, device=self.device, dtype=self.dtype)
+            return torch.zeros(0, device=self.device, dtype=dtype)
         pad_shape = [0] + [int(tail_shape_vec[i].item()) for i in range(ndim - 1)]
-        return torch.zeros(pad_shape, device=self.device, dtype=self.dtype)
+        return torch.zeros(pad_shape, device=self.device, dtype=dtype)
 
     def _equalize_none_reduction_list(self, state: list, process_group: Optional[Any] = None) -> list:
         """Pad ``dist_reduce_fx=None`` list states so all ranks perform the same number of collectives."""
         if not isinstance(state, list) or not jit_distributed_available():
+            return state
+
+        # Only tensor entries are gathered: `apply_to_collection` below dispatches on `Tensor`, so a
+        # list of non-tensors (`MeanAveragePrecision.detection_mask` holds RLE tuples, for example)
+        # runs no collectives and needs no equalizing. Reading `state[0].ndim` on one would also fail.
+        if not all(isinstance(item, Tensor) for item in state):
             return state
 
         group = process_group or self.process_group
@@ -538,20 +570,26 @@ class Metric(Module, ABC):
                 tail_shape_vec[i] = dim_size
         torch.distributed.all_reduce(tail_shape_vec, op=torch.distributed.ReduceOp.MAX, group=group)
 
+        # Agree on the element dtype. Ranks holding elements all carry the same one, so a MAX over
+        # their codes picks it, while a rank with nothing to contribute sends -1 and defers.
+        local_code = _DTYPE_CODES.index(state[0].dtype) if local_len > 0 and state[0].dtype in _DTYPE_CODES else -1
+        code_t = torch.tensor([local_code], device=self.device, dtype=torch.long)
+        torch.distributed.all_reduce(code_t, op=torch.distributed.ReduceOp.MAX, group=group)
+        code = int(code_t.item())
+        dtype = _DTYPE_CODES[code] if code >= 0 else self.dtype
+
         if local_len == max_len:
             return state
 
         while len(state) < max_len:
             ref = state[-1] if state else None
-            state.append(self._make_empty_pad_tensor(ref, ndim, tail_shape_vec))
+            state.append(self._make_empty_pad_tensor(ref, ndim, tail_shape_vec, dtype))
         return state
 
     def _sync_dist(self, dist_sync_fn: Callable = gather_all_tensors, process_group: Optional[Any] = None) -> None:
         group = process_group or self.process_group
         if jit_distributed_available():
             torch.distributed.barrier(group=group)
-
-        input_dict = {attr: getattr(self, attr) for attr in self._reductions}
 
         input_dict = {attr: getattr(self, attr) for attr in self._reductions}
 

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -525,6 +525,7 @@ class Metric(Module, ABC):
         states are commonly integer typed (``MeanAveragePrecision`` labels, for example) while the
         metric dtype is floating point. A rank holding no elements has no ``ref`` to copy from, so
         padding with ``self.dtype`` there would make the collectives disagree on dtype.
+
         """
         if ref is not None:
             if ref.ndim == 0:

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -541,12 +541,6 @@ class Metric(Module, ABC):
         if not isinstance(state, list) or not jit_distributed_available():
             return state
 
-        # Only tensor entries are gathered: `apply_to_collection` below dispatches on `Tensor`, so a
-        # list of non-tensors (`MeanAveragePrecision.detection_mask` holds RLE tuples, for example)
-        # runs no collectives and needs no equalizing. Reading `state[0].ndim` on one would also fail.
-        if not all(isinstance(item, Tensor) for item in state):
-            return state
-
         group = process_group or self.process_group
         world_size = torch.distributed.get_world_size(group)
         local_len = len(state)
@@ -557,6 +551,21 @@ class Metric(Module, ABC):
         max_len = max(int(t.item()) for t in all_lens)
 
         if max_len == 0:
+            return state
+
+        # Only tensor entries are gathered: `apply_to_collection` dispatches on `Tensor`, so a list of
+        # non-tensors (`MeanAveragePrecision.detection_mask` holds RLE tuples, for example) runs no
+        # collectives and needs no equalizing; reading `state[0].ndim` on one would also fail.
+        #
+        # This has to be decided together, not per rank. A rank holding nothing sees a vacuously
+        # all-tensor list, so if it decided locally it would go on to run the collectives below while
+        # a rank holding non-tensors returned early -- the very deadlock this method prevents. MIN
+        # means any rank holding a non-tensor makes every rank skip.
+        all_tensor_t = torch.tensor(
+            [int(all(isinstance(item, Tensor) for item in state))], device=self.device, dtype=torch.long
+        )
+        torch.distributed.all_reduce(all_tensor_t, op=torch.distributed.ReduceOp.MIN, group=group)
+        if int(all_tensor_t.item()) == 0:
             return state
 
         local_ndim = state[0].ndim if local_len > 0 else 0

--- a/tests/unittests/bases/test_ddp.py
+++ b/tests/unittests/bases/test_ddp.py
@@ -342,3 +342,53 @@ def _test_sync_with_unequal_size_lists(rank):
 def test_sync_with_unequal_size_lists():
     """Test that synchronization of states can be enabled and disabled for compute."""
     pytest.pool.map(_test_sync_with_unequal_size_lists, range(NUM_PROCESSES))
+
+
+class _NoneReductionListMetric(Metric):
+    """Metric with list state using dist_reduce_fx=None for DDP sync tests."""
+
+    full_state_update = True
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.add_state("items", default=[], dist_reduce_fx=None)
+
+    def update(self, x: torch.Tensor) -> None:
+        self.items.append(x)
+
+    def compute(self) -> torch.Tensor:
+        if len(self.items) == 0:
+            return torch.tensor(0.0, device=self.device)
+        return torch.cat(self.items, dim=0).sum()
+
+
+def _test_sync_none_reduction_unequal_list_lengths(rank):
+    """Regression test for #3336: ranks with different list lengths must not deadlock on compute()."""
+    metric = _NoneReductionListMetric(sync_on_compute=True)
+    if rank == 1:
+        metric.update(torch.tensor([1.0, 2.0]))
+        metric.update(torch.tensor([3.0]))
+    val = metric.compute()
+    assert val == 6.0
+
+
+def _test_sync_none_reduction_multidim_list(rank):
+    """Multidimensional list states with dist_reduce_fx=None sync across uneven ranks."""
+    metric = _NoneReductionListMetric(sync_on_compute=True)
+    if rank == 1:
+        metric.update(torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+    val = metric.compute()
+    assert val == 10.0
+
+
+@pytest.mark.DDP
+@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test only works on newer torch versions")
+@pytest.mark.skipif(_IS_WINDOWS, reason="DDP not available on windows")
+@pytest.mark.skipif(not USE_PYTEST_POOL, reason="DDP pool is not available.")
+@pytest.mark.parametrize(
+    "process",
+    [_test_sync_none_reduction_unequal_list_lengths, _test_sync_none_reduction_multidim_list],
+)
+def test_sync_none_reduction_unequal_list_lengths(process):
+    """Test that dist_reduce_fx=None list states sync without deadlocking."""
+    pytest.pool.map(process, range(NUM_PROCESSES))

--- a/tests/unittests/bases/test_ddp.py
+++ b/tests/unittests/bases/test_ddp.py
@@ -14,6 +14,7 @@
 import os
 from copy import deepcopy
 from functools import partial
+from typing import Any
 
 import pytest
 import torch
@@ -349,7 +350,7 @@ class _NoneReductionListMetric(Metric):
 
     full_state_update = True
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.add_state("items", default=[], dist_reduce_fx=None)
 

--- a/tests/unittests/bases/test_ddp.py
+++ b/tests/unittests/bases/test_ddp.py
@@ -363,6 +363,25 @@ class _NoneReductionListMetric(Metric):
         return torch.cat(self.items, dim=0).sum()
 
 
+class _NoneReductionObjectListMetric(Metric):
+    """Metric whose dist_reduce_fx=None list state holds non-tensor objects.
+
+    Mirrors states like ``MeanAveragePrecision.detection_mask``, which stores RLE tuples.
+    """
+
+    full_state_update = True
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.add_state("objects", default=[], dist_reduce_fx=None)
+
+    def update(self, obj: Any) -> None:
+        self.objects.append(obj)
+
+    def compute(self) -> int:
+        return len(self.objects)
+
+
 def _test_sync_none_reduction_unequal_list_lengths(rank):
     """Regression test for #3336: ranks with different list lengths must not deadlock on compute()."""
     metric = _NoneReductionListMetric(sync_on_compute=True)
@@ -382,13 +401,42 @@ def _test_sync_none_reduction_multidim_list(rank):
     assert val == 10.0
 
 
+def _test_sync_none_reduction_non_default_dtype(rank):
+    """Padding must use the element dtype, not the metric dtype.
+
+    List states are commonly integer typed while the metric dtype is floating point --
+    ``MeanAveragePrecision`` labels, for example. A rank with no elements has nothing to copy a
+    dtype from, so padding with the metric dtype would make the collectives disagree.
+    """
+    metric = _NoneReductionListMetric(sync_on_compute=True)
+    if rank == 1:
+        metric.update(torch.tensor([1, 2], dtype=torch.long))
+        metric.update(torch.tensor([3], dtype=torch.long))
+    val = metric.compute()
+    assert val == 6
+    assert val.dtype == torch.long
+
+
+def _test_sync_none_reduction_non_tensor_list(rank):
+    """Non-tensor list states are not gathered, so they must pass through untouched."""
+    metric = _NoneReductionObjectListMetric(sync_on_compute=True)
+    if rank == 1:
+        metric.update(("rle", 1))
+    assert metric.compute() == (1 if rank == 1 else 0)
+
+
 @pytest.mark.DDP
 @pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test only works on newer torch versions")
 @pytest.mark.skipif(_IS_WINDOWS, reason="DDP not available on windows")
 @pytest.mark.skipif(not USE_PYTEST_POOL, reason="DDP pool is not available.")
 @pytest.mark.parametrize(
     "process",
-    [_test_sync_none_reduction_unequal_list_lengths, _test_sync_none_reduction_multidim_list],
+    [
+        _test_sync_none_reduction_unequal_list_lengths,
+        _test_sync_none_reduction_multidim_list,
+        _test_sync_none_reduction_non_default_dtype,
+        _test_sync_none_reduction_non_tensor_list,
+    ],
 )
 def test_sync_none_reduction_unequal_list_lengths(process):
     """Test that dist_reduce_fx=None list states sync without deadlocking."""

--- a/tests/unittests/bases/test_ddp.py
+++ b/tests/unittests/bases/test_ddp.py
@@ -367,6 +367,7 @@ class _NoneReductionObjectListMetric(Metric):
     """Metric whose dist_reduce_fx=None list state holds non-tensor objects.
 
     Mirrors states like ``MeanAveragePrecision.detection_mask``, which stores RLE tuples.
+
     """
 
     full_state_update = True
@@ -407,6 +408,7 @@ def _test_sync_none_reduction_non_default_dtype(rank):
     List states are commonly integer typed while the metric dtype is floating point --
     ``MeanAveragePrecision`` labels, for example. A rank with no elements has nothing to copy a
     dtype from, so padding with the metric dtype would make the collectives disagree.
+
     """
     metric = _NoneReductionListMetric(sync_on_compute=True)
     if rank == 1:


### PR DESCRIPTION
## What does this PR do?

Fixes #3336

When a metric uses `dist_reduce_fx=None` list states (e.g. `MeanAveragePrecision`, retrieval metrics) and different ranks call `update()` a different number of times, `_sync_dist` deadlocks on `compute()` because `apply_to_collection` issues a different number of `all_gather` calls per rank.

This extends the empty-list fix from #2468 to `None`-reduction list states by:

1. Exchanging list lengths across ranks via `all_gather`
2. Exchanging tensor ndim / trailing shape metadata via `all_reduce` (all ranks participate, even when no padding is needed locally)
3. Padding shorter lists with ndim-matched empty tensors `(0, *tail_shape)` so every rank performs the same number of collectives
4. Adding barriers before/after equalization so no rank enters `apply_to_collection` early

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃

Made with [Cursor](https://cursor.com)