### PR TITLE
fix(validation): correct argument validation in auroc, logauc, and pesq metrics

### DIFF
--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -114,7 +114,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
         if mode not in ("wb", "nb"):
             raise ValueError(f"Expected argument `mode` to either be 'wb' or 'nb' but got {mode}")
         self.mode = mode
-        if not isinstance(n_processes, int) and n_processes <= 0:
+        if not isinstance(n_processes, int) or n_processes <= 0:
             raise ValueError(f"Expected argument `n_processes` to be an int larger than 0 but got {n_processes}")
         self.n_processes = n_processes
 

--- a/src/torchmetrics/functional/classification/auroc.py
+++ b/src/torchmetrics/functional/classification/auroc.py
@@ -76,7 +76,7 @@ def _binary_auroc_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _binary_precision_recall_curve_arg_validation(thresholds, ignore_index)
-    if max_fpr is not None and not isinstance(max_fpr, float) and 0 < max_fpr <= 1:
+    if max_fpr is not None and (not isinstance(max_fpr, float) or not (0 < max_fpr <= 1)):
         raise ValueError(f"Arguments `max_fpr` should be a float in range (0, 1], but got: {max_fpr}")
 
 

--- a/src/torchmetrics/functional/classification/logauc.py
+++ b/src/torchmetrics/functional/classification/logauc.py
@@ -26,7 +26,7 @@ from torchmetrics.utilities.enums import ClassificationTask
 
 def _validate_fpr_range(fpr_range: Tuple[float, float]) -> None:
     """Validate the `fpr_range` argument for the logauc metric."""
-    if not isinstance(fpr_range, tuple) and not len(fpr_range) == 2:
+    if not isinstance(fpr_range, tuple) or len(fpr_range) != 2:
         raise ValueError(f"The `fpr_range` should be a tuple of two floats, but got {type(fpr_range)}.")
     if not (0 <= fpr_range[0] < fpr_range[1] <= 1):
         raise ValueError(f"The `fpr_range` should be a tuple of two floats in the range [0, 1], but got {fpr_range}.")

--- a/src/torchmetrics/retrieval/auroc.py
+++ b/src/torchmetrics/retrieval/auroc.py
@@ -114,7 +114,7 @@ class RetrievalAUROC(RetrievalMetric):
         if top_k is not None and not (isinstance(top_k, int) and top_k > 0):
             raise ValueError("`top_k` has to be a positive integer or None")
         self.top_k = top_k
-        if max_fpr is not None and not isinstance(max_fpr, float) and 0 < max_fpr <= 1:
+        if max_fpr is not None and (not isinstance(max_fpr, float) or not (0 < max_fpr <= 1)):
             raise ValueError(f"Arguments `max_fpr` should be a float in range (0, 1], but got: {max_fpr}")
         self.max_fpr = max_fpr
 


### PR DESCRIPTION
## Summary

Four more instances of the same `and` vs `or` logical operator bug in argument validation, affecting the AUROC, LogAUC, and PESQ metrics. These are the remaining sites not covered by PR #3440.

## The Bug

Each guard uses `and` where `or` is required:

```python
# Wrong: only raises when BOTH conditions are simultaneously True
if <type-check-fails> and <value-check-fails>:
    raise ValueError(...)
```

This means a value with a **correct type but invalid range** silently bypasses the check.

## Files Changed

| File | Parameter | Example of bypassed invalid input |
|------|-----------|-----------------------------------|
| `audio/pesq.py` | `n_processes` | `n_processes=0` (int, but ≤ 0) |
| `functional/classification/auroc.py` | `max_fpr` | `max_fpr=2.0` (float, but outside (0, 1]) |
| `retrieval/auroc.py` | `max_fpr` | same as above in class API |
| `functional/classification/logauc.py` | `fpr_range` | `fpr_range=[0.001, 0.1]` (list of len 2, not tuple) |

## Reproduction

```python
from torchmetrics.functional.classification import binary_auroc

# Before fix: no error for out-of-range max_fpr (silently computes wrong AUROC)
binary_auroc(preds, target, max_fpr=2.0)

# After fix:
# ValueError: Arguments `max_fpr` should be a float in range (0, 1], but got: 2.0
```

```python
from torchmetrics.audio import PerceptualEvaluationSpeechQuality

# Before fix: no error for n_processes=0
PerceptualEvaluationSpeechQuality(fs=16000, mode='wb', n_processes=0)

# After fix:
# ValueError: Expected argument `n_processes` to be an int larger than 0 but got 0
```

## Related

- PR #3440 fixes the same bug pattern in specificity/precision/sensitivity, regression, group-fairness, and psnrb metrics.
- PRs #3406 / #3416 / #3418 fix the same pattern for `top_k` in stat_scores and retrieval metrics.