### PR TITLE
fix(validation): correct 'and' to 'or' in argument validation across multiple metrics

### DIFF
--- a/src/torchmetrics/classification/group_fairness.py
+++ b/src/torchmetrics/classification/group_fairness.py
@@ -122,7 +122,7 @@ class BinaryGroupStatRates(_AbstractGroupStatScores):
         if validate_args:
             _binary_stat_scores_arg_validation(threshold, "global", ignore_index)
 
-        if not isinstance(num_groups, int) and num_groups < 2:
+        if not isinstance(num_groups, int) or num_groups < 2:
             raise ValueError(f"Expected argument `num_groups` to be an int larger than 1, but got {num_groups}")
         self.num_groups = num_groups
         self.threshold = threshold
@@ -236,7 +236,7 @@ class BinaryFairness(_AbstractGroupStatScores):
         if validate_args:
             _binary_stat_scores_arg_validation(threshold, "global", ignore_index)
 
-        if not isinstance(num_groups, int) and num_groups < 2:
+        if not isinstance(num_groups, int) or num_groups < 2:
             raise ValueError(f"Expected argument `num_groups` to be an int larger than 1, but got {num_groups}")
         self.num_groups = num_groups
         self.task = task

--- a/src/torchmetrics/functional/classification/recall_fixed_precision.py
+++ b/src/torchmetrics/functional/classification/recall_fixed_precision.py
@@ -82,7 +82,7 @@ def _binary_recall_at_fixed_precision_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _binary_precision_recall_curve_arg_validation(thresholds, ignore_index)
-    if not isinstance(min_precision, float) and not (0 <= min_precision <= 1):
+    if not isinstance(min_precision, float) or not (0 <= min_precision <= 1):
         raise ValueError(
             f"Expected argument `min_precision` to be an float in the [0,1] range, but got {min_precision}"
         )
@@ -179,7 +179,7 @@ def _multiclass_recall_at_fixed_precision_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multiclass_precision_recall_curve_arg_validation(num_classes, thresholds, ignore_index)
-    if not isinstance(min_precision, float) and not (0 <= min_precision <= 1):
+    if not isinstance(min_precision, float) or not (0 <= min_precision <= 1):
         raise ValueError(
             f"Expected argument `min_precision` to be an float in the [0,1] range, but got {min_precision}"
         )
@@ -289,7 +289,7 @@ def _multilabel_recall_at_fixed_precision_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multilabel_precision_recall_curve_arg_validation(num_labels, thresholds, ignore_index)
-    if not isinstance(min_precision, float) and not (0 <= min_precision <= 1):
+    if not isinstance(min_precision, float) or not (0 <= min_precision <= 1):
         raise ValueError(
             f"Expected argument `min_precision` to be an float in the [0,1] range, but got {min_precision}"
         )

--- a/src/torchmetrics/functional/classification/sensitivity_specificity.py
+++ b/src/torchmetrics/functional/classification/sensitivity_specificity.py
@@ -76,7 +76,7 @@ def _binary_sensitivity_at_specificity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _binary_precision_recall_curve_arg_validation(thresholds, ignore_index)
-    if not isinstance(min_specificity, float) and not (0 <= min_specificity <= 1):
+    if not isinstance(min_specificity, float) or not (0 <= min_specificity <= 1):
         raise ValueError(
             f"Expected argument `min_specificity` to be an float in the [0,1] range, but got {min_specificity}"
         )
@@ -173,7 +173,7 @@ def _multiclass_sensitivity_at_specificity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multiclass_precision_recall_curve_arg_validation(num_classes, thresholds, ignore_index)
-    if not isinstance(min_specificity, float) and not (0 <= min_specificity <= 1):
+    if not isinstance(min_specificity, float) or not (0 <= min_specificity <= 1):
         raise ValueError(
             f"Expected argument `min_specificity` to be an float in the [0,1] range, but got {min_specificity}"
         )
@@ -289,7 +289,7 @@ def _multilabel_sensitivity_at_specificity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multilabel_precision_recall_curve_arg_validation(num_labels, thresholds, ignore_index)
-    if not isinstance(min_specificity, float) and not (0 <= min_specificity <= 1):
+    if not isinstance(min_specificity, float) or not (0 <= min_specificity <= 1):
         raise ValueError(
             f"Expected argument `min_specificity` to be an float in the [0,1] range, but got {min_specificity}"
         )

--- a/src/torchmetrics/functional/classification/specificity_sensitivity.py
+++ b/src/torchmetrics/functional/classification/specificity_sensitivity.py
@@ -77,7 +77,7 @@ def _binary_specificity_at_sensitivity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _binary_precision_recall_curve_arg_validation(thresholds, ignore_index)
-    if not isinstance(min_sensitivity, float) and not (0 <= min_sensitivity <= 1):
+    if not isinstance(min_sensitivity, float) or not (0 <= min_sensitivity <= 1):
         raise ValueError(
             f"Expected argument `min_sensitivity` to be an float in the [0,1] range, but got {min_sensitivity}"
         )
