### PR TITLE
Fix nominal metrics for non-zero-based category labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 
 
+- Fixed functional nominal metrics raising when category labels are not contiguous zero-based integers ([#3462](https://github.com/Lightning-AI/torchmetrics/pull/3462))
+
+
+- Fixed `cramers_v` and `tschuprows_t` raising on 2x2 inputs by no longer applying the bias correction in place ([#3462](https://github.com/Lightning-AI/torchmetrics/pull/3462))
+
+
 ---
 
 ## [1.9.0] - 2026-03-05

--- a/src/torchmetrics/functional/nominal/cramers.py
+++ b/src/torchmetrics/functional/nominal/cramers.py
@@ -25,6 +25,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_nominal_labels,
     _unable_to_use_bias_correction_warning,
 )
 
@@ -133,7 +134,7 @@ def cramers_v(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
+    preds, target, num_classes = _remap_nominal_labels(preds, target, nan_strategy, nan_replace_value)
     confmat = _cramers_v_update(preds, target, num_classes, nan_strategy, nan_replace_value)
     return _cramers_v_compute(confmat, bias_correction)
 
@@ -177,7 +178,7 @@ def cramers_v_matrix(
     cramers_v_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
+        x, y, num_classes = _remap_nominal_labels(x, y, nan_strategy, nan_replace_value)
         confmat = _cramers_v_update(x, y, num_classes, nan_strategy, nan_replace_value)
         cramers_v_matrix_value[i, j] = cramers_v_matrix_value[j, i] = _cramers_v_compute(confmat, bias_correction)
     return cramers_v_matrix_value

--- a/src/torchmetrics/functional/nominal/pearson.py
+++ b/src/torchmetrics/functional/nominal/pearson.py
@@ -24,6 +24,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_nominal_labels,
 )
 
 
@@ -123,7 +124,7 @@ def pearsons_contingency_coefficient(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
+    preds, target, num_classes = _remap_nominal_labels(preds, target, nan_strategy, nan_replace_value)
     confmat = _pearsons_contingency_coefficient_update(preds, target, num_classes, nan_strategy, nan_replace_value)
     return _pearsons_contingency_coefficient_compute(confmat)
 
@@ -167,7 +168,7 @@ def pearsons_contingency_coefficient_matrix(
     pearsons_cont_coef_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
+        x, y, num_classes = _remap_nominal_labels(x, y, nan_strategy, nan_replace_value)
         confmat = _pearsons_contingency_coefficient_update(x, y, num_classes, nan_strategy, nan_replace_value)
         val = _pearsons_contingency_coefficient_compute(confmat)
         pearsons_cont_coef_matrix_value[i, j] = pearsons_cont_coef_matrix_value[j, i] = val

--- a/src/torchmetrics/functional/nominal/theils_u.py
+++ b/src/torchmetrics/functional/nominal/theils_u.py
@@ -23,6 +23,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_nominal_labels,
 )
 
 
@@ -146,7 +147,7 @@ def theils_u(
         tensor(0.8530)
 
     """
-    num_classes = len(torch.cat([preds, target]).unique())
+    preds, target, num_classes = _remap_nominal_labels(preds, target, nan_strategy, nan_replace_value)
     confmat = _theils_u_update(preds, target, num_classes, nan_strategy, nan_replace_value)
     return _theils_u_compute(confmat)
 
@@ -188,7 +189,7 @@ def theils_u_matrix(
     theils_u_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
+        x, y, num_classes = _remap_nominal_labels(x, y, nan_strategy, nan_replace_value)
         confmat = _theils_u_update(x, y, num_classes, nan_strategy, nan_replace_value)
         theils_u_matrix_value[i, j] = _theils_u_compute(confmat)
         theils_u_matrix_value[j, i] = _theils_u_compute(confmat.T)

--- a/src/torchmetrics/functional/nominal/tschuprows.py
+++ b/src/torchmetrics/functional/nominal/tschuprows.py
@@ -25,6 +25,7 @@ from torchmetrics.functional.nominal.utils import (
     _drop_empty_rows_and_cols,
     _handle_nan_in_data,
     _nominal_input_validation,
+    _remap_nominal_labels,
     _unable_to_use_bias_correction_warning,
 )
 
@@ -139,7 +140,7 @@ def tschuprows_t(
 
     """
     _nominal_input_validation(nan_strategy, nan_replace_value)
-    num_classes = len(torch.cat([preds, target]).unique())
+    preds, target, num_classes = _remap_nominal_labels(preds, target, nan_strategy, nan_replace_value)
     confmat = _tschuprows_t_update(preds, target, num_classes, nan_strategy, nan_replace_value)
     return _tschuprows_t_compute(confmat, bias_correction)
 
@@ -185,7 +186,7 @@ def tschuprows_t_matrix(
     tschuprows_t_matrix_value = torch.ones(num_variables, num_variables, device=matrix.device)
     for i, j in itertools.combinations(range(num_variables), 2):
         x, y = matrix[:, i], matrix[:, j]
-        num_classes = len(torch.cat([x, y]).unique())
+        x, y, num_classes = _remap_nominal_labels(x, y, nan_strategy, nan_replace_value)
         confmat = _tschuprows_t_update(x, y, num_classes, nan_strategy, nan_replace_value)
         tschuprows_t_matrix_value[i, j] = tschuprows_t_matrix_value[j, i] = _tschuprows_t_compute(
             confmat, bias_correction

--- a/src/torchmetrics/functional/nominal/utils.py
+++ b/src/torchmetrics/functional/nominal/utils.py
@@ -53,7 +53,9 @@ def _compute_chi_squared(confmat: Tensor, bias_correction: bool) -> Tensor:
     if df == 1 and bias_correction:
         diff = expected_freqs - confmat
         direction = diff.sign()
-        confmat += direction * torch.minimum(0.5 * torch.ones_like(direction), direction.abs())
+        # not in-place: ``confmat`` may be an integer tensor, which cannot hold the float correction, and the caller
+        # should not observe its input being mutated
+        confmat = confmat + direction * torch.minimum(0.5 * torch.ones_like(direction), direction.abs())
 
     return torch.sum((confmat - expected_freqs) ** 2 / expected_freqs)
 
@@ -138,6 +140,42 @@ def _handle_nan_in_data(
         return preds.nan_to_num(nan_replace_value), target.nan_to_num(nan_replace_value)
     rows_contain_nan = torch.logical_or(preds.isnan(), target.isnan())
     return preds[~rows_contain_nan], target[~rows_contain_nan]
+
+
+def _remap_nominal_labels(
+    preds: Tensor,
+    target: Tensor,
+    nan_strategy: Literal["replace", "drop"] = "replace",
+    nan_replace_value: Optional[float] = 0.0,
+) -> tuple[Tensor, Tensor, int]:
+    """Map categorical labels onto contiguous zero-based indices.
+
+    The nominal metrics bin their inputs into a ``num_classes x num_classes`` confusion matrix, which requires the
+    category labels to be exactly ``0, ..., num_classes - 1``. Categorical data is frequently encoded differently, for
+    example as ``[1, 2]`` or ``[5, 6]``, which would otherwise index outside the matrix. Categories are ranked by
+    sorted order, so inputs that are already zero-based and contiguous are left unchanged.
+
+    Args:
+        preds: 1D or 2D tensor of categorical (nominal) data
+        target: 1D or 2D tensor of categorical (nominal) data
+        nan_strategy: Indication of whether to replace or drop ``NaN`` values
+        nan_replace_value: Value to replace ``NaN``s when ``nan_strategy = 'replace'``
+
+    Returns:
+        Remapped ``preds`` and ``target`` tensors, and the number of distinct categories across both
+
+    Example:
+        >>> from torch import tensor
+        >>> from torchmetrics.functional.nominal.utils import _remap_nominal_labels
+        >>> _remap_nominal_labels(tensor([5, 6, 5]), tensor([6, 6, 5]))
+        (tensor([0, 1, 0]), tensor([1, 1, 0]), 2)
+
+    """
+    preds = preds.argmax(1) if preds.ndim == 2 else preds
+    target = target.argmax(1) if target.ndim == 2 else target
+    preds, target = _handle_nan_in_data(preds, target, nan_strategy, nan_replace_value)
+    classes = torch.cat([preds, target]).unique()
+    return torch.bucketize(preds, classes), torch.bucketize(target, classes), classes.numel()
 
 
 def _unable_to_use_bias_correction_warning(metric_name: str) -> None:

--- a/tests/unittests/nominal/test_nominal_label_encoding.py
+++ b/tests/unittests/nominal/test_nominal_label_encoding.py
@@ -1,0 +1,141 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Nominal metrics must not depend on how the categories happen to be encoded.
+
+Categorical data carries no inherent ordering or origin, so relabelling the categories consistently across ``preds``
+and ``target`` must leave every nominal statistic unchanged. Before the fix for
+https://github.com/Lightning-AI/torchmetrics/issues/3460 the functional metrics passed the raw labels straight to the
+confusion matrix update, which requires them to be exactly ``0, ..., num_classes - 1``, so anything else raised.
+
+"""
+
+import pytest
+import torch
+
+from torchmetrics.functional.nominal import (
+    cramers_v,
+    cramers_v_matrix,
+    pearsons_contingency_coefficient,
+    pearsons_contingency_coefficient_matrix,
+    theils_u,
+    theils_u_matrix,
+    tschuprows_t,
+    tschuprows_t_matrix,
+)
+from torchmetrics.functional.nominal.utils import _compute_chi_squared
+
+NUM_CLASSES = 4
+NUM_SAMPLES = 200
+
+METRICS = [
+    pytest.param(cramers_v, id="cramers_v"),
+    pytest.param(pearsons_contingency_coefficient, id="pearsons_contingency_coefficient"),
+    pytest.param(theils_u, id="theils_u"),
+    pytest.param(tschuprows_t, id="tschuprows_t"),
+]
+
+MATRIX_METRICS = [
+    pytest.param(cramers_v_matrix, id="cramers_v_matrix"),
+    pytest.param(pearsons_contingency_coefficient_matrix, id="pearsons_contingency_coefficient_matrix"),
+    pytest.param(theils_u_matrix, id="theils_u_matrix"),
+    pytest.param(tschuprows_t_matrix, id="tschuprows_t_matrix"),
+]
+
+# each maps the zero-based labels ``0, ..., NUM_CLASSES - 1`` onto a different encoding of the same categories
+RELABELLINGS = [
+    pytest.param([5, 6, 7, 8], id="offset"),
+    pytest.param([1, 2, 3, 4], id="one_based"),
+    pytest.param([0, 2, 7, 9], id="non_contiguous"),
+    pytest.param([-3, -1, 1, 3], id="negative"),
+    pytest.param([2, 0, 3, 1], id="permuted"),
+]
+
+
+def _zero_based_input():
+    """Return a reproducible pair of zero-based categorical vectors with a non-trivial association."""
+    generator = torch.Generator().manual_seed(42)
+    preds = torch.randint(high=NUM_CLASSES, size=(NUM_SAMPLES,), generator=generator)
+    # make target correlated with preds so the statistics are not degenerate
+    noise = torch.randint(high=2, size=(NUM_SAMPLES,), generator=generator)
+    target = (preds + noise) % NUM_CLASSES
+    return preds, target
+
+
+def _relabel(tensor: torch.Tensor, mapping: list) -> torch.Tensor:
+    """Replace each zero-based label with its counterpart in ``mapping``."""
+    return torch.tensor(mapping, dtype=torch.long)[tensor]
+
+
+@pytest.mark.parametrize("metric", METRICS)
+@pytest.mark.parametrize("mapping", RELABELLINGS)
+def test_functional_metric_is_invariant_to_label_encoding(metric, mapping):
+    """Relabelling the categories must not change the statistic."""
+    preds, target = _zero_based_input()
+    expected = metric(preds, target)
+    actual = metric(_relabel(preds, mapping), _relabel(target, mapping))
+    assert torch.allclose(actual, expected), f"{expected} != {actual} for mapping {mapping}"
+
+
+@pytest.mark.parametrize("metric", MATRIX_METRICS)
+@pytest.mark.parametrize("mapping", RELABELLINGS)
+def test_matrix_metric_is_invariant_to_label_encoding(metric, mapping):
+    """The matrix variants must be invariant to the encoding as well."""
+    preds, target = _zero_based_input()
+    matrix = torch.stack([preds, target], dim=-1)
+    expected = metric(matrix)
+    actual = metric(_relabel(matrix, mapping))
+    assert torch.allclose(actual, expected, equal_nan=True)
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_functional_metric_accepts_float_labels(metric):
+    """Float-encoded categories are supported and agree with their integer counterpart."""
+    preds, target = _zero_based_input()
+    expected = metric(preds, target)
+    actual = metric(preds.float(), target.float())
+    assert torch.allclose(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "metric", [pytest.param(cramers_v, id="cramers_v"), pytest.param(tschuprows_t, id="tschuprows_t")]
+)
+@pytest.mark.parametrize("bias_correction", [True, False])
+def test_binary_input_with_bias_correction(metric, bias_correction):
+    """Binary inputs produce a 2x2 table, the only case that triggers the bias correction branch.
+
+    The correction adds a float offset to the confusion matrix, which is integer-typed on the functional path, so
+    doing it in place raised ``RuntimeError: result type Float can't be cast to the desired output type Long``.
+
+    """
+    preds = torch.tensor([0, 1, 0, 1, 0, 1, 0, 1])
+    target = torch.tensor([0, 1, 0, 0, 1, 1, 0, 1])
+    value = metric(preds, target, bias_correction=bias_correction)
+    assert torch.isfinite(value) or torch.isnan(value)
+
+
+def test_compute_chi_squared_does_not_mutate_input():
+    """The bias correction must not write into the confusion matrix it is handed."""
+    confmat = torch.tensor([[3.0, 1.0], [1.0, 3.0]])
+    original = confmat.clone()
+    _compute_chi_squared(confmat, bias_correction=True)
+    assert torch.equal(confmat, original)
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_functional_metric_raises_nothing_on_single_category(metric):
+    """A single observed category is degenerate but must not raise."""
+    preds = torch.full((NUM_SAMPLES,), 7)
+    target = torch.full((NUM_SAMPLES,), 7)
+    value = metric(preds, target)
+    assert value.numel() == 1


### PR DESCRIPTION
## What does this PR do?

Fixes #3460

The functional nominal metrics infer `num_classes` from the number of distinct values but pass the **raw** labels to `_multiclass_confusion_matrix_update`, which requires them to be exactly `0, ..., num_classes - 1`. Any other encoding indexes outside the matrix and raises during binning:

```python
cramers_v(torch.tensor([5, 6, 5, 6]), torch.tensor([5, 6, 5, 5]))
# RuntimeError: shape '[2, 2]' is invalid for input of size 19
```

### Second bug found while reproducing

`_compute_chi_squared` applies the bias correction **in place**:

```python
confmat += direction * torch.minimum(...)
```

On the functional path `confmat` is integer-typed, so the float correction raises regardless of how the labels are encoded. This branch is reached whenever `df == 1`, i.e. for **every 2x2 contingency table**, which means `cramers_v` and `tschuprows_t` fail on binary inputs even with perfectly valid zero-based labels:

```python
cramers_v(torch.tensor([0, 1, 0, 1]), torch.tensor([0, 1, 0, 0]))
# RuntimeError: result type Float can't be cast to the desired output type Long
```

The in-place write also mutated the caller's tensor, which is why the class-based metrics — whose `confmat` state is float — were unaffected but would have had their state silently modified.

## Changes

- Add `_remap_nominal_labels` in `functional/nominal/utils.py`: handles NaNs first, then ranks the observed categories onto contiguous zero-based indices via `torch.bucketize` and returns the resulting `num_classes`. Ranking is by sorted order, so inputs that are already zero-based and contiguous are returned unchanged.
- Use it in `cramers_v`, `pearsons_contingency_coefficient`, `theils_u`, `tschuprows_t` and their four `_matrix` variants (8 call sites).
- Make the bias correction in `_compute_chi_squared` out-of-place.
- Add `tests/unittests/nominal/test_nominal_label_encoding.py`.

### Scope: functional API only

The class-based metrics (`CramersV`, `TschuprowsT`, …) take `num_classes` in `__init__`, allocate a fixed `num_classes x num_classes` state, and accumulate `self.confmat += confmat` across batches. Remapping per batch would map different raw labels onto the same index in different batches and silently corrupt the accumulated matrix, so their existing contract — callers pass zero-based labels — is deliberately left alone. This matches the issue title.

## Tests

New file parametrises all four metrics and their matrix variants across five relabellings (offset, one-based, non-contiguous, negative, permuted), plus float labels, the 2x2 bias-correction regression, non-mutation of the input confmat, and the single-category edge case.

Verified the tests actually catch the bug — against the unpatched source:

```
$ pytest tests/unittests/nominal/test_nominal_label_encoding.py -q
39 failed, 14 passed in 4.58s
```

With the fix:

```
$ pytest tests/unittests/nominal/test_nominal_label_encoding.py -q
53 passed, 2 warnings in 2.86s
```

Full nominal suite, unchanged from the pre-patch baseline of 104 (104 existing + 53 new):

```
$ pytest tests/unittests/nominal -q
157 passed, 298 warnings in 21.59s
```

Doctests, lint and types:

```
$ pytest --doctest-modules src/torchmetrics/functional/nominal -q
11 passed, 1 warning in 5.93s

$ ruff check src/torchmetrics/functional/nominal tests/unittests/nominal
All checks passed!

$ ruff format --check src/torchmetrics/functional/nominal tests/unittests/nominal
14 files already formatted

$ mypy src/torchmetrics/functional/nominal/utils.py src/torchmetrics/functional/nominal/cramers.py
Success: no issues found in 2 source files
```

Values are unchanged for already-valid inputs — the existing 104 tests compare against the `dython` reference implementation and still pass, and the new invariance tests assert that a relabelled input produces exactly the same statistic as its zero-based original.

## Note

`theils_u` is the only one of the four that never calls `_nominal_input_validation`, so an invalid `nan_strategy` passes through it silently. Left alone as out of scope — happy to fix it here or in a follow-up if you'd like.

## Before submitting

- [x] Was this **discussed/agreed** via a GitHub issue? (#3460)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure to **update the docs**? (docstring for the new helper)
- [x] Did you write any new **necessary tests**?
