### PR TITLE
fix: use or instead of and in PSNRB block_size validation

### DIFF
--- a/src/torchmetrics/image/psnrb.py
+++ b/src/torchmetrics/image/psnrb.py
@@ -79,7 +79,7 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        if not isinstance(block_size, int) and block_size < 1:
+        if not isinstance(block_size, int) or block_size < 1:
             raise ValueError("Argument ``block_size`` should be a positive integer")
         self.block_size = block_size
 


### PR DESCRIPTION
## Problem

`PeakSignalNoiseRatioWithBlockedEffect` input validation uses `and` where `or` is intended:

```python
if not isinstance(block_size, int) and block_size < 1:
```

| Input | Expected | Actual (bug) |
|---|---|---|
| 0 | ValueError | silently accepted |
| -5 | ValueError | silently accepted |
| 1.5 | ValueError | silently accepted |
| "foo" | ValueError | TypeError |

## Fix

`and` → `or` so both conditions are independently checked.

Fixes #3364