### PR TITLE
Fix malformed LaTeX in CLIPScore and HausdorffDistance docstring math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#XXXX](https://github.com/Lightning-AI/torchmetrics/pull/XXXX))
+- Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#XXXX](https://github.com/Lightning-AI/torchmetrics/pull/XXXX))
 
 
 ---

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -268,7 +268,7 @@ def clip_score(
     to be highly correlated with human judgement. The metric is defined as:
 
     .. math::
-        \text{CLIPScore(I, C)} = max(100 * cos(E_I, E_C), 0)
+        \text{CLIPScore}(I, C) = max(100 * cos(E_I, E_C), 0)
 
     which corresponds to the cosine similarity between visual `CLIP`_ embedding :math:`E_i` for an image :math:`i` and
     textual CLIP embedding :math:`E_C` for an caption :math:`C`. The score is bound between 0 and 100 and the closer
@@ -277,12 +277,12 @@ def clip_score(
     Additionally, the CLIP Score can be calculated for the same modalities:
 
     .. math::
-        \text{CLIPScore(I_1, I_2)} = max(100 * cos(E_{I_1}, E_{I_2}), 0)
+        \text{CLIPScore}(I_1, I_2) = max(100 * cos(E_{I_1}, E_{I_2}), 0)
 
     where :math:`E_{I_1}` and :math:`E_{I_2}` are the visual embeddings for images :math:`I_1` and :math:`I_2`.
 
     .. math::
-        \text{CLIPScore(T_1, T_2)} = max(100 * cos(E_{T_1}, E_{T_2}), 0)
+        \text{CLIPScore}(T_1, T_2) = max(100 * cos(E_{T_1}, E_{T_2}), 0)
 
     where :math:`E_{T_1}` and :math:`E_{T_2}` are the textual embeddings for texts :math:`T_1` and :math:`T_2`.
 

--- a/src/torchmetrics/multimodal/clip_score.py
+++ b/src/torchmetrics/multimodal/clip_score.py
@@ -54,7 +54,7 @@ class CLIPScore(Metric):
     to be highly correlated with human judgement. The metric is defined as:
 
     .. math::
-        \text{CLIPScore(I, C)} = max(100 * cos(E_I, E_C), 0)
+        \text{CLIPScore}(I, C) = max(100 * cos(E_I, E_C), 0)
 
     which corresponds to the cosine similarity between visual `CLIP`_ embedding :math:`E_i` for an image :math:`i` and
     textual CLIP embedding :math:`E_C` for an caption :math:`C`. The score is bound between 0 and 100 and the closer
@@ -63,12 +63,12 @@ class CLIPScore(Metric):
     Additionally, the CLIP Score can be calculated for the same modalities:
 
     .. math::
-        \text{CLIPScore(I_1, I_2)} = max(100 * cos(E_{I_1}, E_{I_2}), 0)
+        \text{CLIPScore}(I_1, I_2) = max(100 * cos(E_{I_1}, E_{I_2}), 0)
 
     where :math:`E_{I_1}` and :math:`E_{I_2}` are the visual embeddings for images :math:`I_1` and :math:`I_2`.
 
     .. math::
-        \text{CLIPScore(T_1, T_2)} = max(100 * cos(E_{T_1}, E_{T_2}), 0)
+        \text{CLIPScore}(T_1, T_2) = max(100 * cos(E_{T_1}, E_{T_2}), 0)
 
     where :math:`E_{T_1}` and :math:`E_{T_2}` are the textual embeddings for texts :math:`T_1` and :math:`T_2`.
 

--- a/src/torchmetrics/segmentation/hausdorff_distance.py
+++ b/src/torchmetrics/segmentation/hausdorff_distance.py
@@ -32,9 +32,9 @@ class HausdorffDistance(Metric):
     r"""Compute the `Hausdorff Distance`_ between two subsets of a metric space for semantic segmentation.
 
     .. math::
-        d_{\Pi}(X,Y) = \max{/sup_{x\in X} {d(x,Y)}, /sup_{y\in Y} {d(X,y)}}
+        d_{\Pi}(X,Y) = \max\{\sup_{x\in X} d(x,Y), \sup_{y\in Y} d(X,y)\}
 
-    where :math:`\X, \Y` are two subsets of a metric space with distance metric :math:`d`. The Hausdorff distance is
+    where :math:`X, Y` are two subsets of a metric space with distance metric :math:`d`. The Hausdorff distance is
     the maximum distance from a point in one set to the closest point in the other set. The Hausdorff distance is a
     measure of the degree of mismatch between two sets.
 


### PR DESCRIPTION
## What does this PR do?

Fixes malformed LaTeX in three metric docstrings that renders incorrectly — or not at all under stricter math renderers such as KaTeX. These blocks were authored for MathJax, which silently tolerates the mistakes, so the rendered math is wrong even on the current docs site.

This is in preparation for rendering the torchmetrics docs within Lightning AI's updated documentation site (which renders math with KaTeX), but the fixes correct the math for MathJax too.

* **`HausdorffDistance`** — `\X` / `\Y` are undefined macros (no `\newcommand`, no MathJax macro config), so they don't render at all → replaced with plain `X, Y`. Also `/sup` is a typo for `\sup` (×2), and `\max{…}` dropped its set braces → `\max\{…\}`.
* **`CLIPScore`** (class + functional) — subscripts inside `\text{…}` (`\text{CLIPScore(I_1, I_2)}`) are invalid in text mode → moved the arguments out: `\text{CLIPScore}(I_1, I_2)`.

Docstring-only; no code or behaviour changes. Each rewritten expression was checked to render under strict KaTeX.

<details>
<summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? _(exempt — docs improvement)_
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**? _(this is the docs)_
- [ ] Did you write any new **necessary tests**? _(N/A — docstring-only)_

</details>

## Did you have fun?

Always 🙂