### PR TITLE
fix: normalize category labels in functional nominal metrics for non-zero-based labels

### DIFF
--- a/src/torchmetrics/functional/nominal/cramers.py
+++ b/src/torchmetrics/functional/nominal/cramers.py
@@ -24,6 +24,7 @@ from torchmetrics.functional.nominal.utils import (
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
+    _normalize_categorical_labels,
     _nominal_input_validation,
     _unable_to_use_bias_correction_warning,
 )
@@ -52,6 +53,7 @@ def _cramers_v_update(
     preds = preds.argmax(1) if preds.ndim == 2 else preds
     target = target.argmax(1) if target.ndim == 2 else target
     preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
+    preds, target = _normalize_categorical_labels(preds, target)
     return _multiclass_confusion_matrix_update(preds, target, num_classes)
 
 

--- a/src/torchmetrics/functional/nominal/cramers.py
+++ b/src/torchmetrics/functional/nominal/cramers.py
@@ -24,8 +24,8 @@ from torchmetrics.functional.nominal.utils import (
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
-    _normalize_categorical_labels,
     _nominal_input_validation,
+    _normalize_categorical_labels,
     _unable_to_use_bias_correction_warning,
 )
 

--- a/src/torchmetrics/functional/nominal/pearson.py
+++ b/src/torchmetrics/functional/nominal/pearson.py
@@ -23,6 +23,7 @@ from torchmetrics.functional.nominal.utils import (
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
+    _normalize_categorical_labels,
     _nominal_input_validation,
 )
 
@@ -50,6 +51,7 @@ def _pearsons_contingency_coefficient_update(
     preds = preds.argmax(1) if preds.ndim == 2 else preds
     target = target.argmax(1) if target.ndim == 2 else target
     preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
+    preds, target = _normalize_categorical_labels(preds, target)
     return _multiclass_confusion_matrix_update(preds, target, num_classes)
 
 

--- a/src/torchmetrics/functional/nominal/pearson.py
+++ b/src/torchmetrics/functional/nominal/pearson.py
@@ -23,8 +23,8 @@ from torchmetrics.functional.nominal.utils import (
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
-    _normalize_categorical_labels,
     _nominal_input_validation,
+    _normalize_categorical_labels,
 )
 
 

--- a/src/torchmetrics/functional/nominal/theils_u.py
+++ b/src/torchmetrics/functional/nominal/theils_u.py
@@ -22,6 +22,7 @@ from torchmetrics.functional.classification.confusion_matrix import _multiclass_
 from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
+    _normalize_categorical_labels,
     _nominal_input_validation,
 )
 
@@ -75,6 +76,7 @@ def _theils_u_update(
     preds = preds.argmax(1) if preds.ndim == 2 else preds
     target = target.argmax(1) if target.ndim == 2 else target
     preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
+    preds, target = _normalize_categorical_labels(preds, target)
     return _multiclass_confusion_matrix_update(preds, target, num_classes)
 
 

--- a/src/torchmetrics/functional/nominal/theils_u.py
+++ b/src/torchmetrics/functional/nominal/theils_u.py
@@ -22,8 +22,8 @@ from torchmetrics.functional.classification.confusion_matrix import _multiclass_
 from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
-    _normalize_categorical_labels,
     _nominal_input_validation,
+    _normalize_categorical_labels,
 )
 
 

--- a/src/torchmetrics/functional/nominal/tschuprows.py
+++ b/src/torchmetrics/functional/nominal/tschuprows.py
@@ -24,8 +24,8 @@ from torchmetrics.functional.nominal.utils import (
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
-    _normalize_categorical_labels,
     _nominal_input_validation,
+    _normalize_categorical_labels,
     _unable_to_use_bias_correction_warning,
 )
 

--- a/src/torchmetrics/functional/nominal/tschuprows.py
+++ b/src/torchmetrics/functional/nominal/tschuprows.py
@@ -24,6 +24,7 @@ from torchmetrics.functional.nominal.utils import (
     _compute_chi_squared,
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
+    _normalize_categorical_labels,
     _nominal_input_validation,
     _unable_to_use_bias_correction_warning,
 )
@@ -52,6 +53,7 @@ def _tschuprows_t_update(
     preds = preds.argmax(1) if preds.ndim == 2 else preds
     target = target.argmax(1) if target.ndim == 2 else target
     preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
+    preds, target = _normalize_categorical_labels(preds, target)
     return _multiclass_confusion_matrix_update(preds, target, num_classes)
 
 

--- a/src/torchmetrics/functional/nominal/utils.py
+++ b/src/torchmetrics/functional/nominal/utils.py
@@ -140,6 +140,27 @@ def _handle_nan_in_data(
     return preds[~rows_contain_nan], target[~rows_contain_nan]
 
 
+def _normalize_categorical_labels(preds: Tensor, target: Tensor) -> tuple[Tensor, Tensor]:
+    """Map observed labels to contiguous 0-based IDs.
+
+    Nominal association metrics are invariant to renaming categories, but the
+    confusion-matrix updater uses raw label values as bin indices. Labels like
+    [1, 2] (instead of [0, 1]) would create an out-of-range bin.
+
+    Returns:
+        preds and target relabeled as contiguous 0-based IDs, or the
+        originals when they are already contiguous from zero.
+    """
+    all_vals = torch.cat([preds, target])
+    unique_vals = all_vals.unique()
+    expected = torch.arange(len(unique_vals), device=unique_vals.device, dtype=unique_vals.dtype)
+    if torch.equal(unique_vals, expected):
+        return preds, target
+    preds = torch.searchsorted(unique_vals, preds)
+    target = torch.searchsorted(unique_vals, target)
+    return preds, target
+
+
 def _unable_to_use_bias_correction_warning(metric_name: str) -> None:
     rank_zero_warn(
         f"Unable to compute {metric_name} using bias correction. Please consider to set `bias_correction=False`."

--- a/src/torchmetrics/functional/nominal/utils.py
+++ b/src/torchmetrics/functional/nominal/utils.py
@@ -150,6 +150,7 @@ def _normalize_categorical_labels(preds: Tensor, target: Tensor) -> tuple[Tensor
     Returns:
         preds and target relabeled as contiguous 0-based IDs, or the
         originals when they are already contiguous from zero.
+
     """
     all_vals = torch.cat([preds, target])
     unique_vals = all_vals.unique()


### PR DESCRIPTION
## Problem

Functional nominal metrics (cramers_v, pearsons_contingency_coefficient, theils_u, tschuprows_t) crash when category labels are not zero-based and contiguous:

```python
cramers_v(torch.tensor([1, 1, 2, 2]), torch.tensor([1, 1, 2, 2]), bias_correction=False)
# RuntimeError: shape '[2, 2]' is invalid for input of size 7
```

Nominal association is invariant to renaming categories — labels [0,1] and [1,2] describe the same two categories and should produce the same result.

## Root Cause

num_classes is inferred as the count of unique values (2), but the confusion-matrix updater uses raw label values as bin indices. Label 2 creates a bin outside the expected 2x2 range.

## Fix

Added `_normalize_categorical_labels` to nominal/utils.py which maps observed labels to contiguous 0-based IDs when they aren't already. Called from all 4 update functions after NaN handling:

- cramers.py
- pearson.py
- theils_u.py
- tschuprows.py

Stateful metrics with explicit num_classes are unaffected (they already use stable encoding).

## Verification

```python
base = torch.tensor([0, 0, 1, 1])
shifted = base + 1
# Before: shifted input raises RuntimeError
# After: both produce tensor(1.) for Cramer's V
```

Fixes #3446