### PR TITLE
docs: add community health files (CONTRIBUTING.md, CODE_OF_CONDUCT.md)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,12 +7,14 @@ We as members, contributors, and leaders pledge to make participation in our com
 ## Our Standards
 
 Examples of behavior that contributes to a positive environment:
+
 - Using welcoming and inclusive language
 - Being respectful of differing viewpoints
 - Gracefully accepting constructive criticism
 - Focusing on what is best for the community
 
 Examples of unacceptable behavior:
+
 - Harassment of any kind
 - Trolling, insulting or derogatory comments
 - Public or private harassment
@@ -26,5 +28,6 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
 
----
+______________________________________________________________________
+
 *[Mukller](https://github.com/Mukller)*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+- Harassment of any kind
+- Trolling, insulting or derogatory comments
+- Public or private harassment
+- Publishing others' private information without permission
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Thank you for your interest in contributing!
 ## Reporting Issues
 
 Use GitHub Issues to report bugs or request features. Please include:
+
 - Steps to reproduce
 - Expected vs actual behavior
 - Environment details
@@ -29,5 +30,6 @@ Use GitHub Issues to report bugs or request features. Please include:
 - Update documentation as needed
 - Ensure all tests pass
 
----
+______________________________________________________________________
+
 *[Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/your-feature`
+3. Make your changes
+4. Run tests: `pytest`
+5. Submit a Pull Request
+
+## Code Style
+
+- Follow existing code style and conventions
+- Write clear, descriptive commit messages
+- Add tests for new features
+
+## Reporting Issues
+
+Use GitHub Issues to report bugs or request features. Please include:
+- Steps to reproduce
+- Expected vs actual behavior
+- Environment details
+
+## Pull Request Guidelines
+
+- Keep PRs focused on a single change
+- Update documentation as needed
+- Ensure all tests pass
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -378,6 +378,6 @@ If you want to cite this framework feel free to use GitHub's built-in citation o
 Please observe the Apache 2.0 license that is listed in this repository.
 In addition, the Lightning framework is Patent Pending.
 
----
+______________________________________________________________________
 
 *[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -377,3 +377,7 @@ If you want to cite this framework feel free to use GitHub's built-in citation o
 
 Please observe the Apache 2.0 license that is listed in this repository.
 In addition, the Lightning framework is Patent Pending.
+
+---
+
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Summary

Adds missing open-source community health files:

- **CONTRIBUTING.md** — contribution guidelines, development setup, PR process
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **README.md** — contributor profile link

### Why
These files help contributors understand how to participate and set community expectations.

---
*[Mukller](https://github.com/Mukller)*