### PR TITLE
Add MeanAveragePrecision3D for 3D bounding box detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Added `MeanAveragePrecision3D` and `mean_average_precision_3d` for computing mAP/mAR on axis-aligned 3D bounding boxes ([#3398](https://github.com/Lightning-AI/torchmetrics/issues/3398))
 
 
 ### Changed

--- a/docs/source/detection/mean_average_precision_3d.rst
+++ b/docs/source/detection/mean_average_precision_3d.rst
@@ -1,0 +1,21 @@
+.. customcarditem::
+   :header: Mean-Average-Precision (mAP) 3D
+   :image: https://pl-flash-data.s3.amazonaws.com/assets/thumbnails/object_detection.svg
+   :tags: Detection
+
+.. include:: ../links.rst
+
+###############################
+Mean-Average-Precision (mAP) 3D
+###############################
+
+Module Interface
+________________
+
+.. autoclass:: torchmetrics.detection.mean_ap_3d.MeanAveragePrecision3D
+    :exclude-members: update, compute
+
+Functional Interface
+____________________
+
+.. autofunction:: torchmetrics.functional.detection.mean_average_precision_3d

--- a/src/torchmetrics/detection/__init__.py
+++ b/src/torchmetrics/detection/__init__.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from torchmetrics.detection.mean_ap_3d import MeanAveragePrecision3D
 from torchmetrics.detection.panoptic_qualities import ModifiedPanopticQuality, PanopticQuality
 from torchmetrics.utilities.imports import _TORCHVISION_AVAILABLE
 
-__all__ = ["ModifiedPanopticQuality", "PanopticQuality"]
+__all__ = ["MeanAveragePrecision3D", "ModifiedPanopticQuality", "PanopticQuality"]
 
 if _TORCHVISION_AVAILABLE:
     from torchmetrics.detection.ciou import CompleteIntersectionOverUnion

--- a/src/torchmetrics/detection/mean_ap_3d.py
+++ b/src/torchmetrics/detection/mean_ap_3d.py
@@ -1,0 +1,178 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Dict, List, Literal, Optional
+
+from torch import Tensor
+
+from torchmetrics.detection.helpers import _input_validator
+from torchmetrics.functional.detection.map_3d import mean_average_precision_3d
+from torchmetrics.metric import Metric
+
+__all__ = ["MeanAveragePrecision3D"]
+
+
+class MeanAveragePrecision3D(Metric):
+    r"""Compute the ``Mean-Average-Precision (mAP) and Mean-Average-Recall (mAR)`` for 3D object detection.
+
+    This is the 3D counterpart of :class:`~torchmetrics.detection.MeanAveragePrecision`. Instead of 2D bounding
+    boxes it operates on axis-aligned 3D bounding boxes, e.g. as produced by detectors operating on point-clouds
+    or voxel grids. Because axis-aligned 3D boxes are used, this implementation does not depend on
+    ``pycocotools``/``faster_coco_eval`` and instead computes the intersection-over-union and average precision
+    directly.
+
+    As input to ``forward`` and ``update`` the metric accepts the following input:
+
+    - ``preds`` (:class:`~List`): A list of dictionaries, each containing the key-values
+
+        - ``boxes`` (:class:`~torch.Tensor`): float tensor of shape ``(num_boxes, 6)`` containing ``num_boxes``
+          detection boxes of the format specified in the constructor. By default, this method expects
+          ``(center_x, center_y, center_z, width, height, depth)`` but can be changed using the ``box_format``
+          parameter.
+        - ``scores`` (:class:`~torch.Tensor`): float tensor of shape ``(num_boxes)`` containing detection scores
+          for the boxes.
+        - ``labels`` (:class:`~torch.Tensor`): integer tensor of shape ``(num_boxes)`` containing 0-indexed
+          detection classes for the boxes.
+
+    - ``target`` (:class:`~List`): A list of dictionaries, each containing the key-values
+
+        - ``boxes`` (:class:`~torch.Tensor`): float tensor of shape ``(num_boxes, 6)`` containing ``num_boxes``
+          ground truth boxes of the format specified in the constructor.
+        - ``labels`` (:class:`~torch.Tensor`): integer tensor of shape ``(num_boxes)`` containing 0-indexed ground
+          truth classes for the boxes.
+
+    As output of ``forward`` and ``compute`` the metric returns a dictionary containing ``map``, ``map_50``,
+    ``map_75``, ``mar_{max_det}`` (one key per value in ``max_detection_thresholds``), ``map_per_class``,
+    ``mar_{max_det}_per_class`` and ``classes``. See
+    :func:`~torchmetrics.functional.detection.mean_average_precision_3d` for a description of these values.
+
+    Args:
+        box_format: Format of the input 3D boxes. Either ``"xyzwhd"`` (center x, y, z and width, height, depth) or
+            ``"xyzxyz"`` (min x, y, z and max x, y, z corners).
+        iou_thresholds: List of IoU thresholds (default is ``[0.5, 0.55, ..., 0.95]``).
+        rec_thresholds: Unused, kept for API parity with the 2D metric.
+        max_detection_thresholds: List of maximum detections per sample (default is ``[1, 10, 100]``).
+        class_metrics: Whether to compute per-class mAP and mAR metrics.
+        kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
+
+    Example::
+
+        >>> from torch import tensor
+        >>> from torchmetrics.detection import MeanAveragePrecision3D
+        >>> preds = [
+        ...   dict(
+        ...     boxes=tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]),
+        ...     scores=tensor([0.9]),
+        ...     labels=tensor([0]),
+        ...   )
+        ... ]
+        >>> target = [
+        ...   dict(
+        ...     boxes=tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]),
+        ...     labels=tensor([0]),
+        ...   )
+        ... ]
+        >>> metric = MeanAveragePrecision3D()
+        >>> metric.update(preds, target)
+        >>> result = metric.compute()
+        >>> print(f"mAP: {result['map']:.4f}, mAP@0.5: {result['map_50']:.4f}")
+        mAP: 1.0000, mAP@0.5: 1.0000
+
+    """
+
+    is_differentiable: bool = False
+    higher_is_better: Optional[bool] = True
+    full_state_update: bool = True
+    plot_lower_bound: float = 0.0
+    plot_upper_bound: float = 1.0
+
+    detection_box: List[Tensor]
+    detection_scores: List[Tensor]
+    detection_labels: List[Tensor]
+    groundtruth_box: List[Tensor]
+    groundtruth_labels: List[Tensor]
+
+    def __init__(
+        self,
+        box_format: Literal["xyzwhd", "xyzxyz"] = "xyzwhd",
+        iou_thresholds: Optional[List[float]] = None,
+        rec_thresholds: Optional[List[float]] = None,
+        max_detection_thresholds: Optional[List[int]] = None,
+        class_metrics: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+
+        allowed_box_formats = ("xyzwhd", "xyzxyz")
+        if box_format not in allowed_box_formats:
+            raise ValueError(f"Expected argument `box_format` to be one of {allowed_box_formats} but got {box_format}")
+        self.box_format = box_format
+
+        if iou_thresholds is not None and not isinstance(iou_thresholds, list):
+            raise ValueError(
+                f"Expected argument `iou_thresholds` to either be `None` or a list of floats but got {iou_thresholds}"
+            )
+        self.iou_thresholds = iou_thresholds
+
+        if rec_thresholds is not None and not isinstance(rec_thresholds, list):
+            raise ValueError(
+                f"Expected argument `rec_thresholds` to either be `None` or a list of floats but got {rec_thresholds}"
+            )
+        self.rec_thresholds = rec_thresholds
+
+        if max_detection_thresholds is not None and not isinstance(max_detection_thresholds, list):
+            raise ValueError(
+                f"Expected argument `max_detection_thresholds` to either be `None` or a list of ints"
+                f" but got {max_detection_thresholds}"
+            )
+        self.max_detection_thresholds = max_detection_thresholds
+
+        if not isinstance(class_metrics, bool):
+            raise ValueError("Expected argument `class_metrics` to be a boolean")
+        self.class_metrics = class_metrics
+
+        self.add_state("detection_box", default=[], dist_reduce_fx=None)
+        self.add_state("detection_scores", default=[], dist_reduce_fx=None)
+        self.add_state("detection_labels", default=[], dist_reduce_fx=None)
+        self.add_state("groundtruth_box", default=[], dist_reduce_fx=None)
+        self.add_state("groundtruth_labels", default=[], dist_reduce_fx=None)
+
+    def update(self, preds: List[Dict[str, Tensor]], target: List[Dict[str, Tensor]]) -> None:
+        """Update metric state."""
+        _input_validator(preds, target, iou_type="bbox")
+        for item in preds:
+            self.detection_box.append(item["boxes"])
+            self.detection_scores.append(item["scores"])
+            self.detection_labels.append(item["labels"])
+        for item in target:
+            self.groundtruth_box.append(item["boxes"])
+            self.groundtruth_labels.append(item["labels"])
+
+    def compute(self) -> Dict[str, Tensor]:
+        """Computes the metric."""
+        preds = [
+            {"boxes": box, "scores": scores, "labels": labels}
+            for box, scores, labels in zip(self.detection_box, self.detection_scores, self.detection_labels)
+        ]
+        target = [
+            {"boxes": box, "labels": labels} for box, labels in zip(self.groundtruth_box, self.groundtruth_labels)
+        ]
+        return mean_average_precision_3d(
+            preds,
+            target,
+            box_format=self.box_format,
+            iou_thresholds=self.iou_thresholds,
+            rec_thresholds=self.rec_thresholds,
+            max_detection_thresholds=self.max_detection_thresholds,
+            class_metrics=self.class_metrics,
+        )

--- a/src/torchmetrics/functional/detection/__init__.py
+++ b/src/torchmetrics/functional/detection/__init__.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from torchmetrics.functional.detection.map_3d import mean_average_precision_3d
 from torchmetrics.functional.detection.panoptic_qualities import modified_panoptic_quality, panoptic_quality
 from torchmetrics.utilities.imports import (
     _TORCHVISION_AVAILABLE,
 )
 
-__all__ = ["modified_panoptic_quality", "panoptic_quality"]
+__all__ = ["mean_average_precision_3d", "modified_panoptic_quality", "panoptic_quality"]
 
 if _TORCHVISION_AVAILABLE:
     from torchmetrics.functional.detection.ciou import complete_intersection_over_union

--- a/src/torchmetrics/functional/detection/map_3d.py
+++ b/src/torchmetrics/functional/detection/map_3d.py
@@ -1,0 +1,288 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Dict, List, Literal, Optional
+
+import torch
+from torch import Tensor
+
+__all__ = ["mean_average_precision_3d"]
+
+
+def _convert_3d_boxes_to_corners(boxes: Tensor, box_format: Literal["xyzwhd", "xyzxyz"]) -> Tensor:
+    """Convert 3D boxes to the ``(xmin, ymin, zmin, xmax, ymax, zmax)`` corner format."""
+    if box_format == "xyzxyz":
+        return boxes
+    if box_format == "xyzwhd":
+        cx, cy, cz, w, h, d = boxes.unbind(-1)
+        return torch.stack(
+            [cx - w / 2, cy - h / 2, cz - d / 2, cx + w / 2, cy + h / 2, cz + d / 2],
+            dim=-1,
+        )
+    raise ValueError(f"Expected argument `box_format` to be one of ('xyzwhd', 'xyzxyz') but got {box_format}")
+
+
+def _volume_3d(boxes: Tensor) -> Tensor:
+    """Compute the volume of a set of axis-aligned 3D boxes given in corner format."""
+    dx = (boxes[:, 3] - boxes[:, 0]).clamp(min=0)
+    dy = (boxes[:, 4] - boxes[:, 1]).clamp(min=0)
+    dz = (boxes[:, 5] - boxes[:, 2]).clamp(min=0)
+    return dx * dy * dz
+
+
+def _pairwise_iou_3d(preds: Tensor, target: Tensor) -> Tensor:
+    """Compute the pairwise 3D IoU between two sets of axis-aligned boxes given in corner format."""
+    if preds.numel() == 0 or target.numel() == 0:
+        return torch.zeros((preds.shape[0], target.shape[0]), dtype=torch.float32)
+
+    lt = torch.max(preds[:, None, :3], target[None, :, :3])
+    rb = torch.min(preds[:, None, 3:], target[None, :, 3:])
+    whd = (rb - lt).clamp(min=0)
+    intersection = whd[..., 0] * whd[..., 1] * whd[..., 2]
+
+    vol_preds = _volume_3d(preds)
+    vol_target = _volume_3d(target)
+    union = vol_preds[:, None] + vol_target[None, :] - intersection
+    return torch.where(union > 0, intersection / union, torch.zeros_like(union))
+
+
+def _compute_average_precision(recall: Tensor, precision: Tensor) -> Tensor:
+    """Compute the 101-point interpolated average precision, following the COCO evaluation protocol."""
+    recall_thresholds = torch.linspace(0, 1, 101)
+    if recall.numel() == 0:
+        return torch.tensor(0.0)
+
+    # precision envelope: precision[i] = max(precision[i:])
+    envelope = precision.flip(0).cummax(0).values.flip(0)
+    indices = torch.searchsorted(recall, recall_thresholds, right=False)
+    interpolated = torch.zeros_like(recall_thresholds)
+    valid = indices < recall.numel()
+    interpolated[valid] = envelope[indices[valid]]
+    return interpolated.mean()
+
+
+def _evaluate_class(
+    preds_per_image: List[Tensor],
+    scores_per_image: List[Tensor],
+    target_per_image: List[Tensor],
+    iou_thresholds: List[float],
+    max_detection_thresholds: List[int],
+) -> Dict[str, Any]:
+    """Evaluate a single class across all images, returning AP per IoU threshold and AR per max-detection threshold."""
+    num_gt = sum(t.shape[0] for t in target_per_image)
+
+    max_det = max(max_detection_thresholds)
+    flat_preds, flat_scores, flat_image_idx = [], [], []
+    for image_idx, (boxes, scores) in enumerate(zip(preds_per_image, scores_per_image)):
+        if boxes.numel() == 0:
+            continue
+        order = torch.argsort(scores, descending=True, stable=True)[:max_det]
+        flat_preds.append(boxes[order])
+        flat_scores.append(scores[order])
+        flat_image_idx.extend([image_idx] * order.numel())
+
+    average_precisions = torch.zeros(len(iou_thresholds))
+    average_recalls = {mdt: torch.tensor(0.0) for mdt in max_detection_thresholds}
+
+    if num_gt == 0 or len(flat_preds) == 0:
+        return {"ap": average_precisions, "ar": average_recalls}
+
+    all_preds = torch.cat(flat_preds, dim=0)
+    all_scores = torch.cat(flat_scores, dim=0)
+    all_image_idx = torch.tensor(flat_image_idx)
+
+    sort_order = torch.argsort(all_scores, descending=True, stable=True)
+    all_preds = all_preds[sort_order]
+    all_image_idx = all_image_idx[sort_order]
+
+    ious = [
+        _pairwise_iou_3d(all_preds[all_image_idx == image_idx], target_per_image[image_idx])
+        if target_per_image[image_idx].numel() > 0
+        else None
+        for image_idx in range(len(target_per_image))
+    ]
+
+    for mdt in max_detection_thresholds:
+        matched = [torch.zeros(t.shape[0], dtype=torch.bool) for t in target_per_image]
+        per_image_count = dict.fromkeys(range(len(target_per_image)), 0)
+        per_image_cursor = dict.fromkeys(range(len(target_per_image)), 0)
+        for i in range(all_preds.shape[0]):
+            image_idx = int(all_image_idx[i])
+            iou_row = ious[image_idx]
+            if iou_row is None:
+                continue
+            pred_cursor = per_image_cursor[image_idx]
+            per_image_cursor[image_idx] += 1
+            if per_image_count[image_idx] >= mdt:
+                continue
+            per_image_count[image_idx] += 1
+            row = iou_row[pred_cursor].clone()
+            row[matched[image_idx]] = -1
+            if row.numel() == 0:
+                continue
+            best_gt = int(row.argmax())
+            if row[best_gt] >= min(iou_thresholds):
+                matched[image_idx][best_gt] = True
+        recall_value = float(sum(m.sum().item() for m in matched)) / num_gt
+        average_recalls[mdt] = torch.tensor(recall_value)
+
+    for t_idx, iou_threshold in enumerate(iou_thresholds):
+        matched = [torch.zeros(t.shape[0], dtype=torch.bool) for t in target_per_image]
+        per_image_cursor = dict.fromkeys(range(len(target_per_image)), 0)
+        tp = torch.zeros(all_preds.shape[0])
+        fp = torch.zeros(all_preds.shape[0])
+        for i in range(all_preds.shape[0]):
+            image_idx = int(all_image_idx[i])
+            iou_row = ious[image_idx]
+            if iou_row is None:
+                fp[i] = 1
+                continue
+            pred_cursor = per_image_cursor[image_idx]
+            per_image_cursor[image_idx] += 1
+            row = iou_row[pred_cursor].clone()
+            row[matched[image_idx]] = -1
+            if row.numel() == 0 or row.max() < iou_threshold:
+                fp[i] = 1
+                continue
+            best_gt = int(row.argmax())
+            matched[image_idx][best_gt] = True
+            tp[i] = 1
+
+        cum_tp = torch.cumsum(tp, dim=0)
+        cum_fp = torch.cumsum(fp, dim=0)
+        recall = cum_tp / num_gt
+        precision = cum_tp / torch.clamp(cum_tp + cum_fp, min=1)
+        average_precisions[t_idx] = _compute_average_precision(recall, precision)
+
+    return {"ap": average_precisions, "ar": average_recalls}
+
+
+def mean_average_precision_3d(
+    preds: List[Dict[str, Any]],
+    target: List[Dict[str, Any]],
+    box_format: Literal["xyzwhd", "xyzxyz"] = "xyzwhd",
+    iou_thresholds: Optional[List[float]] = None,
+    rec_thresholds: Optional[List[float]] = None,
+    max_detection_thresholds: Optional[List[int]] = None,
+    class_metrics: bool = False,
+) -> Dict[str, Tensor]:
+    r"""Compute the mean average precision (mAP) and mean average recall (mAR) for 3D object detection.
+
+    This is the 3D counterpart of :func:`~torchmetrics.functional.detection.mean_average_precision`. Instead of 2D
+    bounding boxes it operates on axis-aligned 3D bounding boxes, e.g. as produced by detectors operating on
+    point-clouds or voxel grids. Because axis-aligned 3D boxes are used, this implementation does not depend on
+    ``pycocotools``/``faster_coco_eval`` and instead computes the intersection-over-union and average precision
+    directly.
+
+    Args:
+        preds: A list of dictionaries, each containing the keys ``boxes`` (a ``(num_boxes, 6)`` tensor in the format
+            given by ``box_format``), ``scores`` (a ``(num_boxes,)`` tensor) and ``labels`` (a ``(num_boxes,)``
+            tensor), one dictionary per sample/point-cloud.
+        target: A list of dictionaries, each containing the keys ``boxes`` (a ``(num_boxes, 6)`` tensor) and
+            ``labels`` (a ``(num_boxes,)`` tensor), one dictionary per sample/point-cloud.
+        box_format: Format of the input 3D boxes. Either ``"xyzwhd"`` (center x, y, z and width, height, depth) or
+            ``"xyzxyz"`` (min x, y, z and max x, y, z corners).
+        iou_thresholds: List of IoU thresholds (default is ``[0.5, 0.55, ..., 0.95]``).
+        rec_thresholds: Unused, kept for API parity with the 2D metric. Recall is always evaluated at 101 points.
+        max_detection_thresholds: List of maximum detections per sample (default is ``[1, 10, 100]``).
+        class_metrics: Whether to compute per-class mAP and mAR metrics.
+
+    Returns:
+        dict: A dictionary containing the evaluation metrics:
+
+            - ``map``: Global mean average precision over the defined IoU thresholds.
+            - ``map_50``: mAP at IoU=0.50 (``-1`` if 0.5 is not part of ``iou_thresholds``).
+            - ``map_75``: mAP at IoU=0.75 (``-1`` if 0.75 is not part of ``iou_thresholds``).
+            - ``mar_{max_det}``: Mean average recall for each maximum detection threshold.
+            - ``map_per_class``: Mean average precision per observed class (``-1`` if ``class_metrics`` is disabled).
+            - ``mar_{max_det}_per_class``: Mean average recall per class at the largest max detection threshold.
+            - ``classes``: A tensor listing all observed classes.
+
+    Example::
+
+        >>> from torch import tensor
+        >>> from torchmetrics.functional.detection.map_3d import mean_average_precision_3d
+        >>> preds = [
+        ...   {
+        ...     "boxes": tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]),
+        ...     "scores": tensor([0.9]),
+        ...     "labels": tensor([0]),
+        ...   }
+        ... ]
+        >>> target = [
+        ...   {
+        ...     "boxes": tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]),
+        ...     "labels": tensor([0]),
+        ...   }
+        ... ]
+        >>> result = mean_average_precision_3d(preds, target)
+        >>> print(f"mAP: {result['map']:.4f}, mAP@0.5: {result['map_50']:.4f}")
+        mAP: 1.0000, mAP@0.5: 1.0000
+
+    """
+    from torchmetrics.detection.helpers import _input_validator
+
+    _input_validator(preds, target, iou_type="bbox")
+
+    iou_thresholds = iou_thresholds or torch.linspace(0.5, 0.95, round((0.95 - 0.5) / 0.05) + 1).tolist()
+    max_detection_thresholds = sorted(max_detection_thresholds or [1, 10, 100])
+
+    pred_boxes = [_convert_3d_boxes_to_corners(item["boxes"], box_format) for item in preds]
+    pred_scores = [item["scores"] for item in preds]
+    pred_labels = [item["labels"] for item in preds]
+    target_boxes = [_convert_3d_boxes_to_corners(item["boxes"], box_format) for item in target]
+    target_labels = [item["labels"] for item in target]
+
+    classes = torch.cat(target_labels + pred_labels).unique() if (target_labels or pred_labels) else torch.tensor([])
+
+    per_class_ap: Dict[float, Tensor] = {}
+    per_class_ar: Dict[int, Dict[float, Tensor]] = {mdt: {} for mdt in max_detection_thresholds}
+    for cls in classes.tolist():
+        preds_c = [boxes[labels == cls] for boxes, labels in zip(pred_boxes, pred_labels)]
+        scores_c = [scores[labels == cls] for scores, labels in zip(pred_scores, pred_labels)]
+        target_c = [boxes[labels == cls] for boxes, labels in zip(target_boxes, target_labels)]
+        result = _evaluate_class(preds_c, scores_c, target_c, iou_thresholds, max_detection_thresholds)
+        per_class_ap[cls] = result["ap"]
+        for mdt in max_detection_thresholds:
+            per_class_ar[mdt][cls] = result["ar"][mdt]
+
+    if len(classes) == 0:
+        map_per_class = torch.tensor(-1.0)
+        map_value = torch.tensor(-1.0)
+        map_50 = torch.tensor(-1.0)
+        map_75 = torch.tensor(-1.0)
+        ar_values = {mdt: torch.tensor(-1.0) for mdt in max_detection_thresholds}
+        ar_per_class = {mdt: torch.tensor(-1.0) for mdt in max_detection_thresholds}
+    else:
+        all_ap = torch.stack(list(per_class_ap.values()))  # (num_classes, num_iou_thresholds)
+        map_value = all_ap.mean()
+        map_50 = all_ap[:, iou_thresholds.index(0.5)].mean() if 0.5 in iou_thresholds else torch.tensor(-1.0)
+        map_75 = all_ap[:, iou_thresholds.index(0.75)].mean() if 0.75 in iou_thresholds else torch.tensor(-1.0)
+        map_per_class = all_ap.mean(dim=1) if class_metrics else torch.tensor(-1.0)
+        ar_values = {mdt: torch.stack(list(per_class_ar[mdt].values())).mean() for mdt in max_detection_thresholds}
+        ar_per_class = {
+            mdt: torch.stack(list(per_class_ar[mdt].values())) if class_metrics else torch.tensor(-1.0)
+            for mdt in max_detection_thresholds
+        }
+
+    result_dict: Dict[str, Tensor] = {
+        "map": map_value,
+        "map_50": map_50,
+        "map_75": map_75,
+        "map_per_class": map_per_class,
+        "classes": classes.to(torch.int32),
+    }
+    for mdt in max_detection_thresholds:
+        result_dict[f"mar_{mdt}"] = ar_values[mdt]
+    result_dict[f"mar_{max_detection_thresholds[-1]}_per_class"] = ar_per_class[max_detection_thresholds[-1]]
+    return {k: (v.squeeze() if isinstance(v, torch.Tensor) and v.numel() == 1 else v) for k, v in result_dict.items()}

--- a/src/torchmetrics/functional/detection/map_3d.py
+++ b/src/torchmetrics/functional/detection/map_3d.py
@@ -43,7 +43,7 @@ def _volume_3d(boxes: Tensor) -> Tensor:
 def _pairwise_iou_3d(preds: Tensor, target: Tensor) -> Tensor:
     """Compute the pairwise 3D IoU between two sets of axis-aligned boxes given in corner format."""
     if preds.numel() == 0 or target.numel() == 0:
-        return torch.zeros((preds.shape[0], target.shape[0]), dtype=torch.float32)
+        return preds.new_zeros((preds.shape[0], target.shape[0]))
 
     lt = torch.max(preds[:, None, :3], target[None, :, :3])
     rb = torch.min(preds[:, None, 3:], target[None, :, 3:])
@@ -58,9 +58,9 @@ def _pairwise_iou_3d(preds: Tensor, target: Tensor) -> Tensor:
 
 def _compute_average_precision(recall: Tensor, precision: Tensor) -> Tensor:
     """Compute the 101-point interpolated average precision, following the COCO evaluation protocol."""
-    recall_thresholds = torch.linspace(0, 1, 101)
+    recall_thresholds = torch.linspace(0, 1, 101, device=recall.device, dtype=recall.dtype)
     if recall.numel() == 0:
-        return torch.tensor(0.0)
+        return recall.new_zeros(())
 
     # precision envelope: precision[i] = max(precision[i:])
     envelope = precision.flip(0).cummax(0).values.flip(0)
@@ -81,6 +81,12 @@ def _evaluate_class(
     """Evaluate a single class across all images, returning AP per IoU threshold and AR per max-detection threshold."""
     num_gt = sum(t.shape[0] for t in target_per_image)
 
+    ref_tensor = next(
+        (t for tensors in (preds_per_image, target_per_image) for t in tensors if t.numel() > 0),
+        None,
+    )
+    device = ref_tensor.device if ref_tensor is not None else torch.device("cpu")
+
     max_det = max(max_detection_thresholds)
     flat_preds, flat_scores, flat_image_idx = [], [], []
     for image_idx, (boxes, scores) in enumerate(zip(preds_per_image, scores_per_image)):
@@ -91,15 +97,15 @@ def _evaluate_class(
         flat_scores.append(scores[order])
         flat_image_idx.extend([image_idx] * order.numel())
 
-    average_precisions = torch.zeros(len(iou_thresholds))
-    average_recalls = {mdt: torch.tensor(0.0) for mdt in max_detection_thresholds}
+    average_precisions = torch.zeros(len(iou_thresholds), device=device)
+    average_recalls = {mdt: torch.zeros((), device=device) for mdt in max_detection_thresholds}
 
     if num_gt == 0 or len(flat_preds) == 0:
         return {"ap": average_precisions, "ar": average_recalls}
 
     all_preds = torch.cat(flat_preds, dim=0)
     all_scores = torch.cat(flat_scores, dim=0)
-    all_image_idx = torch.tensor(flat_image_idx)
+    all_image_idx = torch.tensor(flat_image_idx, device=device)
 
     sort_order = torch.argsort(all_scores, descending=True, stable=True)
     all_preds = all_preds[sort_order]
@@ -113,34 +119,36 @@ def _evaluate_class(
     ]
 
     for mdt in max_detection_thresholds:
-        matched = [torch.zeros(t.shape[0], dtype=torch.bool) for t in target_per_image]
-        per_image_count = dict.fromkeys(range(len(target_per_image)), 0)
-        per_image_cursor = dict.fromkeys(range(len(target_per_image)), 0)
-        for i in range(all_preds.shape[0]):
-            image_idx = int(all_image_idx[i])
-            iou_row = ious[image_idx]
-            if iou_row is None:
-                continue
-            pred_cursor = per_image_cursor[image_idx]
-            per_image_cursor[image_idx] += 1
-            if per_image_count[image_idx] >= mdt:
-                continue
-            per_image_count[image_idx] += 1
-            row = iou_row[pred_cursor].clone()
-            row[matched[image_idx]] = -1
-            if row.numel() == 0:
-                continue
-            best_gt = int(row.argmax())
-            if row[best_gt] >= min(iou_thresholds):
-                matched[image_idx][best_gt] = True
-        recall_value = float(sum(m.sum().item() for m in matched)) / num_gt
-        average_recalls[mdt] = torch.tensor(recall_value)
+        recall_per_iou = []
+        for iou_thr in iou_thresholds:
+            matched = [torch.zeros(t.shape[0], dtype=torch.bool) for t in target_per_image]
+            per_image_count = dict.fromkeys(range(len(target_per_image)), 0)
+            per_image_cursor = dict.fromkeys(range(len(target_per_image)), 0)
+            for i in range(all_preds.shape[0]):
+                image_idx = int(all_image_idx[i])
+                iou_row = ious[image_idx]
+                if iou_row is None:
+                    continue
+                pred_cursor = per_image_cursor[image_idx]
+                per_image_cursor[image_idx] += 1
+                if per_image_count[image_idx] >= mdt:
+                    continue
+                per_image_count[image_idx] += 1
+                row = iou_row[pred_cursor].clone()
+                row[matched[image_idx]] = -1
+                if row.numel() == 0:
+                    continue
+                best_gt = int(row.argmax())
+                if row[best_gt] >= iou_thr:
+                    matched[image_idx][best_gt] = True
+            recall_per_iou.append(float(sum(m.sum().item() for m in matched)) / num_gt)
+        average_recalls[mdt] = torch.tensor(sum(recall_per_iou) / len(recall_per_iou), device=device)
 
     for t_idx, iou_threshold in enumerate(iou_thresholds):
         matched = [torch.zeros(t.shape[0], dtype=torch.bool) for t in target_per_image]
         per_image_cursor = dict.fromkeys(range(len(target_per_image)), 0)
-        tp = torch.zeros(all_preds.shape[0])
-        fp = torch.zeros(all_preds.shape[0])
+        tp = torch.zeros(all_preds.shape[0], device=device)
+        fp = torch.zeros(all_preds.shape[0], device=device)
         for i in range(all_preds.shape[0]):
             image_idx = int(all_image_idx[i])
             iou_row = ious[image_idx]
@@ -243,7 +251,8 @@ def mean_average_precision_3d(
     target_boxes = [_convert_3d_boxes_to_corners(item["boxes"], box_format) for item in target]
     target_labels = [item["labels"] for item in target]
 
-    classes = torch.cat(target_labels + pred_labels).unique() if (target_labels or pred_labels) else torch.tensor([])
+    non_empty_targets = [t for t in target_labels if t.numel() > 0]
+    classes = torch.cat(non_empty_targets).unique() if non_empty_targets else torch.tensor([])
 
     per_class_ap: Dict[float, Tensor] = {}
     per_class_ar: Dict[int, Dict[float, Tensor]] = {mdt: {} for mdt in max_detection_thresholds}

--- a/tests/unittests/detection/test_map_3d.py
+++ b/tests/unittests/detection/test_map_3d.py
@@ -1,0 +1,186 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import torch
+
+from torchmetrics.detection.mean_ap_3d import MeanAveragePrecision3D
+from torchmetrics.functional.detection.map_3d import _pairwise_iou_3d, mean_average_precision_3d
+
+
+def test_pairwise_iou_3d():
+    """Check the pairwise 3D IoU computation against hand-derived values."""
+    boxes1 = torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]])
+    boxes2 = torch.tensor([
+        [0.0, 0.0, 0.0, 2.0, 2.0, 2.0],
+        [1.0, 1.0, 1.0, 3.0, 3.0, 3.0],
+        [10.0, 10.0, 10.0, 12.0, 12.0, 12.0],
+    ])
+    iou = _pairwise_iou_3d(boxes1, boxes2)
+    # identical boxes -> IoU 1.0
+    assert torch.isclose(iou[0, 0], torch.tensor(1.0))
+    # 1x1x1 intersection out of a union of 8 + 8 - 1 = 15
+    assert torch.isclose(iou[0, 1], torch.tensor(1 / 15))
+    # disjoint boxes -> IoU 0.0
+    assert torch.isclose(iou[0, 2], torch.tensor(0.0))
+
+
+def test_map_3d_perfect_match():
+    """A prediction identical to the target should give AP/AR of 1 for all thresholds."""
+    preds = [
+        {
+            "boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]),
+            "scores": torch.tensor([0.9]),
+            "labels": torch.tensor([0]),
+        }
+    ]
+    target = [{"boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]), "labels": torch.tensor([0])}]
+
+    result = mean_average_precision_3d(preds, target)
+    assert torch.isclose(result["map"], torch.tensor(1.0))
+    assert torch.isclose(result["map_50"], torch.tensor(1.0))
+    assert torch.isclose(result["map_75"], torch.tensor(1.0))
+    assert torch.isclose(result["mar_100"], torch.tensor(1.0))
+
+
+def test_map_3d_no_overlap():
+    """A prediction that does not overlap the target should give AP/AR of 0."""
+    preds = [
+        {
+            "boxes": torch.tensor([[10.0, 10.0, 10.0, 12.0, 12.0, 12.0]]),
+            "scores": torch.tensor([0.9]),
+            "labels": torch.tensor([0]),
+        }
+    ]
+    target = [{"boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]), "labels": torch.tensor([0])}]
+
+    result = mean_average_precision_3d(preds, target)
+    assert torch.isclose(result["map"], torch.tensor(0.0))
+    assert torch.isclose(result["mar_100"], torch.tensor(0.0))
+
+
+def test_map_3d_box_format():
+    """The ``xyzxyz`` and ``xyzwhd`` box formats should agree on the same underlying box."""
+    preds_whd = [
+        {
+            "boxes": torch.tensor([[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]]),
+            "scores": torch.tensor([0.9]),
+            "labels": torch.tensor([0]),
+        }
+    ]
+    target_whd = [{"boxes": torch.tensor([[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]]), "labels": torch.tensor([0])}]
+    preds_xyz = [
+        {
+            "boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]),
+            "scores": torch.tensor([0.9]),
+            "labels": torch.tensor([0]),
+        }
+    ]
+    target_xyz = [{"boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]), "labels": torch.tensor([0])}]
+
+    result_whd = mean_average_precision_3d(preds_whd, target_whd, box_format="xyzwhd")
+    result_xyz = mean_average_precision_3d(preds_xyz, target_xyz, box_format="xyzxyz")
+    assert torch.isclose(result_whd["map"], result_xyz["map"])
+
+
+def test_map_3d_class_metrics():
+    """Per-class metrics should be returned when ``class_metrics=True`` and match the observed classes."""
+    preds = [
+        {
+            "boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0], [10.0, 10.0, 10.0, 12.0, 12.0, 12.0]]),
+            "scores": torch.tensor([0.9, 0.1]),
+            "labels": torch.tensor([0, 1]),
+        }
+    ]
+    target = [
+        {
+            "boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0], [10.0, 10.0, 10.0, 12.0, 12.0, 12.0]]),
+            "labels": torch.tensor([0, 1]),
+        }
+    ]
+
+    result = mean_average_precision_3d(preds, target, class_metrics=True)
+    assert torch.equal(result["classes"], torch.tensor([0, 1], dtype=torch.int32))
+    assert result["map_per_class"].shape == (2,)
+    assert torch.allclose(result["map_per_class"], torch.tensor([1.0, 1.0]))
+
+
+def test_map_3d_no_predictions():
+    """If there are no predictions for an image with ground truth, mAP/mAR should be 0."""
+    preds = [
+        {
+            "boxes": torch.zeros((0, 6)),
+            "scores": torch.zeros((0,)),
+            "labels": torch.zeros((0,), dtype=torch.long),
+        }
+    ]
+    target = [{"boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]), "labels": torch.tensor([0])}]
+
+    result = mean_average_precision_3d(preds, target)
+    assert torch.isclose(result["map"], torch.tensor(0.0))
+
+
+def test_map_3d_no_ground_truth():
+    """If there is no ground truth at all, the metric should not error and report -1."""
+    preds = [
+        {
+            "boxes": torch.zeros((0, 6)),
+            "scores": torch.zeros((0,)),
+            "labels": torch.zeros((0,), dtype=torch.long),
+        }
+    ]
+    target = [{"boxes": torch.zeros((0, 6)), "labels": torch.zeros((0,), dtype=torch.long)}]
+
+    result = mean_average_precision_3d(preds, target)
+    assert result["map"] == -1
+
+
+def test_module_matches_functional():
+    """The module interface should match the functional interface for the same inputs."""
+    preds = [
+        {
+            "boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]),
+            "scores": torch.tensor([0.9]),
+            "labels": torch.tensor([0]),
+        },
+        {
+            "boxes": torch.tensor([[5.0, 5.0, 5.0, 1.0, 1.0, 1.0]]),
+            "scores": torch.tensor([0.4]),
+            "labels": torch.tensor([0]),
+        },
+    ]
+    target = [
+        {"boxes": torch.tensor([[0.0, 0.0, 0.0, 2.0, 2.0, 2.0]]), "labels": torch.tensor([0])},
+        {"boxes": torch.tensor([[5.0, 5.0, 5.0, 1.0, 1.0, 1.0]]), "labels": torch.tensor([0])},
+    ]
+
+    functional_result = mean_average_precision_3d(preds, target)
+
+    metric = MeanAveragePrecision3D()
+    metric.update(preds, target)
+    module_result = metric.compute()
+
+    for key in functional_result:
+        assert torch.equal(torch.as_tensor(functional_result[key]), torch.as_tensor(module_result[key]))
+
+
+@pytest.mark.parametrize("box_format", ["xyzwhd", "xyzxyz"])
+def test_invalid_box_format_raises(box_format):
+    """Sanity check that the module accepts both supported box formats without error."""
+    MeanAveragePrecision3D(box_format=box_format)
+
+
+def test_invalid_box_format_raises_value_error():
+    """An unsupported ``box_format`` should raise a ``ValueError``."""
+    with pytest.raises(ValueError, match=r"Expected argument `box_format` to be one of.*"):
+        MeanAveragePrecision3D(box_format="invalid")

--- a/tests/unittests/detection/test_map_3d.py
+++ b/tests/unittests/detection/test_map_3d.py
@@ -175,7 +175,7 @@ def test_module_matches_functional():
 
 
 @pytest.mark.parametrize("box_format", ["xyzwhd", "xyzxyz"])
-def test_invalid_box_format_raises(box_format):
+def test_valid_box_format_does_not_raise(box_format):
     """Sanity check that the module accepts both supported box formats without error."""
     MeanAveragePrecision3D(box_format=box_format)
 


### PR DESCRIPTION
## Summary

Closes #3398.

Adds a `MeanAveragePrecision3D` metric (and its functional counterpart `mean_average_precision_3d`) for computing mAP/mAR on axis-aligned 3D bounding boxes, e.g. for evaluating detectors that operate on point-clouds, voxel grids, or other 3D sensor data.

- `torchmetrics.detection.MeanAveragePrecision3D` / `torchmetrics.functional.detection.mean_average_precision_3d`.
- Supports `box_format="xyzwhd"` (center x, y, z + width, height, depth) and `"xyzxyz"` (corner) formats.
- The existing 2D `MeanAveragePrecision` relies on `pycocotools`/`faster_coco_eval`, which only support 2D boxes and masks, so this is implemented independently: 3D IoU is computed directly on axis-aligned boxes, and average precision follows the same COCO-style 101-point interpolation, with greedy highest-score-first matching per class/IoU-threshold, and per-image `max_detection_thresholds` truncation for mAR — mirroring the existing 2D metric's API and output keys (`map`, `map_50`, `map_75`, `mar_{max_det}`, `map_per_class`, `mar_{max_det}_per_class`, `classes`) as closely as possible.
- No new required dependencies (`torch` only).

### Scope / follow-ups

This first version supports axis-aligned 3D boxes only (no yaw/rotation), which covers the common case for e.g. LiDAR-derived detections but not fully-oriented boxes (KITTI/nuScenes-style rotated boxes). Rotated 3D IoU would need convex-polygon intersection and is left as a natural follow-up if there's interest, potentially as an additional `box_format` option.

## Test plan

- [x] Added `tests/unittests/detection/test_map_3d.py` covering: pairwise 3D IoU correctness, perfect-match AP/AR = 1, non-overlapping AP/AR = 0, box format equivalence, per-class metrics, empty-prediction and empty-ground-truth edge cases, and module/functional parity.
- [x] `ruff check` / `ruff format --check` clean on new files.
- [x] `mypy` clean on new files.
- [x] Doctests in both new modules pass.

## AI Usage

- [x] Claude code was used to draft the implementation and tests. 
- [x] A human submitter ( onepunchmonk) has reviewed the changes