### PR TITLE
Fix eager torchvision import causing circular import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 
 
+- Fixed eager `torchvision` import in `arniqa` and `dists` that could trigger a partially-initialized-module circular import ([#3432](https://github.com/Lightning-AI/torchmetrics/pull/3432))
+
+
 ---
 
 ## [1.9.0] - 2026-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 
 
+- Fixed eager `torchvision` import in `arniqa` and `dists` that could trigger a partially-initialized-module circular import ([#3432](https://github.com/Lightning-AI/torchmetrics/pull/3432))
+
+
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
 
 

--- a/src/torchmetrics/functional/image/arniqa.py
+++ b/src/torchmetrics/functional/image/arniqa.py
@@ -27,10 +27,6 @@ from typing_extensions import Literal
 
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_2, _TORCHVISION_AVAILABLE
 
-if _TORCHVISION_AVAILABLE:
-    from torchvision import transforms
-    from torchvision.models import resnet50
-
 _AVAILABLE_REGRESSOR_DATASETS = {
     "kadid10k": (1, 5),
     "koniq10k": (1, 100),
@@ -75,6 +71,8 @@ class _ARNIQA(nn.Module):
         self.imagenet_norm_mean = [0.485, 0.456, 0.406]
         self.imagenet_norm_std = [0.229, 0.224, 0.225]
 
+        from torchvision.models import resnet50
+
         encoder = resnet50()
         self.feat_dim = encoder.fc.in_features  # get dimensions of the last layer of the encoder
         encoder = nn.Sequential(*list(encoder.children())[:-1])  # remove the fully connected layer
@@ -116,6 +114,8 @@ class _ARNIQA(nn.Module):
         Obtains the half-scale version of the input image and applies normalization if needed.
 
         """
+        from torchvision import transforms
+
         h, w = img.shape[-2:]
         img_ds = transforms.Resize((h // 2, w // 2))(img)  # get the half-scale version of the image
         if normalize:

--- a/src/torchmetrics/functional/image/dists.py
+++ b/src/torchmetrics/functional/image/dists.py
@@ -47,8 +47,6 @@ from torchmetrics.utilities.imports import _TORCHVISION_AVAILABLE
 
 if not _TORCHVISION_AVAILABLE:
     __doctest_skip__ = ["deep_image_structure_and_texture_similarity"]
-else:
-    from torchvision.models import VGG16_Weights, vgg16
 
 _PATH_WEIGHT_DISTS = Path(__file__).resolve().parent / "dists_models" / "weights.pt"
 
@@ -90,6 +88,8 @@ class DISTSNetwork(torch.nn.Module):
             raise ModuleNotFoundError(
                 "DISTS requires torchvision to be installed. Please install it with `pip install torchvision`."
             )
+
+        from torchvision.models import VGG16_Weights, vgg16
 
         vgg_pretrained_features = vgg16(weights=VGG16_Weights.DEFAULT).features
         self.stage1 = torch.nn.Sequential()

--- a/tests/unittests/image/test_arniqa.py
+++ b/tests/unittests/image/test_arniqa.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import subprocess
+import sys
 from functools import partial
 
 import pytest
@@ -172,3 +174,22 @@ def test_check_for_backprop():
     loss.backward()
     assert metric.model.encoder[0].weight.grad is None
     assert metric.model.regressor.weight.grad is None
+
+
+@pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
+def test_import_does_not_eagerly_load_torchvision():
+    """Importing the ARNIQA modules must not eagerly import ``torchvision`` (regression for #3314).
+
+    A module-level ``torchvision`` import triggers a ``partially initialized module 'torchvision'`` circular
+    import in some ``torchvision`` versions. ``torchvision`` must therefore be imported lazily, only when the
+    metric is actually instantiated. Run in a fresh interpreter so previously imported modules do not hide a
+    regression.
+    """
+    script = (
+        "import sys\n"
+        "import torchmetrics.functional.image.arniqa\n"
+        "import torchmetrics.image.arniqa\n"
+        "assert 'torchvision' not in sys.modules, "
+        "'torchvision imported at module load: %s' % sorted(m for m in sys.modules if 'torchvision' in m)\n"
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)  # noqa: S603

--- a/tests/unittests/image/test_arniqa.py
+++ b/tests/unittests/image/test_arniqa.py
@@ -184,6 +184,7 @@ def test_import_does_not_eagerly_load_torchvision():
     import in some ``torchvision`` versions. ``torchvision`` must therefore be imported lazily, only when the
     metric is actually instantiated. Run in a fresh interpreter so previously imported modules do not hide a
     regression.
+
     """
     script = (
         "import sys\n"

--- a/tests/unittests/image/test_dists.py
+++ b/tests/unittests/image/test_dists.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import shutil
+import subprocess
 import sys
 from functools import partial
 from typing import NamedTuple
@@ -23,6 +24,7 @@ from torch import Tensor
 
 from torchmetrics.functional.image.dists import _PATH_WEIGHT_DISTS, deep_image_structure_and_texture_similarity
 from torchmetrics.image.dists import DeepImageStructureAndTextureSimilarity
+from torchmetrics.utilities.imports import _TORCHVISION_AVAILABLE
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
 
@@ -104,3 +106,22 @@ class TestDISTS(MetricTester):
         self.run_precision_test_gpu(
             preds=inputs.img1, target=inputs.img2, metric_module=DeepImageStructureAndTextureSimilarity
         )
+
+
+@pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
+def test_import_does_not_eagerly_load_torchvision():
+    """Importing the DISTS modules must not eagerly import ``torchvision`` (regression for #3314).
+
+    A module-level ``torchvision`` import triggers a ``partially initialized module 'torchvision'`` circular
+    import in some ``torchvision`` versions. ``torchvision`` must therefore be imported lazily, only when the
+    metric is actually instantiated. Run in a fresh interpreter so previously imported modules do not hide a
+    regression.
+    """
+    script = (
+        "import sys\n"
+        "import torchmetrics.functional.image.dists\n"
+        "import torchmetrics.image.dists\n"
+        "assert 'torchvision' not in sys.modules, "
+        "'torchvision imported at module load: %s' % sorted(m for m in sys.modules if 'torchvision' in m)\n"
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)  # noqa: S603

--- a/tests/unittests/image/test_dists.py
+++ b/tests/unittests/image/test_dists.py
@@ -116,6 +116,7 @@ def test_import_does_not_eagerly_load_torchvision():
     import in some ``torchvision`` versions. ``torchvision`` must therefore be imported lazily, only when the
     metric is actually instantiated. Run in a fresh interpreter so previously imported modules do not hide a
     regression.
+
     """
     script = (
         "import sys\n"


### PR DESCRIPTION
## What does this PR do?

Fixes #3314

`arniqa` and `dists` imported `torchvision` at module level (inside the `_TORCHVISION_AVAILABLE` guard), which loaded torchvision as soon as `torchmetrics` was imported and could trigger the `partially initialized module 'torchvision'` circular import in the issue traceback. This moves those imports into the metric bodies (lazy import), matching the pattern already used by `lpips` and the detection functionals, so torchvision loads only when a metric is instantiated.

Behavior is unchanged when torchvision is installed, and the missing-torchvision `ModuleNotFoundError` still fires (the `_TORCHVISION_AVAILABLE` guards are untouched).

Verified: after the change, `import torchmetrics` and the affected modules no longer pull torchvision into `sys.modules`; a real `dists` compute still produces valid output; `pytest tests/unittests/image/test_arniqa.py test_dists.py` gives 11 passed / 10 skipped (including 2 new regression tests asserting no eager torchvision load); `ruff` clean.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? — yes, #3314 (maintainer-authored, help wanted)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**? — N/A, internal import-timing fix, no docs/API change
- [x] Did you write any new **necessary tests**? — a regression test per module

</details>

## Did you have fun?

Yes.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). I verified the lazy-import fix (torchvision no longer eagerly loaded), that compute and the missing-dependency error path are unchanged, and that the image tests pass.*
