### PR TITLE
fix(metric): honor `torch.device` context manager when setting default device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 
 
+- Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
+
+
 ---
 
 ## [1.9.0] - 2026-03-05

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -39,7 +39,7 @@ from torchmetrics.utilities.data import (
 )
 from torchmetrics.utilities.distributed import gather_all_tensors
 from torchmetrics.utilities.exceptions import TorchMetricsUserError
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1, _TORCH_GREATER_EQUAL_2_3
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1, _TORCH_GREATER_EQUAL_2_8
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE, plot_single_or_multi_val
 from torchmetrics.utilities.prints import rank_zero_warn
 
@@ -113,7 +113,9 @@ class Metric(Module, ABC):
         torch._C._log_api_usage_once(f"torchmetrics.metric.{self.__class__.__name__}")
         # magic patch for `RuntimeError: DataLoader worker (pid(s) 104) exited unexpectedly`
         self._TORCH_GREATER_EQUAL_2_1 = bool(_TORCH_GREATER_EQUAL_2_1)
-        self._device = torch.get_default_device() if _TORCH_GREATER_EQUAL_2_3 else torch.empty(0).device
+        # `get_default_device` only reflects an active `with torch.device(...)` context manager from 2.8 onwards;
+        # before that it only tracked `set_default_device`, so fall back to probing an actual tensor.
+        self._device = torch.get_default_device() if _TORCH_GREATER_EQUAL_2_8 else torch.empty(0).device
         self._dtype = torch.get_default_dtype()
 
         self.compute_on_cpu = kwargs.pop("compute_on_cpu", False)

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -113,8 +113,7 @@ class Metric(Module, ABC):
         torch._C._log_api_usage_once(f"torchmetrics.metric.{self.__class__.__name__}")
         # magic patch for `RuntimeError: DataLoader worker (pid(s) 104) exited unexpectedly`
         self._TORCH_GREATER_EQUAL_2_1 = bool(_TORCH_GREATER_EQUAL_2_1)
-        # `get_default_device` only reflects an active `with torch.device(...)` context manager from 2.8 onwards;
-        # before that it only tracked `set_default_device`, so fall back to probing an actual tensor.
+        # before 2.8, `get_default_device` only tracked `set_default_device`, not an active `torch.device` context
         self._device = torch.get_default_device() if _TORCH_GREATER_EQUAL_2_8 else torch.empty(0).device
         self._dtype = torch.get_default_dtype()
 

--- a/src/torchmetrics/utilities/imports.py
+++ b/src/torchmetrics/utilities/imports.py
@@ -23,6 +23,7 @@ _TORCH_GREATER_EQUAL_2_1 = RequirementCache("torch>=2.1.0")
 _TORCH_GREATER_EQUAL_2_2 = RequirementCache("torch>=2.2.0")
 _TORCH_GREATER_EQUAL_2_3 = RequirementCache("torch>=2.3.0")
 _TORCH_GREATER_EQUAL_2_5 = RequirementCache("torch>=2.5.0")
+_TORCH_GREATER_EQUAL_2_8 = RequirementCache("torch>=2.8.0")
 _TORCH_LESS_THAN_2_6 = RequirementCache("torch<2.6.0")
 _TORCHMETRICS_GREATER_EQUAL_1_6 = RequirementCache("torchmetrics>=1.7.0")
 

--- a/tests/unittests/bases/test_metric.py
+++ b/tests/unittests/bases/test_metric.py
@@ -30,6 +30,7 @@ from torchmetrics.classification import BinaryAccuracy
 from torchmetrics.clustering import AdjustedRandScore
 from torchmetrics.image import StructuralSimilarityIndexMeasure
 from torchmetrics.regression import PearsonCorrCoef, R2Score
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_8
 from unittests._helpers import seed_all
 from unittests._helpers.testers import DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum
 
@@ -333,16 +334,31 @@ def test_device_and_dtype_transfer(tmpdir):
     torch.set_default_dtype(default_dtype)
 
 
-def test_device_from_device_context_manager():
+@pytest.mark.parametrize(
+    "torch_greater_equal_2_8",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not _TORCH_GREATER_EQUAL_2_8, reason="`torch.get_default_device` ignores the context manager < 2.8"
+            ),
+        ),
+        False,
+    ],
+)
+def test_device_from_device_context_manager(monkeypatch, torch_greater_equal_2_8):
     """Test that a metric picks up the device from an active ``torch.device`` context manager.
 
-    Uses the ``meta`` device so this is runnable without a GPU. ``torch.get_default_device`` only started reflecting
-    the context manager in torch 2.8, so on older versions this guards the ``torch.empty(0).device`` fallback.
+    Uses the ``meta`` device so this is runnable without a GPU. Both branches of the version gate are exercised:
+    ``torch.get_default_device`` only started reflecting the context manager in torch 2.8, so below that we probe
+    ``torch.empty(0).device`` instead - forcing that branch keeps it covered on newer torch as well.
 
     """