@@ -174,7 +174,7 @@ def _multiclass_specificity_at_sensitivity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multiclass_precision_recall_curve_arg_validation(num_classes, thresholds, ignore_index)
-    if not isinstance(min_sensitivity, float) and not (0 <= min_sensitivity <= 1):
+    if not isinstance(min_sensitivity, float) or not (0 <= min_sensitivity <= 1):
         raise ValueError(
             f"Expected argument `min_sensitivity` to be an float in the [0,1] range, but got {min_sensitivity}"
         )
@@ -290,7 +290,7 @@ def _multilabel_specificity_at_sensitivity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multilabel_precision_recall_curve_arg_validation(num_labels, thresholds, ignore_index)
-    if not isinstance(min_sensitivity, float) and not (0 <= min_sensitivity <= 1):
+    if not isinstance(min_sensitivity, float) or not (0 <= min_sensitivity <= 1):
         raise ValueError(
             f"Expected argument `min_sensitivity` to be an float in the [0,1] range, but got {min_sensitivity}"
         )

--- a/src/torchmetrics/image/psnrb.py
+++ b/src/torchmetrics/image/psnrb.py
@@ -79,7 +79,7 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        if not isinstance(block_size, int) and block_size < 1:
+        if not isinstance(block_size, int) or block_size < 1:
             raise ValueError("Argument ``block_size`` should be a positive integer")
         self.block_size = block_size
 

--- a/src/torchmetrics/regression/log_cosh.py
+++ b/src/torchmetrics/regression/log_cosh.py
@@ -77,7 +77,7 @@ class LogCoshError(Metric):
     def __init__(self, num_outputs: int = 1, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-        if not isinstance(num_outputs, int) and num_outputs < 1:
+        if not isinstance(num_outputs, int) or num_outputs < 1:
             raise ValueError(f"Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
         self.add_state("sum_log_cosh_error", default=torch.zeros(num_outputs), dist_reduce_fx="sum")

--- a/src/torchmetrics/regression/pearson.py
+++ b/src/torchmetrics/regression/pearson.py
@@ -160,7 +160,7 @@ class PearsonCorrCoef(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        if not isinstance(num_outputs, int) and num_outputs < 1:
+        if not isinstance(num_outputs, int) or num_outputs < 1:
             raise ValueError("Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
 

--- a/src/torchmetrics/regression/spearman.py
+++ b/src/torchmetrics/regression/spearman.py
@@ -88,7 +88,7 @@ class SpearmanCorrCoef(Metric):
             "Metric `SpearmanCorrcoef` will save all targets and predictions in the buffer."
             " For large datasets, this may lead to large memory footprint."
         )
-        if not isinstance(num_outputs, int) and num_outputs < 1:
+        if not isinstance(num_outputs, int) or num_outputs < 1:
             raise ValueError(f"Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
 


### PR DESCRIPTION
## Summary

Several argument validation guards across multiple metrics used the wrong logical operator ( instead of ). As a result, **invalid arguments were silently accepted** and caused cryptic runtime errors deep inside the metric computation rather than a clear `ValueError` at initialisation time.

This pattern was first identified in `stat_scores.py` (issues #3405, resolved in PRs #3406/#3416) and in retrieval metrics (issue #3378). This PR fixes the identical bug in all remaining affected files.

## The Bug

The guards follow the pattern:

```python
# Wrong: only fails when BOTH conditions are True
if not isinstance(x, SomeType) and x_is_invalid:
    raise ValueError(...)
```

For an invalid-value-but-correct-type input (e.g., `min_sensitivity=2.0`):
- `not isinstance(2.0, float)` → `False`
- `2.0` is outside `[0, 1]` → `True`
- `False and True` → **`False`** — no error raised!

**Fix:** replace  with  so validation fails when *either* the type or the value is wrong.

## Files Changed

| File | Parameter | Invalid values that bypassed validation |
|------|-----------|----------------------------------------|
| `functional/classification/specificity_sensitivity.py` (3 sites) | `min_sensitivity` | out-of-range floats, e.g. `2.0`, `-0.5` |
| `functional/classification/recall_fixed_precision.py` (3 sites) | `min_precision` | out-of-range floats, e.g. `2.0`, `-0.1` |
| `functional/classification/sensitivity_specificity.py` (3 sites) | `min_specificity` | out-of-range floats, e.g. `2.0`, `-0.5` |
| `regression/spearman.py` | `num_outputs` | `0`, negative integers |
| `regression/pearson.py` | `num_outputs` | `0`, negative integers |
| `regression/log_cosh.py` | `num_outputs` | `0`, negative integers |
| `classification/group_fairness.py` (2 sites) | `num_groups` | `0`, `1`, negative integers |
| `image/psnrb.py` | `block_size` | `0`, negative integers |

## Minimal Reproduction

```python
from torchmetrics.functional.classification import binary_specificity_at_sensitivity

# Before fix: no error raised for out-of-range float
binary_specificity_at_sensitivity(preds, target, min_sensitivity=2.0)

# After fix: raises ValueError immediately
# ValueError: Expected argument `min_sensitivity` to be an float in the [0,1] range, but got 2.0
```

```python
from torchmetrics.regression import SpearmanCorrCoef

# Before fix: no error for zero num_outputs (int)
SpearmanCorrCoef(num_outputs=0)

# After fix: raises ValueError immediately
# ValueError: Expected argument `num_outputs` to be an int larger than 0, but got 0
```