### PR TITLE
fix(multimodal): handle BaseModelOutputWithPooling return type in CLIPScore for transformers >= 5.0

### DIFF
--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -147,7 +147,9 @@ def _get_features(
                 )
                 processed["attention_mask"] = processed["attention_mask"][..., :max_position_embeddings]
                 processed["input_ids"] = processed["input_ids"][..., :max_position_embeddings]
-        text_features = model.get_text_features(processed["input_ids"].to(device), processed["attention_mask"].to(device))
+        text_features = model.get_text_features(
+            processed["input_ids"].to(device), processed["attention_mask"].to(device)
+        )
         # transformers >= 5.0 changed get_image_features / get_text_features to return
         # BaseModelOutputWithPooling instead of a raw tensor; unwrap when needed.
         return text_features if isinstance(text_features, Tensor) else text_features.pooler_output

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -130,7 +130,10 @@ def _get_features(
     if modality == "image":
         image_data = [i for i in data if isinstance(i, Tensor)]  # Add type checking for images
         processed = processor(images=[i.cpu() for i in image_data], return_tensors="pt", padding=True)
-        return model.get_image_features(processed["pixel_values"].to(device))
+        image_features = model.get_image_features(processed["pixel_values"].to(device))
+        # transformers >= 5.0 changed get_image_features / get_text_features to return
+        # BaseModelOutputWithPooling instead of a raw tensor; unwrap when needed.
+        return image_features if isinstance(image_features, Tensor) else image_features.pooler_output
     if modality == "text":
         processed = processor(text=data, return_tensors="pt", padding=True)
         if hasattr(model.config, "text_config") and hasattr(model.config.text_config, "max_position_embeddings"):
@@ -144,7 +147,10 @@ def _get_features(
                 )
                 processed["attention_mask"] = processed["attention_mask"][..., :max_position_embeddings]
                 processed["input_ids"] = processed["input_ids"][..., :max_position_embeddings]
-        return model.get_text_features(processed["input_ids"].to(device), processed["attention_mask"].to(device))
+        text_features = model.get_text_features(processed["input_ids"].to(device), processed["attention_mask"].to(device))
+        # transformers >= 5.0 changed get_image_features / get_text_features to return
+        # BaseModelOutputWithPooling instead of a raw tensor; unwrap when needed.
+        return text_features if isinstance(text_features, Tensor) else text_features.pooler_output
     raise ValueError(f"invalid modality {modality}")
 
 


### PR DESCRIPTION
## Summary

`CLIPScore` crashes with `AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'` when used with `transformers >= 5.0`.

**Root cause:** In transformers >= 5.0, `CLIPModel.get_image_features` and `get_text_features` now return `BaseModelOutputWithPooling` rather than a raw tensor. The code in `_get_features` passed this object directly to the caller, where `.norm(p=2, dim=-1, keepdim=True)` was called on it — causing the crash.

## Changes

- **`src/torchmetrics/functional/multimodal/clip_score.py`**: In `_get_features`, after calling `get_image_features` / `get_text_features`, check `isinstance(features, Tensor)`. If the return value is a `BaseModelOutputWithPooling` (transformers ≥ 5.0), extract `.pooler_output` — the projected embedding tensor — before returning. Both old and new transformers versions are handled transparently.

## Repro (before fix)

```python
import torch
from torchmetrics.multimodal.clip_score import CLIPScore

metric = CLIPScore(model_name_or_path="openai/clip-vit-base-patch16")
image = torch.randint(255, (3, 224, 224), generator=torch.Generator().manual_seed(42))
score = metric(image, "a photo of a cat")
# Before: AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'
# After:  tensor(24.)
```

Fixes #3407