### PR TITLE
Do not import scipy.signal and matplotlib at package import time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Stopped importing `scipy.signal` and `matplotlib` at `import torchmetrics` time, resolving both on first use instead ([#3463](https://github.com/Lightning-AI/torchmetrics/pull/3463))
 
 
 ### Deprecated

--- a/src/torchmetrics/__init__.py
+++ b/src/torchmetrics/__init__.py
@@ -27,13 +27,6 @@ if package_available("PIL"):
     if not hasattr(PIL, "PILLOW_VERSION"):
         PIL.PILLOW_VERSION = PIL.__version__
 
-if package_available("scipy"):
-    import scipy.signal
-
-    # back compatibility patch due to SMRMpy using scipy.signal.hamming
-    if not hasattr(scipy.signal, "hamming"):
-        scipy.signal.hamming = scipy.signal.windows.hamming
-
 from torchmetrics import functional  # noqa: E402
 from torchmetrics.aggregation import (  # noqa: E402
     CatMetric,

--- a/src/torchmetrics/audio/__init__.py
+++ b/src/torchmetrics/audio/__init__.py
@@ -29,16 +29,8 @@ from torchmetrics.utilities.imports import (
     _PESQ_AVAILABLE,
     _PYSTOI_AVAILABLE,
     _REQUESTS_AVAILABLE,
-    _SCIPI_AVAILABLE,
     _TORCHAUDIO_AVAILABLE,
 )
-
-if _SCIPI_AVAILABLE:
-    import scipy.signal
-
-    # back compatibility patch due to SMRMpy using scipy.signal.hamming
-    if not hasattr(scipy.signal, "hamming"):
-        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "ComplexScaleInvariantSignalNoiseRatio",

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -26,7 +26,7 @@ from torchmetrics.metric import Metric
 from torchmetrics.utilities import rank_zero_warn
 from torchmetrics.utilities.data import _flatten, _flatten_dict, allclose
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
-from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE, plot_single_or_multi_val
+from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE, _is_axes, plot_single_or_multi_val
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["MetricCollection.plot", "MetricCollection.plot_all"]
@@ -706,12 +706,12 @@ class MetricCollection(ModuleDict):
         if not isinstance(together, bool):
             raise ValueError(f"Expected argument `together` to be a boolean, but got {type(together)}")
         if ax is not None:
-            if together and not isinstance(ax, _AX_TYPE):
+            if together and not _is_axes(ax):
                 raise ValueError(
                     f"Expected argument `ax` to be a matplotlib axis object, but got {type(ax)} when `together=True`"
                 )
             if not together and not (
-                isinstance(ax, Sequence) and all(isinstance(a, _AX_TYPE) for a in ax) and len(ax) == len(self)
+                isinstance(ax, Sequence) and all(_is_axes(a) for a in ax) and len(ax) == len(self)
             ):
                 raise ValueError(
                     f"Expected argument `ax` to be a sequence of matplotlib axis objects with the same length as the "

--- a/src/torchmetrics/functional/audio/__init__.py
+++ b/src/torchmetrics/functional/audio/__init__.py
@@ -29,16 +29,8 @@ from torchmetrics.utilities.imports import (
     _PESQ_AVAILABLE,
     _PYSTOI_AVAILABLE,
     _REQUESTS_AVAILABLE,
-    _SCIPI_AVAILABLE,
     _TORCHAUDIO_AVAILABLE,
 )
-
-if _SCIPI_AVAILABLE:
-    import scipy.signal
-
-    # back compatibility patch due to SMRMpy using scipy.signal.hamming
-    if not hasattr(scipy.signal, "hamming"):
-        scipy.signal.hamming = scipy.signal.windows.hamming
 
 __all__ = [
     "complex_scale_invariant_signal_noise_ratio",

--- a/src/torchmetrics/utilities/plot.py
+++ b/src/torchmetrics/utilities/plot.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Generator, Sequence
+from contextlib import contextmanager
 from itertools import product
 from math import ceil, floor, sqrt
-from typing import Any, List, Optional, Union, no_type_check
+from typing import TYPE_CHECKING, Any, List, Optional, Union, no_type_check
 
 import numpy as np
 import torch
@@ -22,7 +23,7 @@ from torch import Tensor
 
 from torchmetrics.utilities.imports import _LATEX_AVAILABLE, _MATPLOTLIB_AVAILABLE, _SCIENCEPLOT_AVAILABLE
 
-if _MATPLOTLIB_AVAILABLE:
+if TYPE_CHECKING:
     import matplotlib
     import matplotlib.axes
     import matplotlib.pyplot as plt
@@ -30,27 +31,46 @@ if _MATPLOTLIB_AVAILABLE:
     _PLOT_OUT_TYPE = tuple[plt.Figure, Union[matplotlib.axes.Axes, np.ndarray]]
     _AX_TYPE = matplotlib.axes.Axes
     _CMAP_TYPE = Union[matplotlib.colors.Colormap, str]
-
-    style_change = plt.style.context
 else:
-    _PLOT_OUT_TYPE = tuple[object, object]  # type: ignore[misc]
+    # `matplotlib` is resolved on first use instead of at import: pulling it in eagerly costs roughly a second of
+    # `import torchmetrics` for everyone, including those who never plot. The ~140 modules that annotate with these
+    # aliases never introspect the annotations at runtime, so plain `object` is enough outside of type checking.
+    _PLOT_OUT_TYPE = tuple[object, object]
     _AX_TYPE = object
-    _CMAP_TYPE = object  # type: ignore[misc]
+    _CMAP_TYPE = object
 
-    from contextlib import contextmanager
+_style = ["science"] if _SCIENCEPLOT_AVAILABLE and _LATEX_AVAILABLE else ["default"]
 
-    @contextmanager
-    def style_change(*args: Any, **kwargs: Any) -> Generator:
-        """No-ops decorator if matplotlib is not installed."""
+
+@contextmanager
+def style_change(*args: Any, **kwargs: Any) -> Generator:
+    """Apply a ``matplotlib`` style, no-op if ``matplotlib`` is not installed."""
+    if not _MATPLOTLIB_AVAILABLE:
+        yield
+        return
+
+    import matplotlib.pyplot as plt
+
+    if _SCIENCEPLOT_AVAILABLE:
+        import scienceplots  # noqa: F401  # registers the "science" style on import
+
+    with plt.style.context(*args, **kwargs):
         yield
 
 
-if _SCIENCEPLOT_AVAILABLE:
-    import scienceplots  # noqa: F401
+def _is_axes(obj: Any) -> bool:
+    """Check whether ``obj`` is a ``matplotlib`` ``Axes``.
 
-    _style = ["science", "no-latex"]
+    The ``_AX_TYPE`` alias is only a real class while type checking, so it cannot be used with ``isinstance``. This
+    resolves the actual class instead, importing ``matplotlib`` only when there is something plausible to check.
 
-_style = ["science"] if _SCIENCEPLOT_AVAILABLE and _LATEX_AVAILABLE else ["default"]
+    """
+    if not _MATPLOTLIB_AVAILABLE:
+        return False
+
+    import matplotlib.axes
+
+    return isinstance(obj, matplotlib.axes.Axes)
 
 
 def _error_on_missing_matplotlib() -> None:
@@ -93,6 +113,8 @@ def plot_single_or_multi_val(
 
     """
     _error_on_missing_matplotlib()
+    import matplotlib.pyplot as plt
+
     fig, ax = plt.subplots() if ax is None else (None, ax)
     ax.get_xaxis().set_visible(False)
 
@@ -201,13 +223,13 @@ def _get_text_color(patch_color: tuple[float, float, float, float]) -> str:
     return ".1" if y > 0.4 else "white"
 
 
-def trim_axs(axs: Union[_AX_TYPE, np.ndarray], nb: int) -> Union[np.ndarray, _AX_TYPE]:  # type: ignore[valid-type]
+def trim_axs(axs: Union[_AX_TYPE, np.ndarray], nb: int) -> Union[np.ndarray, _AX_TYPE]:
     """Reduce `axs` to `nb` Axes.
 
     All further Axes are removed from the figure.
 
     """
-    if isinstance(axs, _AX_TYPE):
+    if _is_axes(axs):
         return axs
 
     axs = axs.flat  # type: ignore[union-attr]
@@ -248,6 +270,7 @@ def plot_confusion_matrix(
 
     """
     _error_on_missing_matplotlib()
+    import matplotlib.pyplot as plt
 
     if confmat.ndim == 3:  # multilabel
         nb, n_classes = confmat.shape[0], 2
@@ -297,7 +320,7 @@ def plot_confusion_matrix(
 def plot_curve(
     curve: Union[tuple[Tensor, Tensor, Tensor], tuple[List[Tensor], List[Tensor], List[Tensor]]],
     score: Optional[Tensor] = None,
-    ax: Optional[_AX_TYPE] = None,  # type: ignore[valid-type]
+    ax: Optional[_AX_TYPE] = None,
     label_names: Optional[tuple[str, str]] = None,
     legend_name: Optional[str] = None,
     name: Optional[str] = None,
@@ -331,6 +354,8 @@ def plot_curve(
     x, y = curve[:2]
 
     _error_on_missing_matplotlib()
+    import matplotlib.pyplot as plt
+
     fig, ax = plt.subplots() if ax is None else (None, ax)
 
     if isinstance(x, Tensor) and isinstance(y, Tensor) and x.ndim == 1 and y.ndim == 1:

--- a/src/torchmetrics/wrappers/multitask.py
+++ b/src/torchmetrics/wrappers/multitask.py
@@ -21,7 +21,7 @@ from torch import Tensor, nn
 from torchmetrics.collections import MetricCollection
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
-from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE, _is_axes
 from torchmetrics.wrappers.abstract import WrapperMetric
 
 if not _MATPLOTLIB_AVAILABLE:
@@ -358,7 +358,7 @@ class MultitaskWrapper(WrapperMetric):
             if not isinstance(axes, Sequence):
                 raise TypeError(f"Expected argument `axes` to be a Sequence. Found type(axes) = {type(axes)}")
 
-            if not all(isinstance(ax, _AX_TYPE) for ax in axes):
+            if not all(_is_axes(ax) for ax in axes):
                 raise TypeError("Expected each ax in argument `axes` to be a matplotlib axis object")
 
             if len(axes) != len(self.task_metrics):

--- a/tests/unittests/audio/test_srmr.py
+++ b/tests/unittests/audio/test_srmr.py
@@ -15,9 +15,16 @@ from functools import partial
 from typing import Any
 
 import pytest
+import scipy.signal
 import torch
-from srmrpy import srmr as srmrpy_srmr
 from torch import Tensor
+
+# back compatibility patch due to SRMRpy using `scipy.signal.hamming`, which was removed in scipy 1.13. Applied here
+# rather than in `torchmetrics/__init__.py` so that importing torchmetrics does not pull in scipy, see #3457.
+if not hasattr(scipy.signal, "hamming"):
+    scipy.signal.hamming = scipy.signal.windows.hamming
+
+from srmrpy import srmr as srmrpy_srmr
 
 from torchmetrics.audio.srmr import SpeechReverberationModulationEnergyRatio
 from torchmetrics.functional.audio.srmr import speech_reverberation_modulation_energy_ratio

--- a/tests/unittests/utilities/test_lazy_imports.py
+++ b/tests/unittests/utilities/test_lazy_imports.py
@@ -1,0 +1,120 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Optional heavy dependencies must not be imported just because they happen to be installed.
+
+`import torchmetrics` is on the critical path for downstream libraries — Lightning imports it merely to compare
+versions — so eagerly pulling in plotting or signal-processing stacks costs every user, including those who never
+touch the features that need them. See https://github.com/Lightning-AI/torchmetrics/issues/3457.
+
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE, _SCIPI_AVAILABLE
+
+# checked in a subprocess: the test session itself has already imported large parts of the world
+_PROBE = (
+    "import sys, torchmetrics; "
+    "print(','.join(m for m in ('scipy.signal', 'matplotlib', 'matplotlib.pyplot') if m in sys.modules))"
+)
+
+
+def _modules_after_importing_torchmetrics() -> set:
+    """Return the probed optional modules that a bare ``import torchmetrics`` pulled in."""
+    # S603 is suppressed below: the interpreter path and the probe are fixed literals, no external input is involved
+    out = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _PROBE], capture_output=True, text=True, check=True
+    )
+    return {name for name in out.stdout.strip().split(",") if name}
+
+
+@pytest.mark.skipif(not _SCIPI_AVAILABLE, reason="test only meaningful when scipy is installed")
+def test_importing_torchmetrics_does_not_import_scipy_signal():
+    """`scipy.signal` was only pulled in by the SRMRpy back-compat patch, which no longer runs at import.
+
+    Asserted on `scipy.signal` rather than `scipy` on purpose: when `transformers` is installed,
+    `functional/text/bert.py` imports it at module level and that pulls in `scipy.sparse`. That is a separate eager
+    import from the one this test guards, so asserting on the `scipy` root would make this test fail for an unrelated
+    reason.
+
+    """
+    loaded = _modules_after_importing_torchmetrics()
+    assert "scipy.signal" not in loaded, f"`import torchmetrics` pulled in {sorted(loaded)}"
+
+
+@pytest.mark.skipif(not _MATPLOTLIB_AVAILABLE, reason="test only meaningful when matplotlib is installed")
+def test_importing_torchmetrics_does_not_import_matplotlib():
+    """`matplotlib` is only needed by ``.plot()``, which most users never call."""
+    loaded = _modules_after_importing_torchmetrics()
+    assert "matplotlib" not in loaded, f"`import torchmetrics` pulled in {sorted(loaded)}"
+    assert "matplotlib.pyplot" not in loaded
+
+
+@pytest.mark.skipif(not _MATPLOTLIB_AVAILABLE, reason="requires matplotlib")
+def test_plot_type_aliases_are_defined_at_runtime():
+    """The aliases are annotations on ~140 metrics, so they must still resolve without matplotlib loaded."""
+    from torchmetrics.utilities.plot import _AX_TYPE, _CMAP_TYPE, _PLOT_OUT_TYPE
+
+    assert _AX_TYPE is not None
+    assert _CMAP_TYPE is not None
+    assert _PLOT_OUT_TYPE is not None
+
+
+@pytest.mark.skipif(not _MATPLOTLIB_AVAILABLE, reason="requires matplotlib")
+def test_is_axes_discriminates_real_axes():
+    """``_AX_TYPE`` is ``object`` at runtime, so ``isinstance(x, _AX_TYPE)`` would match anything.
+
+    Several call sites branch on whether an argument is a real ``Axes`` — ``trim_axs``, ``MetricCollection.plot`` and
+    ``MultitaskWrapper.plot``. They must use ``_is_axes``, otherwise the checks silently pass for every input:
+    validation stops raising and ``trim_axs`` returns the untrimmed array.
+
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from torchmetrics.utilities.plot import _AX_TYPE, _is_axes
+
+    _, ax = plt.subplots()
+    _, axs = plt.subplots(nrows=2, ncols=2)
+
+    assert _is_axes(ax)
+    assert not _is_axes(axs)  # an ndarray of axes, not an Axes
+    assert not _is_axes("not an axis")
+    assert not _is_axes(None)
+
+    # the alias itself must not be used for this: every object is an instance of `object`
+    assert isinstance("not an axis", _AX_TYPE)
+
+    plt.close("all")
+
+
+def test_style_change_works_as_context_manager_and_decorator():
+    """``style_change`` is applied as a decorator at import time, so it must not need matplotlib to be constructed."""
+    from torchmetrics.utilities.plot import _style, style_change
+
+    with style_change(_style):
+        pass
+
+    @style_change(_style)
+    def _fn() -> str:
+        return "ok"
+
+    # a context manager used as a decorator must survive being called more than once
+    assert _fn() == "ok"
+    assert _fn() == "ok"

--- a/tests/unittests/utilities/test_lazy_imports.py
+++ b/tests/unittests/utilities/test_lazy_imports.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Optional heavy dependencies must not be imported just because they happen to be installed.
 
-`import torchmetrics` is on the critical path for downstream libraries — Lightning imports it merely to compare
-versions — so eagerly pulling in plotting or signal-processing stacks costs every user, including those who never
-touch the features that need them. See https://github.com/Lightning-AI/torchmetrics/issues/3457.
+`import torchmetrics` is on the critical path for downstream libraries — Lightning imports it merely to compare versions
+— so eagerly pulling in plotting or signal-processing stacks costs every user, including those who never touch the
+features that need them. See
+https://github.com/Lightning-AI/torchmetrics/issues/3457.
 
 """
 


### PR DESCRIPTION
## What does this PR do?

Refs #3457 — the `scipy.signal` and `matplotlib` halves. Leaves the `torchvision`/arniqa half to #3432 to avoid conflicting.

`import torchmetrics` pulled in two optional stacks that nothing on the import path uses. This sits on the critical path for downstream libraries — Lightning imports torchmetrics only to compare versions — so everyone paid for it, including users who never plot or touch audio metrics.

### `scipy.signal`

Came from the SRMRpy `hamming` back-compat patch, duplicated across three eagerly executed `__init__.py` files. `srmrpy` is only ever imported by `tests/unittests/audio/test_srmr.py` — the library reimplements SRMR in pure PyTorch and never imports it — so the patch moves into that test module.

### `matplotlib`

Came from `utilities/plot.py`, which imported it at module level purely to build the `_AX_TYPE` / `_PLOT_OUT_TYPE` / `_CMAP_TYPE` annotation aliases and to alias `style_change = plt.style.context`. The aliases now resolve to the real classes under `TYPE_CHECKING` and to `object` at runtime, and `style_change` imports `pyplot` on first use.

I kept runtime `object` fallbacks rather than making the aliases `TYPE_CHECKING`-only, because that would require `from __future__ import annotations` in the ~140 modules that annotate with them. This way the diff stays inside `plot.py` (plus the two call sites below).

### The subtle part

Once the aliases stop being real classes at runtime, `isinstance(x, _AX_TYPE)` becomes `isinstance(x, object)` — **always true**. Four places relied on that check:

| Location | What silently broke |
|---|---|
| `plot.py` `trim_axs` | returned the untrimmed axes array instead of flattening and trimming |
| `collections.py` ×2 | `MetricCollection.plot` argument validation stopped raising |
| `wrappers/multitask.py` | `MultitaskWrapper.plot` argument validation stopped raising |

The `trim_axs` one was caught by `test_confusion_matrix_plotter[multilabel confusion matrix]` failing with `AttributeError: 'numpy.ndarray' object has no attribute 'set_title'`. All four now go through a new `_is_axes` helper that resolves the actual class, and there is a regression test pinning the behaviour.

## Measurements

`import torchmetrics`, median of 5 cold subprocesses, Python 3.13 / Windows:

**With only scipy and matplotlib installed** — the configuration this PR targets:

| | master | this PR |
|---|---|---|
| wall time | 5559 ms | **3571 ms** (−36%) |
| `sys.modules` | 2158 | **1371** (−787) |
| heavy modules loaded | `scipy.signal`, `matplotlib.pyplot` | none |

**With `transformers` and `torchvision` also installed**, where other eager imports dominate:

| | master | this PR |
|---|---|---|
| wall time | 15686 ms | 14426 ms (−8%) |
| `sys.modules` | 3947 | 3776 (−171) |
| heavy modules loaded | `scipy.signal`, `matplotlib.pyplot`, `torchvision` | `torchvision` |

## Tests

New `tests/unittests/utilities/test_lazy_imports.py` checks in a subprocess that a bare `import torchmetrics` leaves `scipy.signal` and `matplotlib` out of `sys.modules`, that the aliases still resolve at runtime, that `style_change` works as both a context manager and a repeatable decorator, and that `_is_axes` discriminates where the alias cannot.

```
$ MPLBACKEND=Agg pytest tests/unittests/utilities -q
6 failed, 371 passed, 8 skipped in 171.62s
```

All 6 failures are missing optional packages locally (`pesq`, `gammatone`, `pycocotools`) and are identical on unpatched `master`:

```
$ git stash && MPLBACKEND=Agg pytest tests/unittests/utilities -q
9 failed, 368 passed, 8 skipped in 110.95s
```

— the 3 extra being this PR's own new tests, which correctly fail without the fix.

Lint and types, compared against `master` for the same files:

```
$ ruff check <changed files>
3 errors  (RUF059 ×3 — all pre-existing, identical on master)

$ ruff format --check <changed files>
5 files already formatted

$ mypy src/torchmetrics/utilities/plot.py src/torchmetrics/collections.py src/torchmetrics/wrappers/multitask.py
Found 11 errors   (master: 16 — the TYPE_CHECKING types let mypy resolve more, net -5)
```

## One thing found along the way, not fixed here

When `transformers` is installed, `import torchmetrics` still pulls in `scipy` — but via a different path than this issue describes:

```
torchmetrics/__init__.py
  → functional/__init__.py:129
    → functional/text/__init__.py:50
      → functional/text/bert.py:56  →  from transformers import AutoModel, AutoTokenizer
```

`bert.py` imports `transformers` at module level, which pulls in `scipy.sparse` (and a lot more). That is a separate eager import from the SRMRpy one, so I left it alone and scoped the regression test to `scipy.signal` accordingly — asserting on the `scipy` root would make the test fail for an unrelated reason. Happy to open a follow-up issue if that is worth tracking.

## Before submitting

- [x] Was this **discussed/agreed** via a GitHub issue? (#3457)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure to **update the docs**? (docstrings on the new helpers)
- [x] Did you write any new **necessary tests**?
