### PR TITLE
fix(nominal): support non-zero-based category labels in functional metrics (#3460)

### DIFF
--- a/src/torchmetrics/functional/nominal/cramers.py
+++ b/src/torchmetrics/functional/nominal/cramers.py
@@ -25,6 +25,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_categorical_inputs,
     _unable_to_use_bias_correction_warning,
 )
 
@@ -133,8 +134,8 @@ def cramers_v(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _cramers_v_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    preds, target, num_classes = _remap_categorical_inputs(preds, target, nan_strategy, nan_replace_value)
+    confmat = _multiclass_confusion_matrix_update(preds, target, num_classes)
     return _cramers_v_compute(confmat, bias_correction)
 
 
@@ -176,8 +177,7 @@ def cramers_v_matrix(
     num_variables = matrix.shape[1]
     cramers_v_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
-        x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _cramers_v_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        x, y, num_classes = _remap_categorical_inputs(matrix[:, i], matrix[:, j], nan_strategy, nan_replace_value)
+        confmat = _multiclass_confusion_matrix_update(x, y, num_classes)
         cramers_v_matrix_value[i, j] = cramers_v_matrix_value[j, i] = _cramers_v_compute(confmat, bias_correction)
     return cramers_v_matrix_value

--- a/src/torchmetrics/functional/nominal/pearson.py
+++ b/src/torchmetrics/functional/nominal/pearson.py
@@ -24,6 +24,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_categorical_inputs,
 )
 
 
@@ -123,8 +124,8 @@ def pearsons_contingency_coefficient(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _pearsons_contingency_coefficient_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    preds, target, num_classes = _remap_categorical_inputs(preds, target, nan_strategy, nan_replace_value)
+    confmat = _multiclass_confusion_matrix_update(preds, target, num_classes)
     return _pearsons_contingency_coefficient_compute(confmat)
 
 
@@ -166,9 +167,8 @@ def pearsons_contingency_coefficient_matrix(
     num_variables = matrix.shape[1]
     pearsons_cont_coef_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
-        x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _pearsons_contingency_coefficient_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        x, y, num_classes = _remap_categorical_inputs(matrix[:, i], matrix[:, j], nan_strategy, nan_replace_value)
+        confmat = _multiclass_confusion_matrix_update(x, y, num_classes)
         val = _pearsons_contingency_coefficient_compute(confmat)
         pearsons_cont_coef_matrix_value[i, j] = pearsons_cont_coef_matrix_value[j, i] = val
     return pearsons_cont_coef_matrix_value

--- a/src/torchmetrics/functional/nominal/theils_u.py
+++ b/src/torchmetrics/functional/nominal/theils_u.py
@@ -23,6 +23,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_categorical_inputs,
 )
 
 
@@ -146,8 +147,9 @@ def theils_u(
         tensor(0.8530)
 
     """
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _theils_u_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    _nominal_input_validation(nan_strategy, nan_replace_value)
+    preds, target, num_classes = _remap_categorical_inputs(preds, target, nan_strategy, nan_replace_value)
+    confmat = _multiclass_confusion_matrix_update(preds, target, num_classes)
     return _theils_u_compute(confmat)
 
 
@@ -187,9 +189,8 @@ def theils_u_matrix(
     num_variables = matrix.shape[1]
     theils_u_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
-        x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _theils_u_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        x, y, num_classes = _remap_categorical_inputs(matrix[:, i], matrix[:, j], nan_strategy, nan_replace_value)
+        confmat = _multiclass_confusion_matrix_update(x, y, num_classes)
         theils_u_matrix_value[i, j] = _theils_u_compute(confmat)
         theils_u_matrix_value[j, i] = _theils_u_compute(confmat.T)
     return theils_u_matrix_value

--- a/src/torchmetrics/functional/nominal/tschuprows.py
+++ b/src/torchmetrics/functional/nominal/tschuprows.py
@@ -25,6 +25,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_categorical_inputs,
     _unable_to_use_bias_correction_warning,
 )
 
@@ -139,8 +140,8 @@ def tschuprows_t(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
-    confmat = _tschuprows_t_update(preds, target, num_classes, nan_strategy, nan_replace_value)
+    preds, target, num_classes = _remap_categorical_inputs(preds, target, nan_strategy, nan_replace_value)
+    confmat = _multiclass_confusion_matrix_update(preds, target, num_classes)
     return _tschuprows_t_compute(confmat, bias_correction)
 
 
@@ -184,9 +185,8 @@ def tschuprows_t_matrix(
     num_variables = matrix.shape[1]
     tschuprows_t_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
-        x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
-        confmat = _tschuprows_t_update(x, y, num_classes, nan_strategy, nan_replace_value)
+        x, y, num_classes = _remap_categorical_inputs(matrix[:, i], matrix[:, j], nan_strategy, nan_replace_value)
+        confmat = _multiclass_confusion_matrix_update(x, y, num_classes)
         tschuprows_t_matrix_value[i, j] = tschuprows_t_matrix_value[j, i] = _tschuprows_t_compute(
             confmat, bias_correction
         )

--- a/src/torchmetrics/functional/nominal/utils.py
+++ b/src/torchmetrics/functional/nominal/utils.py
@@ -32,6 +32,24 @@ def _nominal_input_validation(nan_strategy: str, nan_replace_value: Optional[flo
         )
 
 
+def _remap_categorical_inputs(
+    preds: Tensor,
+    target: Tensor,
+    nan_strategy: Literal["replace", "drop"] = "replace",
+    nan_replace_value: Optional[float] = 0.0,
+) -> tuple[Tensor, Tensor, int]:
+    """Remap categorical values to contiguous 0-based integers [0, num_classes - 1]."""
+    preds = preds.argmax(1) if preds.ndim == 2 else preds
+    target = target.argmax(1) if target.ndim == 2 else target
+    preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
+    combined = torch.cat([preds.reshape(-1), target.reshape(-1)])
+    unique_vals, inverse = combined.unique(return_inverse=True)
+    num_classes = len(unique_vals)
+    preds_remapped = inverse[: preds.numel()].reshape(preds.shape)
+    target_remapped = inverse[preds.numel() :].reshape(target.shape)
+    return preds_remapped, target_remapped, num_classes
+
+
 def _compute_expected_freqs(confmat: Tensor) -> Tensor:
     """Compute the expected frequenceis from the provided confusion matrix."""
     margin_sum_rows, margin_sum_cols = confmat.sum(1), confmat.sum(0)
@@ -44,6 +62,7 @@ def _compute_chi_squared(confmat: Tensor, bias_correction: bool) -> Tensor:
     Adapted from: https://github.com/scipy/scipy/blob/v1.9.2/scipy/stats/contingency.py.
 
     """
+    confmat = confmat.float()
     expected_freqs = _compute_expected_freqs(confmat)
     # Get degrees of freedom
     df = expected_freqs.numel() - sum(expected_freqs.shape) + expected_freqs.ndim - 1
@@ -53,7 +72,7 @@ def _compute_chi_squared(confmat: Tensor, bias_correction: bool) -> Tensor:
     if df == 1 and bias_correction:
         diff = expected_freqs - confmat
         direction = diff.sign()
-        confmat += direction * torch.minimum(0.5 * torch.ones_like(direction), direction.abs())
+        confmat = confmat + direction * torch.minimum(0.5 * torch.ones_like(direction), direction.abs())
 
     return torch.sum((confmat - expected_freqs) ** 2 / expected_freqs)
 

--- a/tests/unittests/nominal/test_cramers.py
+++ b/tests/unittests/nominal/test_cramers.py
@@ -169,3 +169,19 @@ def test_cramers_v_matrix(cramers_matrix_input, bias_correction, nan_strategy, n
     tm_score = cramers_v_matrix(cramers_matrix_input, bias_correction, nan_strategy, nan_replace_value)
     reference_score = _dython_cramers_v_matrix(cramers_matrix_input, bias_correction, nan_strategy, nan_replace_value)
     assert torch.allclose(tm_score, reference_score)
+
+
+def test_cramers_v_nonzero_labels():
+    """Test that cramers_v works with non-zero-based category labels."""
+    preds = torch.tensor([5, 6, 7, 8, 5, 6, 7, 8])
+    target = torch.tensor([5, 6, 7, 7, 6, 6, 5, 8])
+    res = cramers_v(preds, target, bias_correction=False)
+    preds_0 = preds - 5
+    target_0 = target - 5
+    res_0 = cramers_v(preds_0, target_0, bias_correction=False)
+    assert torch.allclose(res, res_0)
+    ref = _reference_dython_cramers_v(
+        preds_0, target_0, bias_correction=False, nan_strategy="replace", nan_replace_value=0.0
+    )
+    assert torch.allclose(res, ref.float())
+

--- a/tests/unittests/nominal/test_cramers.py
+++ b/tests/unittests/nominal/test_cramers.py
@@ -184,4 +184,3 @@ def test_cramers_v_nonzero_labels():
         preds_0, target_0, bias_correction=False, nan_strategy="replace", nan_replace_value=0.0
     )
     assert torch.allclose(res, ref.float())
-

--- a/tests/unittests/nominal/test_pearson.py
+++ b/tests/unittests/nominal/test_pearson.py
@@ -132,4 +132,3 @@ def test_pearsons_nonzero_labels():
     res = pearsons_contingency_coefficient(preds, target)
     ref = _reference_pd_pearsons_t(preds, target)
     assert torch.allclose(res, ref)
-

--- a/tests/unittests/nominal/test_pearson.py
+++ b/tests/unittests/nominal/test_pearson.py
@@ -123,3 +123,13 @@ def test_pearsons_contingency_coefficient_matrix(pearson_matrix_input):
     tm_score = pearsons_contingency_coefficient_matrix(pearson_matrix_input)
     reference_score = _reference_pd_pearsons_t_matrix(pearson_matrix_input)
     assert torch.allclose(tm_score, reference_score)
+
+
+def test_pearsons_nonzero_labels():
+    """Test that pearsons_contingency_coefficient works with non-zero-based category labels."""
+    preds = torch.tensor([5, 6, 5, 6, 5, 6, 5, 6])
+    target = torch.tensor([5, 6, 5, 5, 6, 6, 5, 6])
+    res = pearsons_contingency_coefficient(preds, target)
+    ref = _reference_pd_pearsons_t(preds, target)
+    assert torch.allclose(res, ref)
+

--- a/tests/unittests/nominal/test_theils_u.py
+++ b/tests/unittests/nominal/test_theils_u.py
@@ -160,3 +160,13 @@ def test_theils_u_matrix(theils_u_matrix_input, nan_strategy, nan_replace_value)
     tm_score = theils_u_matrix(theils_u_matrix_input, nan_strategy, nan_replace_value)
     reference_score = _reference_dython_theils_u_matrix(theils_u_matrix_input, nan_strategy, nan_replace_value)
     assert torch.allclose(tm_score, reference_score, atol=1e-6)
+
+
+def test_theils_u_nonzero_labels():
+    """Test that theils_u works with non-zero-based category labels."""
+    preds = torch.tensor([5, 6, 5, 6, 5, 6, 5, 6])
+    target = torch.tensor([5, 6, 5, 5, 6, 6, 5, 6])
+    res = theils_u(preds, target)
+    ref = _reference_dython_theils_u(preds, target, nan_strategy="replace", nan_replace_value=0.0)
+    assert torch.allclose(res, ref.float())
+

--- a/tests/unittests/nominal/test_theils_u.py
+++ b/tests/unittests/nominal/test_theils_u.py
@@ -169,4 +169,3 @@ def test_theils_u_nonzero_labels():
     res = theils_u(preds, target)
     ref = _reference_dython_theils_u(preds, target, nan_strategy="replace", nan_replace_value=0.0)
     assert torch.allclose(res, ref.float())
-

--- a/tests/unittests/nominal/test_tschuprows.py
+++ b/tests/unittests/nominal/test_tschuprows.py
@@ -134,4 +134,3 @@ def test_tschuprows_t_nonzero_labels():
     res = tschuprows_t(preds, target, bias_correction=False)
     ref = _reference_pd_tschuprows_t(preds, target)
     assert torch.allclose(res, ref)
-

--- a/tests/unittests/nominal/test_tschuprows.py
+++ b/tests/unittests/nominal/test_tschuprows.py
@@ -125,3 +125,13 @@ def test_tschuprows_t_matrix(tschuprows_matrix_input):
     tm_score = tschuprows_t_matrix(tschuprows_matrix_input, bias_correction=False)
     reference_score = _reference_pd_tschuprows_t_matrix(tschuprows_matrix_input)
     assert torch.allclose(tm_score, reference_score)
+
+
+def test_tschuprows_t_nonzero_labels():
+    """Test that tschuprows_t works with non-zero-based category labels."""
+    preds = torch.tensor([5, 6, 5, 6, 5, 6, 5, 6])
+    target = torch.tensor([5, 6, 5, 5, 6, 6, 5, 6])
+    res = tschuprows_t(preds, target, bias_correction=False)
+    ref = _reference_pd_tschuprows_t(preds, target)
+    assert torch.allclose(res, ref)
+


### PR DESCRIPTION
## What does this PR do?

Fixes #3460

- Remaps unique categorical labels in functional nominal metrics (`cramers_v`, `pearsons_contingency_coefficient`, `theils_u`, `tschuprows_t`, and their `_matrix` versions) to contiguous 0-based indices before updating the confusion matrix.
- Casts `confmat` to float in `_compute_chi_squared` before applying Yates' continuity correction to prevent Long-to-Float in-place addition `RuntimeError`.
- Adds unit tests verifying behavior on non-zero-based category labels across all nominal metrics.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue?
- [x] Did you read the contributor guideline?
- [x] Did you write any new **necessary tests**?

</details>