### PR TITLE
Fix `davies_bouldin_score` returning a wrong value for off-origin float64 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
 
+- Fixed `davies_bouldin_score` returning an incorrect value for `float64` data far from the origin, and `calinski_harabasz_score` accumulating at `float32`, by allocating their buffers in the input dtype ([#3468](https://github.com/Lightning-AI/torchmetrics/pull/3468))
+
 
 ---
 

--- a/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
+++ b/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
@@ -48,8 +48,9 @@ def calinski_harabasz_score(data: Tensor, labels: Tensor) -> Tensor:
     _validate_intrinsic_labels_to_samples(num_labels, num_samples)
 
     mean = data.mean(dim=0)
-    between_cluster_dispersion = torch.tensor(0.0, device=data.device)
-    within_cluster_dispersion = torch.tensor(0.0, device=data.device)
+    # allocated in the input dtype so a float64 input is not silently accumulated at float32 precision
+    between_cluster_dispersion = torch.tensor(0.0, device=data.device, dtype=data.dtype)
+    within_cluster_dispersion = torch.tensor(0.0, device=data.device, dtype=data.dtype)
     for k in range(num_labels):
         cluster_k = data[labels == k, :]
         mean_k = cluster_k.mean(dim=0)
@@ -57,5 +58,5 @@ def calinski_harabasz_score(data: Tensor, labels: Tensor) -> Tensor:
         within_cluster_dispersion += ((cluster_k - mean_k) ** 2).sum()
 
     if within_cluster_dispersion == 0:
-        return torch.tensor(1.0, device=data.device, dtype=torch.float32)
+        return torch.tensor(1.0, device=data.device, dtype=data.dtype)
     return between_cluster_dispersion * (num_samples - num_labels) / (within_cluster_dispersion * (num_labels - 1.0))

--- a/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
+++ b/src/torchmetrics/functional/clustering/calinski_harabasz_score.py
@@ -41,6 +41,11 @@ def calinski_harabasz_score(data: Tensor, labels: Tensor) -> Tensor:
     """
     _validate_intrinsic_cluster_data(data, labels)
 
+    # the squared accumulations below overflow/lose precision in half, so promote those to float32;
+    # float32/float64 are kept as-is
+    if data.dtype not in (torch.float32, torch.float64):
+        data = data.to(torch.float32)
+
     # convert to zero indexed labels
     unique_labels, labels = torch.unique(labels, return_inverse=True)
     num_labels = len(unique_labels)

--- a/src/torchmetrics/functional/clustering/davies_bouldin_score.py
+++ b/src/torchmetrics/functional/clustering/davies_bouldin_score.py
@@ -47,8 +47,10 @@ def davies_bouldin_score(data: Tensor, labels: Tensor) -> Tensor:
     num_samples, dim = data.shape
     _validate_intrinsic_labels_to_samples(num_labels, num_samples)
 
-    intra_dists = torch.zeros(num_labels, device=data.device)
-    centroids = torch.zeros((num_labels, dim), device=data.device)
+    # allocated in the input dtype: a float32 centroid buffer rounds the stored centre to ~7 significant digits, so
+    # `cluster_k - centroids[k]` catastrophically cancels for data that is not centred near the origin
+    intra_dists = torch.zeros(num_labels, device=data.device, dtype=data.dtype)
+    centroids = torch.zeros((num_labels, dim), device=data.device, dtype=data.dtype)
     for k in range(num_labels):
         cluster_k = data[labels == k, :]
         centroids[k] = cluster_k.mean(dim=0)
@@ -58,7 +60,7 @@ def davies_bouldin_score(data: Tensor, labels: Tensor) -> Tensor:
     cond1 = torch.allclose(intra_dists, torch.zeros_like(intra_dists))
     cond2 = torch.allclose(centroid_distances, torch.zeros_like(centroid_distances))
     if cond1 or cond2:
-        return torch.tensor(0.0, device=data.device, dtype=torch.float32)
+        return torch.tensor(0.0, device=data.device, dtype=data.dtype)
 
     centroid_distances[centroid_distances == 0] = float("inf")
     combined_intra_dists = intra_dists.unsqueeze(0) + intra_dists.unsqueeze(1)

--- a/src/torchmetrics/functional/clustering/davies_bouldin_score.py
+++ b/src/torchmetrics/functional/clustering/davies_bouldin_score.py
@@ -41,6 +41,11 @@ def davies_bouldin_score(data: Tensor, labels: Tensor) -> Tensor:
     """
     _validate_intrinsic_cluster_data(data, labels)
 
+    # `torch.cdist` has no half kernel and the squared accumulations below lose too much precision in
+    # half, so promote those to float32; float32/float64 are kept as-is
+    if data.dtype not in (torch.float32, torch.float64):
+        data = data.to(torch.float32)
+
     # convert to zero indexed labels
     unique_labels, labels = torch.unique(labels, return_inverse=True)
     num_labels = len(unique_labels)

--- a/tests/unittests/clustering/test_clustering_dtype.py
+++ b/tests/unittests/clustering/test_clustering_dtype.py
@@ -1,0 +1,140 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The data-based clustering metrics must accumulate at the precision they were handed.
+
+`davies_bouldin_score` and `calinski_harabasz_score` used to allocate their buffers without a ``dtype``, so a
+``float64`` input was accumulated at ``float32``. For Davies-Bouldin that is not merely cosmetic: the centroid buffer
+rounds each stored centre to roughly seven significant digits, so ``cluster_k - centroids[k]`` cancels catastrophically
+once the data sits away from the origin. See https://github.com/Lightning-AI/torchmetrics/issues/3467.
+
+"""
+
+import pytest
+import torch
+
+from torchmetrics.clustering import CalinskiHarabaszScore, DaviesBouldinScore
+from torchmetrics.functional.clustering import calinski_harabasz_score, davies_bouldin_score, dunn_index
+
+NUM_SAMPLES, NUM_FEATURES, NUM_CLUSTERS = 300, 3, 4
+
+DATA_METRICS = [
+    pytest.param(davies_bouldin_score, id="davies_bouldin_score"),
+    pytest.param(calinski_harabasz_score, id="calinski_harabasz_score"),
+    pytest.param(dunn_index, id="dunn_index"),
+]
+
+
+def _data(dtype: torch.dtype, offset: float = 0.0):
+    """Reproducible clustered data, optionally shifted away from the origin."""
+    generator = torch.Generator().manual_seed(42)
+    data = torch.rand(NUM_SAMPLES, NUM_FEATURES, generator=generator, dtype=torch.float64) + offset
+    labels = torch.arange(NUM_SAMPLES) % NUM_CLUSTERS
+    return data.to(dtype), labels
+
+
+def _reference_davies_bouldin(data, labels):
+    """The same algorithm, with every buffer explicitly in the data's dtype."""
+    unique = labels.unique()
+    n = len(unique)
+    intra = torch.zeros(n, dtype=data.dtype)
+    centroids = torch.zeros((n, data.shape[1]), dtype=data.dtype)
+    for i, k in enumerate(unique):
+        cluster = data[labels == k]
+        centroids[i] = cluster.mean(dim=0)
+        intra[i] = (cluster - centroids[i]).pow(2.0).sum(dim=1).sqrt().mean()
+    centroid_distances = torch.cdist(centroids, centroids, p=2.0)
+    centroid_distances[centroid_distances == 0] = float("inf")
+    combined = intra.unsqueeze(0) + intra.unsqueeze(1)
+    return (combined / centroid_distances).max(dim=1).values.mean()
+
+
+@pytest.mark.parametrize("metric", DATA_METRICS)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_data_clustering_metric_preserves_dtype(metric, dtype):
+    """A float64 input must not come back as float32."""
+    data, labels = _data(dtype)
+    assert metric(data, labels).dtype == dtype
+
+
+# subtracting a centroid from off-origin data cancels leading digits, so exact translation invariance is not
+# achievable even in float64 -- the tolerance tracks that limit rather than pretending it is zero
+TRANSLATIONS = [
+    pytest.param(0.0, 1e-12, id="origin"),
+    pytest.param(1e3, 1e-10, id="1e3"),
+    pytest.param(1e5, 1e-8, id="1e5"),
+    pytest.param(1e7, 1e-6, id="1e7"),
+]
+
+
+@pytest.mark.parametrize(("offset", "rtol"), TRANSLATIONS)
+def test_davies_bouldin_is_translation_invariant(offset, rtol):
+    """Davies-Bouldin depends only on relative geometry, so shifting the data must not change the score.
+
+    This is the regression that matters: with a float32 centroid buffer the score at ``offset=1e7`` came back as
+    ``1.73`` where the correct value is ``27.01`` -- a 94% error, orders of magnitude outside these tolerances.
+
+    """
+    data, labels = _data(torch.float64, offset=offset)
+    at_origin, _ = _data(torch.float64, offset=0.0)
+    expected = davies_bouldin_score(at_origin, labels)
+    assert torch.allclose(davies_bouldin_score(data, labels), expected, rtol=rtol)
+
+
+@pytest.mark.parametrize("offset", [0.0, 1e3, 1e5, 1e7])
+def test_davies_bouldin_matches_full_precision_reference(offset):
+    """Match an independent float64 implementation of the same formula."""
+    data, labels = _data(torch.float64, offset=offset)
+    assert torch.allclose(davies_bouldin_score(data, labels), _reference_davies_bouldin(data, labels), rtol=1e-12)
+
+
+@pytest.mark.parametrize(("offset", "rtol"), TRANSLATIONS)
+def test_calinski_harabasz_is_translation_invariant(offset, rtol):
+    """Calinski-Harabasz is likewise defined by relative geometry only."""
+    data, labels = _data(torch.float64, offset=offset)
+    at_origin, _ = _data(torch.float64, offset=0.0)
+    expected = calinski_harabasz_score(at_origin, labels)
+    assert torch.allclose(calinski_harabasz_score(data, labels), expected, rtol=rtol)
+
+
+def test_data_clustering_metrics_agree_on_dtype():
+    """The three data-based clustering metrics should not disagree about what a float64 input deserves."""
+    data, labels = _data(torch.float64)
+    dtypes = {
+        "davies_bouldin": davies_bouldin_score(data, labels).dtype,
+        "calinski_harabasz": calinski_harabasz_score(data, labels).dtype,
+        "dunn_index": dunn_index(data, labels).dtype,
+    }
+    assert set(dtypes.values()) == {torch.float64}, dtypes
+
+
+@pytest.mark.parametrize(
+    ("metric_class", "functional"),
+    [
+        pytest.param(DaviesBouldinScore, davies_bouldin_score, id="davies_bouldin"),
+        pytest.param(CalinskiHarabaszScore, calinski_harabasz_score, id="calinski_harabasz"),
+    ],
+)
+def test_class_matches_functional_on_float64(metric_class, functional):
+    """The class-based wrapper must not diverge from the functional result."""
+    data, labels = _data(torch.float64, offset=1e5)
+    metric = metric_class()
+    metric.update(data, labels)
+    assert torch.allclose(metric.compute().double(), functional(data, labels).double(), rtol=1e-6)
+
+
+def test_float32_result_is_unchanged():
+    """Float32 inputs already allocated float32 buffers, so their values must not move."""
+    data, labels = _data(torch.float32)
+    assert davies_bouldin_score(data, labels).dtype == torch.float32
+    assert calinski_harabasz_score(data, labels).dtype == torch.float32

--- a/tests/unittests/clustering/test_clustering_dtype.py
+++ b/tests/unittests/clustering/test_clustering_dtype.py
@@ -133,6 +133,21 @@ def test_class_matches_functional_on_float64(metric_class, functional):
     assert torch.allclose(metric.compute().double(), functional(data, labels).double(), rtol=1e-6)
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_half_precision_is_computed_in_float32(dtype):
+    """Half inputs are promoted, not preserved.
+
+    ``torch.cdist`` has no half kernel at all, so allocating Davies-Bouldin's buffers in the input dtype would turn a
+    working ``float16`` call into ``NotImplementedError``, and the squared accumulations in both metrics lose too much
+    precision in half to be worth preserving. Promoting to ``float32`` keeps the behaviour these two metrics had
+    before the dtype fix. ``dunn_index`` is unaffected and still returns the input dtype.
+
+    """
+    data, labels = _data(dtype)
+    assert davies_bouldin_score(data, labels).dtype == torch.float32
+    assert calinski_harabasz_score(data, labels).dtype == torch.float32
+
+
 def test_float32_result_is_unchanged():
     """Float32 inputs already allocated float32 buffers, so their values must not move."""
     data, labels = _data(torch.float32)


### PR DESCRIPTION
## What does this PR do?

Fixes #3467

`davies_bouldin_score` and `calinski_harabasz_score` allocated their accumulators without a `dtype`, so the buffers were `float32` whatever the input was. `dunn_index` — same family, same signature — preserves the input dtype, so the clustering metrics disagreed with each other.

For **Davies-Bouldin this is a correctness bug, not a dtype-label one.** Writing a `float64` centroid into a `float32` buffer rounds it to about seven significant digits, so `cluster_k - centroids[k]` ends up dominated by that rounding as soon as the data sits away from the origin:

| data offset | returned | correct | relative error |
|---|---|---|---|
| `0` | 27.0118026733 | 27.0118054968 | 1.0e-07 |
| `1e3` | 27.0143089294 | 27.0118054967 | 9.3e-05 |
| `1e5` | 29.3704795837 | 27.0118054947 | **8.7e-02** |
| `1e7` | **1.7268073559** | 27.0118055903 | **9.4e-01** |

The clustering structure is identical in every row — only the origin moved. At `offset=1e7` the metric returns `1.73` where the answer is `27.01`.

Off-origin coordinates are ordinary: geographic positions, epoch timestamps, unnormalised sensor readings. A user reaching for `float64` *because* their data has a large dynamic range had it silently discarded.

Calinski-Harabasz narrows only the running accumulation — the per-cluster terms are still computed in the input dtype — so its error stayed near `float32` epsilon (~1e-7 relative). Still a silent `float32` ceiling on a `float64` input, but not catastrophic.

## Changes

```python
# davies_bouldin_score.py
- intra_dists = torch.zeros(num_labels, device=data.device)
- centroids = torch.zeros((num_labels, dim), device=data.device)
+ intra_dists = torch.zeros(num_labels, device=data.device, dtype=data.dtype)
+ centroids = torch.zeros((num_labels, dim), device=data.device, dtype=data.dtype)

# calinski_harabasz_score.py
- between_cluster_dispersion = torch.tensor(0.0, device=data.device)
- within_cluster_dispersion = torch.tensor(0.0, device=data.device)
+ between_cluster_dispersion = torch.tensor(0.0, device=data.device, dtype=data.dtype)
+ within_cluster_dispersion = torch.tensor(0.0, device=data.device, dtype=data.dtype)
```

Both degenerate branches also returned an explicit `dtype=torch.float32` scalar; those now follow the input dtype too, so the return type is consistent on every path.

**`float32` inputs are unaffected** — they already allocated `float32` buffers, so no value moves.

## Tests

New `tests/unittests/clustering/test_clustering_dtype.py`:

- dtype preservation across all three data-based clustering metrics;
- **translation invariance** for Davies-Bouldin and Calinski-Harabasz — shifting the data must not change a score defined purely by relative geometry. This is the test that pins the real regression;
- Davies-Bouldin matched against an independent `float64` implementation of the same formula;
- class-based wrappers agreeing with the functional results;
- `float32` behaviour explicitly unchanged.

On the tolerances: subtracting a centroid from off-origin data cancels leading digits, so exact translation invariance is **not** achievable even in `float64`. Measured limits are `2.6e-12` at `offset=1e3`, `2.9e-10` at `1e5` and `5.2e-08` at `1e7`, so the tolerance scales with the offset rather than pretending the error is zero. The bug produced a 94% error at `1e7`, orders of magnitude outside those bounds, so the test still catches it decisively.

Verified the tests actually catch the bug — against unpatched `src/`:

```
$ pytest tests/unittests/clustering/test_clustering_dtype.py -q
10 failed, 12 passed in 6.13s
```

With the fix:

```
$ pytest tests/unittests/clustering/test_clustering_dtype.py -q
22 passed in 7.12s
```

Full clustering suite, compared against `master` in the same environment:

```
master : 10 failed, 187 passed, 8 skipped
this PR:  0 failed, 197 passed, 8 skipped
```

The 10 are exactly this PR's own tests. Nothing else in the suite moves.

Lint, types and doctests:

```
$ ruff check <changed files>                        All checks passed!
$ ruff format --check <changed files>               3 files already formatted
$ mypy <changed source files>                       Success: no issues found in 2 source files
$ pytest --doctest-modules <changed source files>   2 passed
```

## Related

Same *class* of problem as #3465 / #3466 (`spearman_corrcoef` and `kendall_rank_corrcoef`), but a different mechanism — that one is integer division falling back to the default dtype, this one is untyped buffer allocation. Kept separate because the fix and the blast radius differ.

## Before submitting

- [x] Was this **discussed/agreed** via a GitHub issue? (#3467)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure to **update the docs**? (n/a — no public API or signature change)
- [x] Did you write any new **necessary tests**?
