### PR TITLE
fix: account for len(thresholds) when dispatching the vectorized PR-curve update

### DIFF
--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -189,6 +189,14 @@ def _binary_precision_recall_curve_format(
     return preds, target, thresholds
 
 
+# The vectorized update paths materialise an intermediate holding
+# ``preds.numel() * len(thresholds)`` elements, so their peak memory grows with the
+# number of thresholds. The input-size checks below cannot see that on their own, so a
+# large ``thresholds`` silently defeats the constant-memory behaviour that argument is
+# documented to provide. Bound the intermediate as well as the input.
+_MAX_VECTORIZED_ELEMENTS = 1_000_000
+
+
 def _binary_precision_recall_curve_update(
     preds: Tensor,
     target: Tensor,
@@ -202,7 +210,7 @@ def _binary_precision_recall_curve_update(
     """
     if thresholds is None:
         return preds, target
-    if preds.numel() <= 50_000:
+    if preds.numel() <= 50_000 and preds.numel() * len(thresholds) <= _MAX_VECTORIZED_ELEMENTS:
         update_fn = _binary_precision_recall_curve_update_vectorized
     else:
         update_fn = _binary_precision_recall_curve_update_loop
@@ -479,7 +487,10 @@ def _multiclass_precision_recall_curve_update(
         return preds, target
     if average == "micro":
         return _binary_precision_recall_curve_update(preds, target, thresholds)
-    if preds.numel() * num_classes <= 1_000_000:
+    if (
+        preds.numel() * num_classes <= 1_000_000
+        and preds.numel() * len(thresholds) <= _MAX_VECTORIZED_ELEMENTS
+    ):
         update_fn = _multiclass_precision_recall_curve_update_vectorized
     else:
         update_fn = _multiclass_precision_recall_curve_update_loop

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -487,10 +487,7 @@ def _multiclass_precision_recall_curve_update(
         return preds, target
     if average == "micro":
         return _binary_precision_recall_curve_update(preds, target, thresholds)
-    if (
-        preds.numel() * num_classes <= 1_000_000
-        and preds.numel() * len(thresholds) <= _MAX_VECTORIZED_ELEMENTS
-    ):
+    if preds.numel() * num_classes <= 1_000_000 and preds.numel() * len(thresholds) <= _MAX_VECTORIZED_ELEMENTS:
         update_fn = _multiclass_precision_recall_curve_update_vectorized
     else:
         update_fn = _multiclass_precision_recall_curve_update_loop

--- a/tests/unittests/classification/test_precision_recall_curve.py
+++ b/tests/unittests/classification/test_precision_recall_curve.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from functools import partial
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -31,6 +32,14 @@ from torchmetrics.functional.classification.precision_recall_curve import (
     binary_precision_recall_curve,
     multiclass_precision_recall_curve,
     multilabel_precision_recall_curve,
+)
+from torchmetrics.functional.classification.precision_recall_curve import (
+    _MAX_VECTORIZED_ELEMENTS,
+    _binary_precision_recall_curve_update_loop,
+    _binary_precision_recall_curve_update_vectorized,
+    _multiclass_precision_recall_curve_update,
+    _multiclass_precision_recall_curve_update_loop,
+    _multiclass_precision_recall_curve_update_vectorized,
 )
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
@@ -489,3 +498,51 @@ def test_precision_nan_when_no_preds_meet_threshold(thresholds):
     assert torch.isnan(precision_bins[mask]).all(), f"Precision not NaN for thresholds {thres[mask]}"
 
     assert torch.all(recall_bins[mask] == 0.0), f"Recall not zero for thresholds {thres[mask]}"
+
+
+@pytest.mark.parametrize("num_thresholds", [5, 200])
+def test_multiclass_update_memory_does_not_scale_with_thresholds(num_thresholds):
+    """The vectorized path allocates ``preds.numel() * len(thresholds)`` elements.
+
+    Passing ``thresholds`` is documented to bound memory, so the dispatch must take the
+    number of thresholds into account rather than looking at the input size alone.
+    See https://github.com/Lightning-AI/torchmetrics/issues/3299.
+
+    """
+    preds = torch.randn(60000, 3)
+    target = torch.randint(0, 3, (60000,))
+    thresholds = torch.linspace(0, 1, num_thresholds)
+
+    intermediate = preds.numel() * num_thresholds
+    expected_vectorized = intermediate <= _MAX_VECTORIZED_ELEMENTS
+
+    with mock.patch(
+        "torchmetrics.functional.classification.precision_recall_curve"
+        "._multiclass_precision_recall_curve_update_vectorized",
+        wraps=_multiclass_precision_recall_curve_update_vectorized,
+    ) as vectorized:
+        _multiclass_precision_recall_curve_update(preds, target, 3, thresholds, average=None)
+
+    assert vectorized.called is expected_vectorized
+
+
+def test_multiclass_update_paths_agree():
+    """Falling back to the loop is only safe if it returns the same state."""
+    preds = torch.randn(2000, 3)
+    target = torch.randint(0, 3, (2000,))
+    for num_thresholds in (3, 20, 200):
+        thresholds = torch.linspace(0, 1, num_thresholds)
+        vectorized = _multiclass_precision_recall_curve_update_vectorized(preds, target, 3, thresholds)
+        looped = _multiclass_precision_recall_curve_update_loop(preds, target, 3, thresholds)
+        assert torch.equal(vectorized, looped)
+
+
+def test_binary_update_paths_agree():
+    """Same invariant for the binary dispatch."""
+    preds = torch.randn(2000)
+    target = torch.randint(0, 2, (2000,))
+    for num_thresholds in (3, 20, 200):
+        thresholds = torch.linspace(0, 1, num_thresholds)
+        vectorized = _binary_precision_recall_curve_update_vectorized(preds, target, thresholds)
+        looped = _binary_precision_recall_curve_update_loop(preds, target, thresholds)
+        assert torch.equal(vectorized, looped)

--- a/tests/unittests/classification/test_precision_recall_curve.py
+++ b/tests/unittests/classification/test_precision_recall_curve.py
@@ -29,17 +29,15 @@ from torchmetrics.classification.precision_recall_curve import (
     PrecisionRecallCurve,
 )
 from torchmetrics.functional.classification.precision_recall_curve import (
-    binary_precision_recall_curve,
-    multiclass_precision_recall_curve,
-    multilabel_precision_recall_curve,
-)
-from torchmetrics.functional.classification.precision_recall_curve import (
     _MAX_VECTORIZED_ELEMENTS,
     _binary_precision_recall_curve_update_loop,
     _binary_precision_recall_curve_update_vectorized,
     _multiclass_precision_recall_curve_update,
     _multiclass_precision_recall_curve_update_loop,
     _multiclass_precision_recall_curve_update_vectorized,
+    binary_precision_recall_curve,
+    multiclass_precision_recall_curve,
+    multilabel_precision_recall_curve,
 )
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1

--- a/tests/unittests/classification/test_precision_recall_curve.py
+++ b/tests/unittests/classification/test_precision_recall_curve.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from functools import partial
+from importlib import import_module
 from unittest import mock
 
 import numpy as np
@@ -514,9 +515,13 @@ def test_multiclass_update_memory_does_not_scale_with_thresholds(num_thresholds)
     intermediate = preds.numel() * num_thresholds
     expected_vectorized = intermediate <= _MAX_VECTORIZED_ELEMENTS
 
-    with mock.patch(
-        "torchmetrics.functional.classification.precision_recall_curve"
-        "._multiclass_precision_recall_curve_update_vectorized",
+    # `torchmetrics.functional.classification` re-exports a *function* named
+    # `precision_recall_curve`, which shadows the submodule, so mock's dotted-name lookup
+    # resolves to the function. Fetch the module itself to patch the name it defines.
+    prc_module = import_module("torchmetrics.functional.classification.precision_recall_curve")
+    with mock.patch.object(
+        prc_module,
+        "_multiclass_precision_recall_curve_update_vectorized",
         wraps=_multiclass_precision_recall_curve_update_vectorized,
     ) as vectorized:
         _multiclass_precision_recall_curve_update(preds, target, 3, thresholds, average=None)


### PR DESCRIPTION
Closes #3299.

### The bug

`thresholds` is documented to bound memory, but the dispatch that chooses between
the vectorized and loop update paths never looks at how many thresholds there are.

```python
if preds.numel() * num_classes <= 1_000_000:
    update_fn = _multiclass_precision_recall_curve_update_vectorized
```

The vectorized path then allocates `preds.numel() * len(thresholds)` elements at

```python
preds_t = (preds.unsqueeze(-1) >= thresholds.unsqueeze(0).unsqueeze(0)).long()
```

and again for `unique_mapping`. For the reported case, `preds` of shape
`(60000, 3)` with `thresholds=200`, the gate computes `540,000 <= 1,000,000` and
picks the vectorized path, which then asks for **288 MB** of int64, twice over:

| thresholds | gate says | intermediate |
| --- | --- | --- |
| 5 | vectorized | 7.2 MB |
| 50 | vectorized | 72.0 MB |
| 200 | vectorized | **288.0 MB** |
| 1000 | vectorized | **1440.0 MB** |

MPS surfaces this as an OOM because its ceiling is lower, but the memory model is
wrong on every device. CPU just absorbs it.

### The fix

Bound the intermediate as well as the input. The binary dispatch has the same
defect (`preds.numel() <= 50_000`, also blind to `len_t`), so both are fixed.

This is a pure narrowing: a case that previously went vectorized either still does,
or falls back to the loop. Nothing that used the loop before is now vectorized, so
no workload gets slower unless it was also allocating hundreds of megabytes.

### Why this is safe

The two paths return identical state. I verified across thresholds of 3, 7, 20 and
200 for multiclass and 3, 20, 200 for binary, on both the vectorized and loop
implementations, with `torch.equal` in every case. Falling back only trades speed
for memory, never correctness.

### Tests

- `test_multiclass_update_memory_does_not_scale_with_thresholds`, parametrized over
  5 and 200 thresholds, asserts which path the dispatch actually picks. The 200 case
  fails on `main` and passes here; the 5 case passes both ways, which pins that small
  threshold counts keep their current fast path.
- `test_multiclass_update_paths_agree` and `test_binary_update_paths_agree` pin the
  invariant the fix depends on.

Full file: **214 passed, 24 skipped, 4 xfailed**, no regressions.

### One question for a reviewer

`_MAX_VECTORIZED_ELEMENTS = 1_000_000` (8 MB of int64, doubled by `unique_mapping`)
is my choice, not something derived from an existing constant. It keeps the reported
case out of the vectorized path with room to spare, but the right budget is really a
maintainer call and I would happily change it. If you would rather express it as a
byte budget, or scale it from the existing `50_000` / `1_000_000` gates, say which
and I will update.

### Not covered here

`_multilabel_precision_recall_curve_update` has the same `preds.numel() * len_t`
allocation and **no** loop fallback to dispatch to, so it is unconditionally exposed.
Fixing it means writing a multilabel loop implementation, which felt like a separate
change from the reported bug. Happy to add it to this PR or open a follow-up,
whichever you prefer.
