### PR TITLE
fix: correct LogCoshError num_outputs input validation (and -> or)

### DIFF
--- a/src/torchmetrics/regression/log_cosh.py
+++ b/src/torchmetrics/regression/log_cosh.py
@@ -77,7 +77,7 @@ class LogCoshError(Metric):
     def __init__(self, num_outputs: int = 1, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-        if not isinstance(num_outputs, int) and num_outputs < 1:
+        if not isinstance(num_outputs, int) or num_outputs < 1:
             raise ValueError(f"Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
         self.add_state("sum_log_cosh_error", default=torch.zeros(num_outputs), dist_reduce_fx="sum")


### PR DESCRIPTION
## Problem
`LogCoshError.__init__` uses `and` where `or` is intended:

```python
if not isinstance(num_outputs, int) and num_outputs < 1:
```

With `and`, non-integer values silently pass validation because the isinstance check short-circuits the `and`:
- `num_outputs=3.5` (float): passes without error
- `num_outputs="abc"` (str): passes without error

Same class of bug as #3364 (PSNRB block_size validation).

## Fix
Change `and` to `or` so ValueError is raised for both non-integer and non-positive values.

Co-Authored-By: Claude <noreply@anthropic.com>