+    monkeypatch.setattr("torchmetrics.metric._TORCH_GREATER_EQUAL_2_8", torch_greater_equal_2_8)
     with torch.device("meta"):
         metric = DummyMetricSum()
     assert metric.device == torch.device("meta")
+    assert metric.x.device == torch.device("meta")
 
 
 def test_disable_of_normal_dtype_methods():

--- a/tests/unittests/bases/test_metric.py
+++ b/tests/unittests/bases/test_metric.py
@@ -335,26 +335,15 @@ def test_device_and_dtype_transfer(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "torch_greater_equal_2_8",
+    "use_get_default_device",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.skipif(
-                not _TORCH_GREATER_EQUAL_2_8, reason="`torch.get_default_device` ignores the context manager < 2.8"
-            ),
-        ),
+        pytest.param(True, marks=pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_8, reason="requires torch>=2.8")),
         False,
     ],
 )
-def test_device_from_device_context_manager(monkeypatch, torch_greater_equal_2_8):
-    """Test that a metric picks up the device from an active ``torch.device`` context manager.
-
-    Uses the ``meta`` device so this is runnable without a GPU. Both branches of the version gate are exercised:
-    ``torch.get_default_device`` only started reflecting the context manager in torch 2.8, so below that we probe
-    ``torch.empty(0).device`` instead - forcing that branch keeps it covered on newer torch as well.
-
-    """
-    monkeypatch.setattr("torchmetrics.metric._TORCH_GREATER_EQUAL_2_8", torch_greater_equal_2_8)
+def test_device_from_device_context_manager(monkeypatch, use_get_default_device):
+    """Test that a metric picks up the device from an active `torch.device` context manager, on both version paths."""
+    monkeypatch.setattr("torchmetrics.metric._TORCH_GREATER_EQUAL_2_8", use_get_default_device)
     with torch.device("meta"):
         metric = DummyMetricSum()
     assert metric.device == torch.device("meta")

--- a/tests/unittests/bases/test_metric.py
+++ b/tests/unittests/bases/test_metric.py
@@ -333,6 +333,18 @@ def test_device_and_dtype_transfer(tmpdir):
     torch.set_default_dtype(default_dtype)
 
 
+def test_device_from_device_context_manager():
+    """Test that a metric picks up the device from an active ``torch.device`` context manager.
+
+    Uses the ``meta`` device so this is runnable without a GPU. ``torch.get_default_device`` only started reflecting
+    the context manager in torch 2.8, so on older versions this guards the ``torch.empty(0).device`` fallback.
+
+    """
+    with torch.device("meta"):
+        metric = DummyMetricSum()
+    assert metric.device == torch.device("meta")
+
+
 def test_disable_of_normal_dtype_methods():
     """Check that the default dtype changing methods does nothing."""
     metric = DummyMetricSum()


### PR DESCRIPTION
## What does this PR do?

Fixes `Metric` landing on CPU instead of the context device when constructed inside a `with torch.device(...)` block on torch 2.3–2.7.

`Metric.__init__` gated its default-device lookup on torch >= 2.3: `torch.get_default_device()` above, `torch.empty(0).device` below. But `get_default_device()` only started consulting the active `DeviceContext` — what the `torch.device` context manager pushes — in torch **2.8** (pytorch/pytorch#148621, fixing pytorch/pytorch#148874). Before that it read only the global slot `set_default_device()` populates, so on 2.3–2.7 the newer branch is strictly worse than the fallback it replaced. Moving the gate to 2.8 respects both the context manager and `set_default_device` on every supported version.

Verified on torch 2.6.0 inside `with torch.device("meta")`: `get_default_device()` → `cpu`, `torch.empty(0).device` → `meta`. The metric's *state* still lands on the context device, so the bug leaves `metric.device` disagreeing with its own state — the mismatch #3316 set out to fix.

Existing coverage for this path is GPU-only and passes today only because the GPU workflow runs the torch 2.0 and 2.8 images. Added a CPU-runnable regression test on the `meta` device that exercises both sides of the version gate.

Prerequisite for #3449.
