### PR TITLE
fix: validate top_k in retrieval metrics and fix PR curve plot labels

### DIFF
--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -241,7 +241,7 @@ def _multiclass_stat_scores_arg_validation(
         )
     if num_classes is not None and (not isinstance(num_classes, int) or num_classes < 2):
         raise ValueError(f"Expected argument `num_classes` to be an integer larger than 1, but got {num_classes}")
-    if not isinstance(top_k, int) and top_k < 1:
+    if not isinstance(top_k, int) or top_k < 1:
         raise ValueError(f"Expected argument `top_k` to be an integer larger than or equal to 1, but got {top_k}")
     if top_k > (num_classes if num_classes is not None else 1):
         raise ValueError(

--- a/src/torchmetrics/functional/retrieval/average_precision.py
+++ b/src/torchmetrics/functional/retrieval/average_precision.py
@@ -49,7 +49,7 @@ def retrieval_average_precision(preds: Tensor, target: Tensor, top_k: Optional[i
     preds, target = _check_retrieval_functional_inputs(preds, target)
 
     top_k = top_k or preds.shape[-1]
-    if not isinstance(top_k, int) and top_k <= 0:
+    if not isinstance(top_k, int) or top_k <= 0:
         raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
 
     target = torch.where(preds > 0, target, torch.zeros_like(target))

--- a/src/torchmetrics/functional/retrieval/reciprocal_rank.py
+++ b/src/torchmetrics/functional/retrieval/reciprocal_rank.py
@@ -49,7 +49,7 @@ def retrieval_reciprocal_rank(preds: Tensor, target: Tensor, top_k: Optional[int
     preds, target = _check_retrieval_functional_inputs(preds, target)
 
     top_k = top_k or preds.shape[-1]
-    if not isinstance(top_k, int) and top_k <= 0:
+    if not isinstance(top_k, int) or top_k <= 0:
         raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
 
     target = torch.where(preds > 0, target, torch.zeros_like(target))

--- a/src/torchmetrics/retrieval/average_precision.py
+++ b/src/torchmetrics/retrieval/average_precision.py
@@ -110,7 +110,7 @@ class RetrievalMAP(RetrievalMetric):
             **kwargs,
         )
 
-        if top_k is not None and not isinstance(top_k, int) and top_k <= 0:
+        if top_k is not None or not isinstance(top_k, int) or top_k <= 0:
             raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}")
         self.k = top_k
 

--- a/src/torchmetrics/retrieval/precision_recall_curve.py
+++ b/src/torchmetrics/retrieval/precision_recall_curve.py
@@ -289,7 +289,7 @@ class RetrievalPrecisionRecallCurve(Metric):
         return plot_curve(
             curve,
             ax=ax,
-            label_names=("False positive rate", "True positive rate"),
+            label_names=("Precision", "Recall"),
             name=self.__class__.__name__,
         )
 

--- a/src/torchmetrics/retrieval/reciprocal_rank.py
+++ b/src/torchmetrics/retrieval/reciprocal_rank.py
@@ -110,7 +110,7 @@ class RetrievalMRR(RetrievalMetric):
             **kwargs,
         )
 
-        if top_k is not None and not isinstance(top_k, int) and top_k <= 0:
+        if top_k is not None or not isinstance(top_k, int) or top_k <= 0:
             raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}")
         self.top_k = top_k
 


### PR DESCRIPTION
## Problem

1. RetrievalMAP/RetrievalMRR accept invalid top_k (e.g. -1) silently, failing later with opaque RuntimeError
2. Multiclass classification metrics accept top_k=-1 and top_k=4.5 silently
3. RetrievalPrecisionRecallCurve.plot() labels axes "False positive rate" / "True positive rate" — but the metric computes precision and recall

## Fix

1. Changed and→or in validation at 5 locations (retrieval reciprocal_rank/average_precision ×4, classification stat_scores ×1)
2. Changed plot labels to "Precision" / "Recall"

Fixes #3378, #3405, #3403