### PR TITLE
fix(docs): ignore NIST link causing intermittent linkcheck 504

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -438,6 +438,8 @@ linkcheck_ignore = [
     "https://ieeexplore.ieee.org/abstract/document/5547575",
     # An Algorithm for Predicting the Intelligibility of Speech Masked by Modulated Noise Maskers
     "https://ieeexplore.ieee.org/abstract/document/7539284",
+    # NIST link check
+    "https://www.nist.gov",
     # A short-time objective intelligibility measure for time-frequency weighted noisy speech
     "https://ieeexplore.ieee.org/abstract/document/5495701",
     # An Algorithm for Intelligibility Prediction of Time-Frequency Weighted Noisy Speech


### PR DESCRIPTION
Fixes #3431

Adds NIST URL to linkcheck_ignore in docs/source/conf.py to prevent intermittent 504 errors during doc builds.