### PR TITLE
fix(text): use stable sort in BERTScore to fix symmetry and batch-size invariance

### DIFF
--- a/src/torchmetrics/functional/text/helper_embedding_metric.py
+++ b/src/torchmetrics/functional/text/helper_embedding_metric.py
@@ -77,8 +77,15 @@ def _output_data_collator(model_output: Tensor, attention_mask: Tensor, target_l
 
 
 def _sort_data_according_length(input_ids: Tensor, attention_mask: Tensor) -> tuple[Tensor, Tensor, Tensor]:
-    """Sort tokenized sentence from the shortest to the longest one."""
-    sorted_indices = attention_mask.sum(1).argsort()
+    """Sort tokenized sentence from the shortest to the longest one.
+
+    Uses a stable sort to ensure that sentences with equal length preserve their original relative order.
+    This is critical for correctness when preds and target contain sentences of the same length, as an
+    unstable sort could produce different orderings for preds vs target, breaking symmetry and
+    batch-size invariance of BERTScore.
+
+    """
+    sorted_indices = attention_mask.sum(1).argsort(stable=True)
     input_ids = input_ids[sorted_indices]
     attention_mask = attention_mask[sorted_indices]
     return input_ids, attention_mask, sorted_indices

--- a/src/torchmetrics/functional/text/helper_embedding_metric.py
+++ b/src/torchmetrics/functional/text/helper_embedding_metric.py
@@ -79,10 +79,9 @@ def _output_data_collator(model_output: Tensor, attention_mask: Tensor, target_l
 def _sort_data_according_length(input_ids: Tensor, attention_mask: Tensor) -> tuple[Tensor, Tensor, Tensor]:
     """Sort tokenized sentence from the shortest to the longest one.
 
-    Uses a stable sort to ensure that sentences with equal length preserve their original relative order.
-    This is critical for correctness when preds and target contain sentences of the same length, as an
-    unstable sort could produce different orderings for preds vs target, breaking symmetry and
-    batch-size invariance of BERTScore.
+    Uses a stable sort to ensure that sentences with equal length preserve their original relative order. This is
+    critical for correctness when preds and target contain sentences of the same length, as an unstable sort could
+    produce different orderings for preds vs target, breaking symmetry and batch-size invariance of BERTScore.
 
     """
     sorted_indices = attention_mask.sum(1).argsort(stable=True)

--- a/tests/unittests/text/test_bertscore.py
+++ b/tests/unittests/text/test_bertscore.py
@@ -350,3 +350,66 @@ def test_bertscore_invalid_references():
     metric = BERTScore()
     with pytest.raises(ValueError, match="Invalid input provided."):
         metric(preds, target)
+
+
+# Regression tests for https://github.com/Lightning-AI/torchmetrics/issues/2728
+# BERTScore should satisfy: (1) self-similarity is maximum, (2) F1 symmetry, (3) batch-size invariance
+
+
+@skip_on_connection_issues()
+@pytest.mark.skipif(not _TRANSFORMERS_GREATER_EQUAL_4_4, reason="test requires transformers>=4.4")
+@pytest.mark.parametrize("idf", [False])
+@pytest.mark.parametrize("batch_size", [1, 3, 9])
+def test_bertscore_self_similarity_is_maximum(idf: bool, batch_size: int) -> None:
+    """BERTScore of a sentence with itself must be >= score against any other sentence (issue #2728, property 1)."""
+    sentences = ["hello there", "master kenobi", "general kenobi"]
+    for sent in sentences:
+        self_score = bert_score([sent], [sent], idf=idf, lang="en", batch_size=batch_size, rescale_with_baseline=False)
+        for other in sentences:
+            if other == sent:
+                continue
+            cross_score = bert_score(
+                [sent], [other], idf=idf, lang="en", batch_size=batch_size, rescale_with_baseline=False
+            )
+            assert self_score["f1"].item() >= cross_score["f1"].item() - 1e-5, (
+                f"Self-similarity violated for '{sent}' vs '{other}': "
+                f"self={self_score['f1'].item():.6f}, cross={cross_score['f1'].item():.6f}"
+            )
+
+
+@skip_on_connection_issues()
+@pytest.mark.skipif(not _TRANSFORMERS_GREATER_EQUAL_4_4, reason="test requires transformers>=4.4")
+@pytest.mark.parametrize("idf", [False])
+@pytest.mark.parametrize("batch_size", [1, 3, 9])
+def test_bertscore_f1_symmetry(idf: bool, batch_size: int) -> None:
+    """BERTScore F1 must be symmetric: score(pred, target) == score(target, pred) (issue #2728, property 2)."""
+    pairs = [
+        ("hello there", "master kenobi"),
+        ("hello there", "general kenobi"),
+        ("master kenobi", "general kenobi"),
+    ]
+    for pred, target in pairs:
+        forward = bert_score([pred], [target], idf=idf, lang="en", batch_size=batch_size, rescale_with_baseline=False)
+        reverse = bert_score([target], [pred], idf=idf, lang="en", batch_size=batch_size, rescale_with_baseline=False)
+        assert torch.isclose(forward["f1"], reverse["f1"], atol=1e-5).all(), (
+            f"F1 symmetry violated for ('{pred}', '{target}'): "
+            f"forward={forward['f1'].item():.6f}, reverse={reverse['f1'].item():.6f}"
+        )
+
+
+@skip_on_connection_issues()
+@pytest.mark.skipif(not _TRANSFORMERS_GREATER_EQUAL_4_4, reason="test requires transformers>=4.4")
+@pytest.mark.parametrize("batch_size", [1, 3, 9])
+def test_bertscore_batch_size_invariance(batch_size: int) -> None:
+    """BERTScore (idf=False) must not change when batch_size changes (issue #2728, property 3)."""
+    preds = ["hello there", "master kenobi", "general kenobi"]
+    targets = ["master kenobi", "hello there", "hello there"]
+
+    reference = bert_score(preds, targets, idf=False, lang="en", batch_size=1, rescale_with_baseline=False)
+    result = bert_score(preds, targets, idf=False, lang="en", batch_size=batch_size, rescale_with_baseline=False)
+
+    for metric in ("precision", "recall", "f1"):
+        assert torch.allclose(reference[metric], result[metric], atol=1e-5), (
+            f"Batch-size invariance violated for '{metric}' at batch_size={batch_size}: "
+            f"batch_size=1 gives {reference[metric]}, batch_size={batch_size} gives {result[metric]}"
+        )


### PR DESCRIPTION
## Summary

Fixes #2728

The three BERTScore property violations reported in #2728 all trace back to a single root cause: `argsort()` without `stable=True` in `_sort_data_according_length()`.

When preds and target contain sentences with equal token lengths, an unstable sort can resolve tie-breaks differently for each dataset. Since embeddings are computed in sorted order and later reindexed by `sorting_indices`, inconsistent orderings between the preds and target datasets break:

1. **F1 symmetry** — `bert_score(A, B) != bert_score(B, A)` when A and B tokenize to the same length, because `argsort` may place them in different positions for each dataset
2. **Batch-size invariance (idf=False)** — different batch sizes process different subsets of equal-length sequences together, triggering different tie-break resolutions in `argsort` across runs

## Fix

One-line change in `_sort_data_according_length`:

```python
# Before
sorted_indices = attention_mask.sum(1).argsort()

# After
sorted_indices = attention_mask.sum(1).argsort(stable=True)
```

Stable sort preserves the original relative order for equal-length sentences, ensuring preds and target are always sorted and reindexed consistently regardless of content or batch size.

## Tests

Added three regression tests to `tests/unittests/text/test_bertscore.py`:
- `test_bertscore_self_similarity_is_maximum` — self-comparison must score highest
- `test_bertscore_f1_symmetry` — F1 must be equal when pred/target are swapped
- `test_bertscore_batch_size_invariance` — scores must not change with batch size (idf=False)

All three are parameterized over `batch_size ∈ {1, 3, 9}`.