### PR TITLE
Do not import scipy.signal at torchmetrics import time

### DIFF
--- a/src/torchmetrics/__init__.py
+++ b/src/torchmetrics/__init__.py
@@ -27,13 +27,6 @@ if package_available("PIL"):
     if not hasattr(PIL, "PILLOW_VERSION"):
         PIL.PILLOW_VERSION = PIL.__version__
 
-if package_available("scipy"):
-    import scipy.signal
-
-    # back compatibility patch due to SMRMpy using scipy.signal.hamming
-    if not hasattr(scipy.signal, "hamming"):
-        scipy.signal.hamming = scipy.signal.windows.hamming
-
 from torchmetrics import functional  # noqa: E402
 from torchmetrics.aggregation import (  # noqa: E402
     CatMetric,

--- a/src/torchmetrics/audio/__init__.py
+++ b/src/torchmetrics/audio/__init__.py
@@ -29,16 +29,8 @@ from torchmetrics.utilities.imports import (
     _PESQ_AVAILABLE,
     _PYSTOI_AVAILABLE,
     _REQUESTS_AVAILABLE,
-    _SCIPI_AVAILABLE,
     _TORCHAUDIO_AVAILABLE,
 )
-
-if _SCIPI_AVAILABLE:
-    import scipy.signal
-
-    # back compatibility patch due to SMRMpy using scipy.signal.hamming
-    if not hasattr(scipy.signal, "hamming"):
-        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "ComplexScaleInvariantSignalNoiseRatio",

--- a/src/torchmetrics/functional/audio/__init__.py
+++ b/src/torchmetrics/functional/audio/__init__.py
@@ -29,16 +29,8 @@ from torchmetrics.utilities.imports import (
     _PESQ_AVAILABLE,
     _PYSTOI_AVAILABLE,
     _REQUESTS_AVAILABLE,
-    _SCIPI_AVAILABLE,
     _TORCHAUDIO_AVAILABLE,
 )
-
-if _SCIPI_AVAILABLE:
-    import scipy.signal
-
-    # back compatibility patch due to SMRMpy using scipy.signal.hamming
-    if not hasattr(scipy.signal, "hamming"):
-        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "complex_scale_invariant_signal_noise_ratio",

--- a/tests/unittests/audio/__init__.py
+++ b/tests/unittests/audio/__init__.py
@@ -5,6 +5,17 @@ from torch import Tensor
 
 from unittests import _PATH_ALL_TESTS
 
+# SRMRpy calls `scipy.signal.hamming`, which SciPy moved to `scipy.signal.windows.hamming`.
+# Only `test_srmr.py` imports SRMRpy, and this package is imported before it, so the shim
+# lives here rather than in `torchmetrics`, which never imports SRMRpy at all.
+try:
+    import scipy.signal
+
+    if not hasattr(scipy.signal, "hamming"):
+        scipy.signal.hamming = scipy.signal.windows.hamming
+except ImportError:
+    pass
+
 _SAMPLE_AUDIO_SPEECH = os.path.join(_PATH_ALL_TESTS, "_data", "audio", "audio_speech.wav")
 _SAMPLE_AUDIO_SPEECH_BAB_DB = os.path.join(_PATH_ALL_TESTS, "_data", "audio", "audio_speech_bab_0dB.wav")
 _SAMPLE_NUMPY_ISSUE_895 = os.path.join(_PATH_ALL_TESTS, "_data", "audio", "issue_895.npz")


### PR DESCRIPTION
## What does this PR do?

Part of #3457, the `scipy.signal` half of it. `torchvision` is #3314 / #3432 and `matplotlib` is untouched here.

`import torchmetrics` pulls in `scipy.signal` eagerly from a SRMRpy back-compatibility shim that is duplicated across `torchmetrics/__init__.py`, `torchmetrics/audio/__init__.py` and `torchmetrics/functional/audio/__init__.py`. The shim exists because SRMRpy calls `scipy.signal.hamming`, which SciPy moved to `scipy.signal.windows.hamming`.

torchmetrics never imports SRMRpy. It appears only in `requirements/audio_test.txt` and `tests/unittests/audio/test_srmr.py`:

```console
$ grep -rn srmrpy src/
$ grep -rn srmrpy requirements/ tests/
requirements/audio_test.txt:7:srmrpy @ git+https://github.com/Lightning-Sandbox/SRMRpy
tests/unittests/audio/test_srmr.py:19:from srmrpy import srmr as srmrpy_srmr
```

So the shim belongs with the tests. It moves to `tests/unittests/audio/__init__.py`, which Python imports before `test_srmr.py` and therefore before that module's `from srmrpy import ...`. Verified:

```console
$ python -c "import scipy.signal; print(hasattr(scipy.signal,'hamming'))"
False
$ python -c "import sys; sys.path.insert(0,'tests'); import unittests.audio, scipy.signal; print(hasattr(scipy.signal,'hamming'))"
True
```

`_SCIPI_AVAILABLE` was imported by the two audio `__init__.py` files only for this block, so it goes with it.

### Measurement

`python -X importtime -c "import torchmetrics"`, three runs each, warm cache:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before | 1085 ms | 1072 ms | 1095 ms |
| after | 652 ms | 657 ms | 655 ms |

and `scipy.signal` is no longer in `sys.modules` after `import torchmetrics`. Roughly 40% off, which is more than `scipy.signal`'s own subtree because its shared parents go too.

`torchmetrics.audio` and `torchmetrics.functional.audio` still import and evaluate, and `ruff check` / `ruff format --check` are clean on the four touched files.