### PR TITLE
fix: correct PearsonCorrCoef num_outputs input validation (and -> or)

### DIFF
--- a/src/torchmetrics/regression/pearson.py
+++ b/src/torchmetrics/regression/pearson.py
@@ -160,7 +160,7 @@ class PearsonCorrCoef(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        if not isinstance(num_outputs, int) and num_outputs < 1:
+        if not isinstance(num_outputs, int) or num_outputs < 1:
             raise ValueError("Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
 


### PR DESCRIPTION
## Problem
Same `and` -> `or` bug as #3364 (PSNRB) and LogCoshError. Non-integer `num_outputs` values silently pass validation.

## Fix
Change `and` to `or` for correct input validation.

Co-Authored-By: Claude <noreply@anthropic.com>