### PR TITLE
Preserve input dtype in spearman_corrcoef and kendall_rank_corrcoef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
 
 
+- Fixed `spearman_corrcoef` and `kendall_rank_corrcoef` silently returning `float32` for `float64` inputs ([#3466](https://github.com/Lightning-AI/torchmetrics/pull/3466))
+
+
 ---
 
 ## [1.9.0] - 2026-03-05

--- a/src/torchmetrics/functional/regression/kendall.py
+++ b/src/torchmetrics/functional/regression/kendall.py
@@ -71,8 +71,7 @@ def _count_concordant_pairs(preds: Tensor, target: Tensor) -> Tensor:
 def _discordant_element_sum(x: Tensor, y: Tensor, i: int) -> Tensor:
     """Count a total number of discordant pairs in a single sequences."""
     return (
-        torch
-        .logical_or(
+        torch.logical_or(
             torch.logical_and(x[i] > x[(i + 1) :], y[i] < y[(i + 1) :]),
             torch.logical_and(x[i] < x[(i + 1) :], y[i] > y[(i + 1) :]),
         )

--- a/src/torchmetrics/functional/regression/kendall.py
+++ b/src/torchmetrics/functional/regression/kendall.py
@@ -71,7 +71,8 @@ def _count_concordant_pairs(preds: Tensor, target: Tensor) -> Tensor:
 def _discordant_element_sum(x: Tensor, y: Tensor, i: int) -> Tensor:
     """Count a total number of discordant pairs in a single sequences."""
     return (
-        torch.logical_or(
+        torch
+        .logical_or(
             torch.logical_and(x[i] > x[(i + 1) :], y[i] < y[(i + 1) :]),
             torch.logical_and(x[i] < x[(i + 1) :], y[i] > y[(i + 1) :]),
         )
@@ -161,21 +162,24 @@ def _calculate_tau(
     variant: _MetricVariant,
 ) -> Tensor:
     """Calculate Kendall's tau from metric metadata."""
+    # the pair and tie counts are integer tensors, so dividing them would fall back to the global default dtype and
+    # silently downcast a float64 input; float16/bfloat16 are promoted to float32 for the accumulation
+    dtype = torch.promote_types(preds.dtype, torch.float32)
+    con_min_dis_pairs = con_min_dis_pairs.to(dtype)
+
     if variant == _MetricVariant.A:
-        return con_min_dis_pairs / (concordant_pairs + discordant_pairs)
+        return con_min_dis_pairs / (concordant_pairs + discordant_pairs).to(dtype)
     if variant == _MetricVariant.B:
-        total_combinations: Tensor = n_total * (n_total - 1) // 2
-        if preds_ties is None:
-            preds_ties = torch.tensor(0.0, dtype=total_combinations.dtype, device=total_combinations.device)
-        if target_ties is None:
-            target_ties = torch.tensor(0.0, dtype=total_combinations.dtype, device=total_combinations.device)
+        total_combinations: Tensor = (n_total * (n_total - 1) // 2).to(dtype)
+        preds_ties = total_combinations.new_zeros(()) if preds_ties is None else preds_ties.to(dtype)
+        target_ties = total_combinations.new_zeros(()) if target_ties is None else target_ties.to(dtype)
         denominator = (total_combinations - preds_ties) * (total_combinations - target_ties)
         return con_min_dis_pairs / torch.sqrt(denominator)
 
-    preds_unique = torch.tensor([len(p.unique()) for p in preds.T], dtype=preds.dtype, device=preds.device)
-    target_unique = torch.tensor([len(t.unique()) for t in target.T], dtype=target.dtype, device=target.device)
+    preds_unique = torch.tensor([len(p.unique()) for p in preds.T], dtype=dtype, device=preds.device)
+    target_unique = torch.tensor([len(t.unique()) for t in target.T], dtype=dtype, device=target.device)
     min_classes = torch.minimum(preds_unique, target_unique)
-    return 2 * con_min_dis_pairs / ((min_classes - 1) / min_classes * n_total**2)
+    return 2 * con_min_dis_pairs / ((min_classes - 1) / min_classes * n_total.to(dtype) ** 2)
 
 
 def _get_p_value_for_t_value_from_dist(t_value: Tensor) -> Tensor:

--- a/src/torchmetrics/functional/regression/spearman.py
+++ b/src/torchmetrics/functional/regression/spearman.py
@@ -35,7 +35,10 @@ def _rank_data(data: Tensor) -> Tensor:
     uniq, inv, counts = torch.unique(data, sorted=True, return_inverse=True, return_counts=True)
     sum_ranks = torch.zeros_like(uniq, dtype=torch.int32)
     sum_ranks.scatter_add_(0, inv, rank.to(torch.int32))
-    mean_ranks = sum_ranks / counts
+    # both operands are integers, so the division would otherwise fall back to the global default dtype and silently
+    # downcast a float64 input; float16/bfloat16 are promoted since ranks need more mantissa than they can hold
+    dtype = torch.promote_types(data.dtype, torch.float32)
+    mean_ranks = sum_ranks.to(dtype) / counts.to(dtype)
     return mean_ranks[inv]
 
 

--- a/tests/unittests/regression/test_corrcoef_dtype.py
+++ b/tests/unittests/regression/test_corrcoef_dtype.py
@@ -1,0 +1,116 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The rank correlation metrics must not silently change the dtype of their input.
+
+`spearman_corrcoef` and `kendall_rank_corrcoef` build their statistics out of integer intermediates -- ranks, and
+concordant/discordant pair counts. Dividing two integer tensors in PyTorch yields the *global default* dtype rather
+than anything derived from the input, so a ``float64`` input used to come back as ``float32``. See
+https://github.com/Lightning-AI/torchmetrics/issues/3465.
+
+"""
+
+import pytest
+import torch
+
+from torchmetrics.functional import kendall_rank_corrcoef, pearson_corrcoef, spearman_corrcoef
+from torchmetrics.functional.regression.spearman import _rank_data
+
+NUM_SAMPLES = 100
+KENDALL_VARIANTS = ["a", "b", "c"]
+
+# float16/bfloat16 are promoted rather than preserved: ranks are integers and need more mantissa than they can hold
+PROMOTED = [
+    pytest.param(torch.float16, torch.float32, id="float16->float32"),
+    pytest.param(torch.bfloat16, torch.float32, id="bfloat16->float32"),
+    pytest.param(torch.float32, torch.float32, id="float32"),
+    pytest.param(torch.float64, torch.float64, id="float64"),
+]
+
+
+def _inputs(dtype: torch.dtype, num_outputs: int = 1):
+    """Reproducible inputs cast to ``dtype``."""
+    generator = torch.Generator().manual_seed(42)
+    shape = (NUM_SAMPLES,) if num_outputs == 1 else (NUM_SAMPLES, num_outputs)
+    preds = torch.rand(shape, generator=generator, dtype=torch.float64)
+    target = torch.rand(shape, generator=generator, dtype=torch.float64)
+    return preds.to(dtype), target.to(dtype)
+
+
+@pytest.mark.parametrize(("in_dtype", "out_dtype"), PROMOTED)
+def test_spearman_corrcoef_dtype(in_dtype, out_dtype):
+    """Spearman must return the promoted input dtype, not the global default."""
+    preds, target = _inputs(in_dtype)
+    assert spearman_corrcoef(preds, target).dtype == out_dtype
+
+
+@pytest.mark.parametrize(("in_dtype", "out_dtype"), PROMOTED)
+@pytest.mark.parametrize("variant", KENDALL_VARIANTS)
+def test_kendall_rank_corrcoef_dtype(in_dtype, out_dtype, variant):
+    """Every Kendall variant must agree on the output dtype.
+
+    Before the fix, ``"c"`` preserved ``float64`` while ``"a"`` and ``"b"`` did not.
+
+    """
+    preds, target = _inputs(in_dtype)
+    assert kendall_rank_corrcoef(preds, target, variant=variant).dtype == out_dtype
+
+
+@pytest.mark.parametrize(("in_dtype", "out_dtype"), PROMOTED)
+def test_rank_data_dtype(in_dtype, out_dtype):
+    """``_rank_data`` is the shared root cause for Spearman -- pin it directly."""
+    data, _ = _inputs(in_dtype)
+    assert _rank_data(data).dtype == out_dtype
+
+
+@pytest.mark.parametrize(("in_dtype", "out_dtype"), PROMOTED)
+def test_spearman_multioutput_dtype(in_dtype, out_dtype):
+    """The multioutput path ranks each column separately and must behave the same."""
+    preds, target = _inputs(in_dtype, num_outputs=3)
+    assert spearman_corrcoef(preds, target).dtype == out_dtype
+
+
+def test_spearman_matches_float32_baseline():
+    """Widening the accumulation must not move the value for inputs float32 already handled."""
+    preds, target = _inputs(torch.float32)
+    baseline = spearman_corrcoef(preds, target)
+    widened = spearman_corrcoef(preds.double(), target.double())
+    assert torch.allclose(widened.float(), baseline, atol=1e-6)
+
+
+@pytest.mark.parametrize("variant", KENDALL_VARIANTS)
+def test_kendall_matches_float32_baseline(variant):
+    """Same for Kendall, across every variant."""
+    preds, target = _inputs(torch.float32)
+    baseline = kendall_rank_corrcoef(preds, target, variant=variant)
+    widened = kendall_rank_corrcoef(preds.double(), target.double(), variant=variant)
+    assert torch.allclose(widened.float(), baseline, atol=1e-6)
+
+
+def test_rank_correlations_agree_with_pearson_on_dtype():
+    """The three correlation metrics should not disagree about what dtype a float64 input deserves."""
+    preds, target = _inputs(torch.float64)
+    dtypes = {
+        "pearson": pearson_corrcoef(preds, target).dtype,
+        "spearman": spearman_corrcoef(preds, target).dtype,
+        "kendall": kendall_rank_corrcoef(preds, target).dtype,
+    }
+    assert set(dtypes.values()) == {torch.float64}, dtypes
+
+
+def test_spearman_ties_dtype():
+    """The tie-averaging branch divides summed ranks by their counts -- the exact spot that used to downcast."""
+    preds = torch.tensor([1.0, 1.0, 2.0, 2.0, 3.0], dtype=torch.float64)
+    target = torch.tensor([1.0, 2.0, 2.0, 3.0, 3.0], dtype=torch.float64)
+    assert _rank_data(preds).dtype == torch.float64
+    assert spearman_corrcoef(preds, target).dtype == torch.float64

--- a/tests/unittests/regression/test_corrcoef_dtype.py
+++ b/tests/unittests/regression/test_corrcoef_dtype.py
@@ -25,14 +25,21 @@ import torch
 
 from torchmetrics.functional import kendall_rank_corrcoef, pearson_corrcoef, spearman_corrcoef
 from torchmetrics.functional.regression.spearman import _rank_data
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 
 NUM_SAMPLES = 100
 KENDALL_VARIANTS = ["a", "b", "c"]
 
+# torch below 2.1 cannot run the half-precision path on CPU at all -- `torch.arange` lacks the support that
+# `_rank_data` relies on -- which is why the existing `test_spearman_corrcoef_half_cpu` carries the same guard
+_half_on_cpu = pytest.mark.skipif(
+    not _TORCH_GREATER_EQUAL_2_1, reason="torch below 2.1 does not support cpu + half precision in these metrics"
+)
+
 # float16/bfloat16 are promoted rather than preserved: ranks are integers and need more mantissa than they can hold
 PROMOTED = [
-    pytest.param(torch.float16, torch.float32, id="float16->float32"),
-    pytest.param(torch.bfloat16, torch.float32, id="bfloat16->float32"),
+    pytest.param(torch.float16, torch.float32, id="float16->float32", marks=_half_on_cpu),
+    pytest.param(torch.bfloat16, torch.float32, id="bfloat16->float32", marks=_half_on_cpu),
     pytest.param(torch.float32, torch.float32, id="float32"),
     pytest.param(torch.float64, torch.float64, id="float64"),
 ]


### PR DESCRIPTION
## What does this PR do?

Fixes #3465

`spearman_corrcoef` and `kendall_rank_corrcoef` returned `float32` for `float64` inputs. Every other functional regression metric preserves the input dtype, and `kendall_rank_corrcoef` preserved it for `variant="c"` but not for `"a"` or `"b"` — so the metric disagreed with itself depending on which variant you picked.

```python
preds = torch.rand(100, dtype=torch.float64)
target = torch.rand(100, dtype=torch.float64)

pearson_corrcoef(preds, target).dtype       # torch.float64
spearman_corrcoef(preds, target).dtype      # torch.float32  <- before
kendall_rank_corrcoef(preds, target).dtype  # torch.float32  <- before
```

## Cause

Both metrics build their statistics from **integer** intermediates, and dividing two integer tensors in PyTorch yields the *global default* dtype rather than anything derived from the input.

`_rank_data` in `functional/regression/spearman.py`:

```python
sum_ranks = torch.zeros_like(uniq, dtype=torch.int32)
mean_ranks = sum_ranks / counts   # int32 / int64 -> float32, whatever data.dtype was
```

`_calculate_tau` in `functional/regression/kendall.py` divides the `int64` concordant/discordant/tie counts. Variant `"c"` escaped it only because it builds `preds_unique` with `dtype=preds.dtype`, which promoted the surrounding expression.

## Fix

Both now compute in `torch.promote_types(input.dtype, torch.float32)`:

| input | output |
|---|---|
| `float64` | `float64` (was `float32`) |
| `float32` | `float32` |
| `float16` / `bfloat16` | `float32` |

`float16`/`bfloat16` are deliberately **promoted rather than preserved** — ranks and pair counts are integers, and `float16` only represents integers exactly up to 2048, so narrowing the accumulation to the input dtype would be worse than the bug. This also matches the existing behaviour for those dtypes, so nothing changes for them.

## Scope — two adjacent things deliberately left alone

**1. The `eps` bias in `_spearman_corrcoef_compute`.** `corrcoef = cov / (preds_std * target_std + eps)` with `eps=1e-6` biases every result away from an exact ±1. On exact integer ranks, where dtype plays no part:

```
_spearman_corrcoef_compute(a, a)             # eps=1e-6 -> 0.9999992000006399
_spearman_corrcoef_compute(a, a, eps=0.0)    #          -> 0.9999999999999998
```

That is independent of this bug and changing it would move results for every existing user, so it is a call for the maintainers. I noted it in #3465; happy to open a separate issue if you want it tracked.

**2. `SpearmanCorrCoef.update` casts explicitly:**

```python
self.preds.append(preds.to(self.dtype))   # module dtype, float32 by default
```

`KendallRankCorrCoef.update` has no such cast, which is why the class-based Kendall now returns `float64` while the class-based Spearman still returns `float32`. That cast may well be deliberate — halving the stored footprint is a reasonable motive given the metric already warns about buffering every prediction — so I have not touched it. Say the word and I'll align it.

## Tests

New `tests/unittests/regression/test_corrcoef_dtype.py` covers Spearman, all three Kendall variants, `_rank_data` directly, the multioutput path, the tie-averaging branch (the exact division that downcast), and asserts the three correlation metrics agree with each other on what a `float64` input deserves. It also pins that widening does not move the value for `float32` inputs.

Verified the tests actually catch the bug — against unpatched `src/`:

```
$ pytest tests/unittests/regression/test_corrcoef_dtype.py -q
9 failed, 21 passed in 6.44s
```

With the fix:

```
$ pytest tests/unittests/regression/test_corrcoef_dtype.py -q
30 passed in 6.66s
```

Full regression suite, compared against `master` in the same environment:

```
master : 27 failed, 620 passed, 155 skipped, 24 xfailed
this PR: 18 failed, 629 passed, 155 skipped, 24 xfailed
```

The 9-test difference is exactly this PR's own tests. The remaining 18 are pre-existing `nrmse` mismatches against the `permetrics` reference in `test_mean_error.py`, identical on `master` and untouched here. No failure in `test_spearman.py`, `test_kendall.py`, `test_pearson.py`, or the new file:

```
$ pytest tests/unittests/regression/test_spearman.py tests/unittests/regression/test_kendall.py \
         tests/unittests/regression/test_pearson.py tests/unittests/regression/test_corrcoef_dtype.py -q
151 passed, 9 skipped in 17.07s
```

Values cross-checked against SciPy on `float32`, with and without ties:

```
spearman  tm=-0.0387489684  scipy=-0.0387489687
kendall   tm=-0.0272361804  scipy=-0.0272361809
ties: spearman  tm=0.0057996665  scipy=0.0057996669
ties: kendall   tm=0.0045146765  scipy=0.0045146766
```

Lint, types and doctests:

```
$ ruff check <changed files>        All checks passed!
$ ruff format --check <changed>     3 files already formatted
$ mypy <changed source files>       Success: no issues found in 2 source files
$ pytest --doctest-modules <changed source files>   3 passed
```

## Before submitting

- [x] Was this **discussed/agreed** via a GitHub issue? (#3465)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure to **update the docs**? (n/a — no public API or signature change)
- [x] Did you write any new **necessary tests**?
