### PR TITLE
fix(aggregation): fix nan_stategy=disable dropping weights

### DIFF
--- a/src/torchmetrics/aggregation.py
+++ b/src/torchmetrics/aggregation.py
@@ -103,7 +103,7 @@ class BaseAggregator(Metric):
                         raise ValueError(f"`nan_strategy` shall be float but you pass {self.nan_strategy}")
                     x[nans | nans_weight] = self.nan_strategy
                     weight[nans | nans_weight] = 1
-        else:
+        elif weight is None:
             weight = torch.ones_like(x)
         return x.to(self.dtype), weight.to(self.dtype)
 

--- a/tests/unittests/bases/test_aggregation.py
+++ b/tests/unittests/bases/test_aggregation.py
@@ -163,6 +163,14 @@ def test_error_on_wrong_nan_strategy(metric_class):
         metric_class(nan_strategy=[])
 
 
+def test_disable_preserves_weight():
+    """`nan_strategy="disable"` should only skip nan checks, not also discarding `weight`."""
+    metric = MeanMetric(nan_strategy="disable")
+    metric.update(torch.tensor(1.0), weight=torch.tensor(3.0))
+    metric.update(torch.tensor(0.0), weight=torch.tensor(1.0))
+    assert torch.allclose(metric.compute(), torch.tensor(0.75))
+
+
 @pytest.mark.skipif(not hasattr(torch, "broadcast_to"), reason="PyTorch <1.8 does not have broadcast_to")
 @pytest.mark.parametrize(
     ("weights", "expected"), [(1, 11.5), (torch.ones(2, 1, 1), 11.5), (torch.tensor([1, 2]).reshape(2, 1, 1), 13.5)]


### PR DESCRIPTION
## What does this PR do?

if you want to disable host syncing on nans, nan_strategy=disable also overwrites your weights with ones.

see `test_disable_preserves_weight`

Fixes #3434 

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
