### PR TITLE
Fix functional nominal metrics for sparse category labels

### DIFF
--- a/src/torchmetrics/functional/nominal/cramers.py
+++ b/src/torchmetrics/functional/nominal/cramers.py
@@ -18,12 +18,11 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.classification.confusion_matrix import _multiclass_confusion_matrix_update
 from torchmetrics.functional.nominal.utils import (
     _compute_bias_corrected_values,
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
-    _handle_nan_in_data,
+    _nominal_confusion_matrix_update,
     _nominal_input_validation,
     _unable_to_use_bias_correction_warning,
 )
@@ -32,7 +31,7 @@ from torchmetrics.functional.nominal.utils import (
 def _cramers_v_update(
     preds: Tensor,
     target: Tensor,
-    num_classes: int,
+    num_classes: Optional[int],
     nan_strategy: Literal["replace", "drop"] = "replace",
     nan_replace_value: Optional[float] = 0.0,
 ) -> Tensor:
@@ -49,10 +48,7 @@ def _cramers_v_update(
         Non-reduced confusion matrix
 
     """
-    preds = preds.argmax(1) if preds.ndim == 2 else preds
-    target = target.argmax(1) if target.ndim == 2 else target
-    preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
-    return _multiclass_confusion_matrix_update(preds, target, num_classes)
+    return _nominal_confusion_matrix_update(preds, target, num_classes, nan_strategy, nan_replace_value)
 
 
 def _cramers_v_compute(confmat: Tensor, bias_correction: bool) -> Tensor:
@@ -133,8 +129,7 @@ def cramers_v(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _cramers_v_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    confmat = _cramers_v_update(preds, target, None, nan_strategy, nan_replace_value)
     return _cramers_v_compute(confmat, bias_correction)
 
 
@@ -177,7 +172,6 @@ def cramers_v_matrix(
     cramers_v_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _cramers_v_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        confmat = _cramers_v_update(x, y, None, nan_strategy, nan_replace_value)
         cramers_v_matrix_value[i, j] = cramers_v_matrix_value[j, i] = _cramers_v_compute(confmat, bias_correction)
     return cramers_v_matrix_value

--- a/src/torchmetrics/functional/nominal/pearson.py
+++ b/src/torchmetrics/functional/nominal/pearson.py
@@ -18,11 +18,10 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.classification.confusion_matrix import _multiclass_confusion_matrix_update
 from torchmetrics.functional.nominal.utils import (
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
-    _handle_nan_in_data,
+    _nominal_confusion_matrix_update,
     _nominal_input_validation,
 )
 
@@ -30,7 +29,7 @@ from torchmetrics.functional.nominal.utils import (
 def _pearsons_contingency_coefficient_update(
     preds: Tensor,
     target: Tensor,
-    num_classes: int,
+    num_classes: Optional[int],
     nan_strategy: Literal["replace", "drop"] = "replace",
     nan_replace_value: Optional[float] = 0.0,
 ) -> Tensor:
@@ -47,10 +46,7 @@ def _pearsons_contingency_coefficient_update(
         Non-reduced confusion matrix
 
     """
-    preds = preds.argmax(1) if preds.ndim == 2 else preds
-    target = target.argmax(1) if target.ndim == 2 else target
-    preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
-    return _multiclass_confusion_matrix_update(preds, target, num_classes)
+    return _nominal_confusion_matrix_update(preds, target, num_classes, nan_strategy, nan_replace_value)
 
 
 def _pearsons_contingency_coefficient_compute(confmat: Tensor) -> Tensor:
@@ -123,8 +119,7 @@ def pearsons_contingency_coefficient(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _pearsons_contingency_coefficient_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    confmat = _pearsons_contingency_coefficient_update(preds, target, None, nan_strategy, nan_replace_value)
     return _pearsons_contingency_coefficient_compute(confmat)
 
 
@@ -167,8 +162,7 @@ def pearsons_contingency_coefficient_matrix(
     pearsons_cont_coef_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _pearsons_contingency_coefficient_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        confmat = _pearsons_contingency_coefficient_update(x, y, None, nan_strategy, nan_replace_value)
         val = _pearsons_contingency_coefficient_compute(confmat)
         pearsons_cont_coef_matrix_value[i, j] = pearsons_cont_coef_matrix_value[j, i] = val
     return pearsons_cont_coef_matrix_value

--- a/src/torchmetrics/functional/nominal/theils_u.py
+++ b/src/torchmetrics/functional/nominal/theils_u.py
@@ -18,10 +18,9 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.classification.confusion_matrix import _multiclass_confusion_matrix_update
 from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
-    _handle_nan_in_data,
+    _nominal_confusion_matrix_update,
     _nominal_input_validation,
 )
 
@@ -55,7 +54,7 @@ def _conditional_entropy_compute(confmat: Tensor) -> Tensor:
 def _theils_u_update(
     preds: Tensor,
     target: Tensor,
-    num_classes: int,
+    num_classes: Optional[int],
     nan_strategy: Literal["replace", "drop"] = "replace",
     nan_replace_value: Optional[float] = 0.0,
 ) -> Tensor:
@@ -72,10 +71,7 @@ def _theils_u_update(
         Non-reduced confusion matrix
 
     """
-    preds = preds.argmax(1) if preds.ndim == 2 else preds
-    target = target.argmax(1) if target.ndim == 2 else target
-    preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
-    return _multiclass_confusion_matrix_update(preds, target, num_classes)
+    return _nominal_confusion_matrix_update(preds, target, num_classes, nan_strategy, nan_replace_value)
 
 
 def _theils_u_compute(confmat: Tensor) -> Tensor:
@@ -146,8 +142,7 @@ def theils_u(
         tensor(0.8530)
 
     """
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _theils_u_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    confmat = _theils_u_update(preds, target, None, nan_strategy, nan_replace_value)
     return _theils_u_compute(confmat)
 
 
@@ -188,8 +183,7 @@ def theils_u_matrix(
     theils_u_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _theils_u_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        confmat = _theils_u_update(x, y, None, nan_strategy, nan_replace_value)
         theils_u_matrix_value[i, j] = _theils_u_compute(confmat)
         theils_u_matrix_value[j, i] = _theils_u_compute(confmat.T)
     return theils_u_matrix_value

--- a/src/torchmetrics/functional/nominal/tschuprows.py
+++ b/src/torchmetrics/functional/nominal/tschuprows.py
@@ -18,12 +18,11 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.functional.classification.confusion_matrix import _multiclass_confusion_matrix_update
 from torchmetrics.functional.nominal.utils import (
     _compute_bias_corrected_values,
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
-    _handle_nan_in_data,
+    _nominal_confusion_matrix_update,
     _nominal_input_validation,
     _unable_to_use_bias_correction_warning,
 )
@@ -32,7 +31,7 @@ from torchmetrics.functional.nominal.utils import (
 def _tschuprows_t_update(
     preds: Tensor,
     target: Tensor,
-    num_classes: int,
+    num_classes: Optional[int],
     nan_strategy: Literal["replace", "drop"] = "replace",
     nan_replace_value: Optional[float] = 0.0,
 ) -> Tensor:
@@ -49,10 +48,7 @@ def _tschuprows_t_update(
         Non-reduced confusion matrix
 
     """
-    preds = preds.argmax(1) if preds.ndim == 2 else preds
-    target = target.argmax(1) if target.ndim == 2 else target
-    preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
-    return _multiclass_confusion_matrix_update(preds, target, num_classes)
+    return _nominal_confusion_matrix_update(preds, target, num_classes, nan_strategy, nan_replace_value)
 
 
 def _tschuprows_t_compute(confmat: Tensor, bias_correction: bool) -> Tensor:
@@ -139,8 +135,7 @@ def tschuprows_t(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _tschuprows_t_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    confmat = _tschuprows_t_update(preds, target, None, nan_strategy, nan_replace_value)
     return _tschuprows_t_compute(confmat, bias_correction)
 
 
@@ -185,8 +180,7 @@ def tschuprows_t_matrix(
     tschuprows_t_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _tschuprows_t_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        confmat = _tschuprows_t_update(x, y, None, nan_strategy, nan_replace_value)
         tschuprows_t_matrix_value[i, j] = tschuprows_t_matrix_value[j, i] = _tschuprows_t_compute(
             confmat, bias_correction
         )

--- a/src/torchmetrics/functional/nominal/utils.py
+++ b/src/torchmetrics/functional/nominal/utils.py
@@ -17,6 +17,7 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
+from torchmetrics.functional.classification.confusion_matrix import _multiclass_confusion_matrix_update
 from torchmetrics.utilities.prints import rank_zero_warn
 
 
@@ -138,6 +139,26 @@ def _handle_nan_in_data(
         return preds.nan_to_num(nan_replace_value), target.nan_to_num(nan_replace_value)
     rows_contain_nan = torch.logical_or(preds.isnan(), target.isnan())
     return preds[~rows_contain_nan], target[~rows_contain_nan]
+
+
+def _nominal_confusion_matrix_update(
+    preds: Tensor,
+    target: Tensor,
+    num_classes: Optional[int],
+    nan_strategy: Literal["replace", "drop"] = "replace",
+    nan_replace_value: Optional[float] = 0.0,
+) -> Tensor:
+    """Create a confusion matrix from nominal data."""
+    preds = preds.argmax(1) if preds.ndim == 2 else preds
+    target = target.argmax(1) if target.ndim == 2 else target
+    preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
+
+    if num_classes is None:
+        categories, inverse = torch.unique(torch.cat([preds, target]), return_inverse=True)
+        preds, target = inverse.split([preds.numel(), target.numel()])
+        num_classes = categories.numel()
+
+    return _multiclass_confusion_matrix_update(preds, target, num_classes)
 
 
 def _unable_to_use_bias_correction_warning(metric_name: str) -> None:

--- a/tests/unittests/nominal/test_category_labels.py
+++ b/tests/unittests/nominal/test_category_labels.py
@@ -1,0 +1,67 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from torchmetrics.functional.nominal import (
+    cramers_v,
+    cramers_v_matrix,
+    pearsons_contingency_coefficient,
+    pearsons_contingency_coefficient_matrix,
+    theils_u,
+    theils_u_matrix,
+    tschuprows_t,
+    tschuprows_t_matrix,
+)
+
+
+@pytest.mark.parametrize(
+    ("metric", "kwargs"),
+    [
+        (cramers_v, {"bias_correction": False}),
+        (pearsons_contingency_coefficient, {}),
+        (theils_u, {}),
+        (tschuprows_t, {"bias_correction": False}),
+    ],
+)
+def test_functional_metric_is_invariant_to_category_labels(metric, kwargs):
+    """Test that functional nominal metrics support non-contiguous category labels."""
+    categories = torch.tensor([0, 0, 1, 1])
+    relabeled_categories = torch.tensor([2, 2, 5, 5])
+
+    expected = metric(categories, categories, **kwargs)
+    actual = metric(relabeled_categories, relabeled_categories, **kwargs)
+
+    assert torch.allclose(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("metric", "kwargs"),
+    [
+        (cramers_v_matrix, {"bias_correction": False}),
+        (pearsons_contingency_coefficient_matrix, {}),
+        (theils_u_matrix, {}),
+        (tschuprows_t_matrix, {"bias_correction": False}),
+    ],
+)
+def test_matrix_metric_is_invariant_to_category_labels(metric, kwargs):
+    """Test that nominal matrix metrics support different non-contiguous labels per variable."""
+    categories = torch.tensor([[0, 1], [0, 1], [1, 0], [1, 0]])
+    relabeled_categories = categories * torch.tensor([3, 4]) + torch.tensor([2, 7])
+
+    expected = metric(categories, **kwargs)
+    actual = metric(relabeled_categories, **kwargs)
+
+    assert torch.allclose(actual, expected)


### PR DESCRIPTION
## What does this PR do?

Fixes #3446.

Functional nominal association metrics inferred `num_classes` from the number of unique values but passed raw category IDs to the classification confusion-matrix updater. Sparse or non-zero-based labels could therefore produce bin indices outside the inferred matrix and fail during reshape.

This change centralizes nominal confusion-matrix preprocessing. Functional APIs jointly encode observed categories as contiguous IDs after logits and NaN handling, while stateful metrics retain their explicit `num_classes` behavior so their encoding remains stable across updates.

Regression coverage checks category-renaming invariance for the scalar and matrix forms of:

- Cramer's V
- Pearson's contingency coefficient
- Theil's U
- Tschuprow's T

## Validation

- `python -m pytest tests/unittests/nominal -q`: 112 passed
- `python -m ruff check <six changed files>`
- `python -m ruff format --check <six changed files>`
- `git diff --check`
- Clean-master reproduction confirmed all four scalar functions fail before this patch and return label-invariant values afterward

## Before submitting

- [x] Bug documented and reproduced in #3446
- [x] Contributor guidelines reviewed
- [x] Regression tests added
- [x] Documentation not changed because this restores already-documented categorical input behavior

AI disclosure: I used Codex to help identify and reproduce the bug, search for existing reports, implement and validate the fix, and draft this PR. I reviewed the code, tests, and validation output and will personally handle review feedback.
