### PR TITLE
fix: correct RetrievalAUROC max_fpr validation logic

### DIFF
--- a/src/torchmetrics/retrieval/auroc.py
+++ b/src/torchmetrics/retrieval/auroc.py
@@ -114,7 +114,7 @@ class RetrievalAUROC(RetrievalMetric):
         if top_k is not None and not (isinstance(top_k, int) and top_k > 0):
             raise ValueError("`top_k` has to be a positive integer or None")
         self.top_k = top_k
-        if max_fpr is not None and not isinstance(max_fpr, float) and 0 < max_fpr <= 1:
+        if max_fpr is not None and not (isinstance(max_fpr, (float, int)) and 0 < max_fpr <= 1):
             raise ValueError(f"Arguments `max_fpr` should be a float in range (0, 1], but got: {max_fpr}")
         self.max_fpr = max_fpr
 


### PR DESCRIPTION
## Problem

`RetrievalAUROC.__init__` has two issues in its `max_fpr` validation:

```python
if max_fpr is not None and not isinstance(max_fpr, float) and 0 < max_fpr <= 1:
```

**Bug 1**: The `and` chain short-circuits when `isinstance(max_fpr, float)` is `True`, so out-of-range float values (e.g. 2.0, 0.0) silently pass without raising `ValueError`.

**Bug 2**: Non-numeric types (e.g. `max_fpr="abc"`) cause `TypeError` on `0 < max_fpr` instead of a helpful `ValueError`.

**Bug 3**: Integer values like `max_fpr=1` fail `isinstance(max_fpr, float)`, even though they are reasonable inputs.

## Fix

Restructure to use a negated compound condition with `(float, int)`:

```python
if max_fpr is not None and not (isinstance(max_fpr, (float, int)) and 0 < max_fpr <= 1):
```

This correctly:
- Raises `ValueError` for non-numeric types (no `TypeError`)
- Raises `ValueError` for out-of-range values
- Accepts both `float` and `int` values
- Skips validation for `None` (optional parameter)

Co-Authored-By: Claude <noreply@anthropic.com>