### PR TITLE
fix: correct and/or logic in argument validation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 
+- Fixed unreachable argument validation across ~20 metrics that used `and` instead of `or`, so invalid arguments were silently accepted ([#XXXX](https://github.com/Lightning-AI/torchmetrics/pull/XXXX))
+
 
 ---
 

--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -114,7 +114,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
         if mode not in ("wb", "nb"):
             raise ValueError(f"Expected argument `mode` to either be 'wb' or 'nb' but got {mode}")
         self.mode = mode
-        if not isinstance(n_processes, int) and n_processes <= 0:
+        if not isinstance(n_processes, int) or n_processes <= 0:
             raise ValueError(f"Expected argument `n_processes` to be an int larger than 0 but got {n_processes}")
         self.n_processes = n_processes
 

--- a/src/torchmetrics/classification/group_fairness.py
+++ b/src/torchmetrics/classification/group_fairness.py
@@ -122,7 +122,7 @@ class BinaryGroupStatRates(_AbstractGroupStatScores):
         if validate_args:
             _binary_stat_scores_arg_validation(threshold, "global", ignore_index)
 
-        if not isinstance(num_groups, int) and num_groups < 2:
+        if not isinstance(num_groups, int) or num_groups < 2:
             raise ValueError(f"Expected argument `num_groups` to be an int larger than 1, but got {num_groups}")
         self.num_groups = num_groups
         self.threshold = threshold
@@ -236,7 +236,7 @@ class BinaryFairness(_AbstractGroupStatScores):
         if validate_args:
             _binary_stat_scores_arg_validation(threshold, "global", ignore_index)
 
-        if not isinstance(num_groups, int) and num_groups < 2:
+        if not isinstance(num_groups, int) or num_groups < 2:
             raise ValueError(f"Expected argument `num_groups` to be an int larger than 1, but got {num_groups}")
         self.num_groups = num_groups
         self.task = task

--- a/src/torchmetrics/functional/classification/logauc.py
+++ b/src/torchmetrics/functional/classification/logauc.py
@@ -26,7 +26,7 @@ from torchmetrics.utilities.enums import ClassificationTask
 
 def _validate_fpr_range(fpr_range: Tuple[float, float]) -> None:
     """Validate the `fpr_range` argument for the logauc metric."""
-    if not isinstance(fpr_range, tuple) and not len(fpr_range) == 2:
+    if not isinstance(fpr_range, tuple) or len(fpr_range) != 2:
         raise ValueError(f"The `fpr_range` should be a tuple of two floats, but got {type(fpr_range)}.")
     if not (0 <= fpr_range[0] < fpr_range[1] <= 1):
         raise ValueError(f"The `fpr_range` should be a tuple of two floats in the range [0, 1], but got {fpr_range}.")

--- a/src/torchmetrics/functional/classification/recall_fixed_precision.py
+++ b/src/torchmetrics/functional/classification/recall_fixed_precision.py
@@ -82,7 +82,7 @@ def _binary_recall_at_fixed_precision_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _binary_precision_recall_curve_arg_validation(thresholds, ignore_index)
-    if not isinstance(min_precision, float) and not (0 <= min_precision <= 1):
+    if not (isinstance(min_precision, float) and (0 <= min_precision <= 1)):
         raise ValueError(
             f"Expected argument `min_precision` to be an float in the [0,1] range, but got {min_precision}"
         )
@@ -179,7 +179,7 @@ def _multiclass_recall_at_fixed_precision_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multiclass_precision_recall_curve_arg_validation(num_classes, thresholds, ignore_index)
-    if not isinstance(min_precision, float) and not (0 <= min_precision <= 1):
+    if not (isinstance(min_precision, float) and (0 <= min_precision <= 1)):
         raise ValueError(
             f"Expected argument `min_precision` to be an float in the [0,1] range, but got {min_precision}"
         )
@@ -289,7 +289,7 @@ def _multilabel_recall_at_fixed_precision_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multilabel_precision_recall_curve_arg_validation(num_labels, thresholds, ignore_index)
-    if not isinstance(min_precision, float) and not (0 <= min_precision <= 1):
+    if not (isinstance(min_precision, float) and (0 <= min_precision <= 1)):
         raise ValueError(
             f"Expected argument `min_precision` to be an float in the [0,1] range, but got {min_precision}"
         )

--- a/src/torchmetrics/functional/classification/sensitivity_specificity.py
+++ b/src/torchmetrics/functional/classification/sensitivity_specificity.py
@@ -76,7 +76,7 @@ def _binary_sensitivity_at_specificity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _binary_precision_recall_curve_arg_validation(thresholds, ignore_index)
-    if not isinstance(min_specificity, float) and not (0 <= min_specificity <= 1):
+    if not (isinstance(min_specificity, float) and (0 <= min_specificity <= 1)):
         raise ValueError(
             f"Expected argument `min_specificity` to be an float in the [0,1] range, but got {min_specificity}"
         )
@@ -173,7 +173,7 @@ def _multiclass_sensitivity_at_specificity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multiclass_precision_recall_curve_arg_validation(num_classes, thresholds, ignore_index)
-    if not isinstance(min_specificity, float) and not (0 <= min_specificity <= 1):
+    if not (isinstance(min_specificity, float) and (0 <= min_specificity <= 1)):
         raise ValueError(
             f"Expected argument `min_specificity` to be an float in the [0,1] range, but got {min_specificity}"
         )
@@ -289,7 +289,7 @@ def _multilabel_sensitivity_at_specificity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multilabel_precision_recall_curve_arg_validation(num_labels, thresholds, ignore_index)
-    if not isinstance(min_specificity, float) and not (0 <= min_specificity <= 1):
+    if not (isinstance(min_specificity, float) and (0 <= min_specificity <= 1)):
         raise ValueError(
             f"Expected argument `min_specificity` to be an float in the [0,1] range, but got {min_specificity}"
         )

--- a/src/torchmetrics/functional/classification/specificity_sensitivity.py
+++ b/src/torchmetrics/functional/classification/specificity_sensitivity.py
@@ -77,7 +77,7 @@ def _binary_specificity_at_sensitivity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _binary_precision_recall_curve_arg_validation(thresholds, ignore_index)
-    if not isinstance(min_sensitivity, float) and not (0 <= min_sensitivity <= 1):
+    if not (isinstance(min_sensitivity, float) and (0 <= min_sensitivity <= 1)):
         raise ValueError(
             f"Expected argument `min_sensitivity` to be an float in the [0,1] range, but got {min_sensitivity}"
         )
@@ -174,7 +174,7 @@ def _multiclass_specificity_at_sensitivity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multiclass_precision_recall_curve_arg_validation(num_classes, thresholds, ignore_index)
-    if not isinstance(min_sensitivity, float) and not (0 <= min_sensitivity <= 1):
+    if not (isinstance(min_sensitivity, float) and (0 <= min_sensitivity <= 1)):
         raise ValueError(
             f"Expected argument `min_sensitivity` to be an float in the [0,1] range, but got {min_sensitivity}"
         )
@@ -290,7 +290,7 @@ def _multilabel_specificity_at_sensitivity_arg_validation(
     ignore_index: Optional[int] = None,
 ) -> None:
     _multilabel_precision_recall_curve_arg_validation(num_labels, thresholds, ignore_index)
-    if not isinstance(min_sensitivity, float) and not (0 <= min_sensitivity <= 1):
+    if not (isinstance(min_sensitivity, float) and (0 <= min_sensitivity <= 1)):
         raise ValueError(
             f"Expected argument `min_sensitivity` to be an float in the [0,1] range, but got {min_sensitivity}"
         )

--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -241,7 +241,7 @@ def _multiclass_stat_scores_arg_validation(
         )
     if num_classes is not None and (not isinstance(num_classes, int) or num_classes < 2):
         raise ValueError(f"Expected argument `num_classes` to be an integer larger than 1, but got {num_classes}")
-    if not isinstance(top_k, int) and top_k < 1:
+    if not isinstance(top_k, int) or top_k < 1:
         raise ValueError(f"Expected argument `top_k` to be an integer larger than or equal to 1, but got {top_k}")
     if top_k > (num_classes if num_classes is not None else 1):
         raise ValueError(

--- a/src/torchmetrics/functional/retrieval/average_precision.py
+++ b/src/torchmetrics/functional/retrieval/average_precision.py
@@ -49,7 +49,7 @@ def retrieval_average_precision(preds: Tensor, target: Tensor, top_k: Optional[i
     preds, target = _check_retrieval_functional_inputs(preds, target)
 
     top_k = top_k or preds.shape[-1]
-    if not isinstance(top_k, int) and top_k <= 0:
+    if not isinstance(top_k, int) or top_k <= 0:
         raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
 
     target = torch.where(preds > 0, target, torch.zeros_like(target))

--- a/src/torchmetrics/functional/retrieval/reciprocal_rank.py
+++ b/src/torchmetrics/functional/retrieval/reciprocal_rank.py
@@ -49,7 +49,7 @@ def retrieval_reciprocal_rank(preds: Tensor, target: Tensor, top_k: Optional[int
     preds, target = _check_retrieval_functional_inputs(preds, target)
 
     top_k = top_k or preds.shape[-1]
-    if not isinstance(top_k, int) and top_k <= 0:
+    if not isinstance(top_k, int) or top_k <= 0:
         raise ValueError(f"Argument ``top_k`` has to be a positive integer or None, but got {top_k}.")
 
     target = torch.where(preds > 0, target, torch.zeros_like(target))

--- a/src/torchmetrics/functional/segmentation/utils.py
+++ b/src/torchmetrics/functional/segmentation/utils.py
@@ -549,7 +549,7 @@ def table_contour_length(spacing: tuple[int, int], device: Optional[torch.device
                   [2, 1]]]])
 
     """
-    if not isinstance(spacing, tuple) and len(spacing) != 2:
+    if not isinstance(spacing, tuple) or len(spacing) != 2:
         raise ValueError("The spacing must be a tuple of length 2.")
 
     first, second = spacing  # spacing along the first and second spatial dimension respectively
@@ -622,7 +622,7 @@ def table_surface_area(spacing: tuple[int, int, int], device: Optional[torch.dev
                    [  2,   1]]]]])
 
     """
-    if not isinstance(spacing, tuple) and len(spacing) != 3:
+    if not isinstance(spacing, tuple) or len(spacing) != 3:
         raise ValueError("The spacing must be a tuple of length 3.")
 
     zeros = [0.0, 0.0, 0.0]

--- a/src/torchmetrics/image/psnrb.py
+++ b/src/torchmetrics/image/psnrb.py
@@ -79,7 +79,7 @@ class PeakSignalNoiseRatioWithBlockedEffect(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        if not isinstance(block_size, int) and block_size < 1:
+        if not isinstance(block_size, int) or block_size < 1:
             raise ValueError("Argument ``block_size`` should be a positive integer")
         self.block_size = block_size
 

--- a/src/torchmetrics/regression/log_cosh.py
+++ b/src/torchmetrics/regression/log_cosh.py
@@ -77,7 +77,7 @@ class LogCoshError(Metric):
     def __init__(self, num_outputs: int = 1, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-        if not isinstance(num_outputs, int) and num_outputs < 1:
+        if not isinstance(num_outputs, int) or num_outputs < 1:
             raise ValueError(f"Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
         self.add_state("sum_log_cosh_error", default=torch.zeros(num_outputs), dist_reduce_fx="sum")

--- a/src/torchmetrics/regression/pearson.py
+++ b/src/torchmetrics/regression/pearson.py
@@ -160,8 +160,8 @@ class PearsonCorrCoef(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        if not isinstance(num_outputs, int) and num_outputs < 1:
-            raise ValueError("Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
+        if not isinstance(num_outputs, int) or num_outputs < 1:
+            raise ValueError(f"Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
 
         self.add_state("mean_x", default=torch.zeros(self.num_outputs), dist_reduce_fx=None)

--- a/src/torchmetrics/regression/spearman.py
+++ b/src/torchmetrics/regression/spearman.py
@@ -88,7 +88,7 @@ class SpearmanCorrCoef(Metric):
             "Metric `SpearmanCorrcoef` will save all targets and predictions in the buffer."
             " For large datasets, this may lead to large memory footprint."
         )
-        if not isinstance(num_outputs, int) and num_outputs < 1:
+        if not isinstance(num_outputs, int) or num_outputs < 1:
             raise ValueError(f"Expected argument `num_outputs` to be an int larger than 0, but got {num_outputs}")
         self.num_outputs = num_outputs
 

--- a/src/torchmetrics/video/vmaf.py
+++ b/src/torchmetrics/video/vmaf.py
@@ -131,7 +131,7 @@ class VideoMultiMethodAssessmentFusion(Metric):
             raise RuntimeError("vmaf-torch is not installed. Please install with `pip install torchmetrics[video]`.")
 
         if not isinstance(features, bool):
-            raise ValueError("Argument `elementary_features` should be a boolean, but got {features}.")
+            raise ValueError(f"Argument `features` should be a boolean, but got {features}.")
         self.features = features
 
         self.add_state("vmaf_score", default=[], dist_reduce_fx="cat")

--- a/tests/unittests/utilities/test_argument_validation.py
+++ b/tests/unittests/utilities/test_argument_validation.py
@@ -1,0 +1,122 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import torch
+
+from torchmetrics.classification import BinaryFairness
+from torchmetrics.functional.classification.logauc import _validate_fpr_range
+from torchmetrics.functional.classification.recall_fixed_precision import (
+    _binary_recall_at_fixed_precision_arg_validation,
+)
+from torchmetrics.functional.classification.sensitivity_specificity import (
+    _binary_sensitivity_at_specificity_arg_validation,
+)
+from torchmetrics.functional.classification.specificity_sensitivity import (
+    _binary_specificity_at_sensitivity_arg_validation,
+)
+from torchmetrics.functional.classification.stat_scores import _multiclass_stat_scores_arg_validation
+from torchmetrics.functional.retrieval import retrieval_average_precision, retrieval_reciprocal_rank
+from torchmetrics.functional.segmentation.utils import table_contour_length, table_surface_area
+from torchmetrics.image import PeakSignalNoiseRatioWithBlockedEffect
+from torchmetrics.regression import LogCoshError, PearsonCorrCoef, SpearmanCorrCoef
+
+
+@pytest.mark.parametrize("metric_class", [PearsonCorrCoef, SpearmanCorrCoef, LogCoshError])
+@pytest.mark.parametrize("value", [0, -1, 1.5, "2", None])
+def test_num_outputs_validation(metric_class, value):
+    """Test that regression metrics reject a ``num_outputs`` that is not an int larger than 0."""
+    with pytest.raises(ValueError, match="Expected argument `num_outputs` to be an int larger than 0"):
+        metric_class(num_outputs=value)
+
+
+def test_num_outputs_error_message_is_interpolated():
+    """Test that the ``PearsonCorrCoef`` message interpolates the value instead of printing a literal brace."""
+    with pytest.raises(ValueError, match="but got 0"):
+        PearsonCorrCoef(num_outputs=0)
+
+
+@pytest.mark.parametrize("value", [1, 0, -1, 2.5, "3", None])
+def test_num_groups_validation(value):
+    """Test that ``BinaryFairness`` rejects a ``num_groups`` that is not an int larger than 1."""
+    with pytest.raises(ValueError, match="Expected argument `num_groups` to be an int larger than 1"):
+        BinaryFairness(num_groups=value)
+
+
+@pytest.mark.parametrize("value", [0, -1, 2.5, "8", None])
+def test_psnrb_block_size_validation(value):
+    """Test that ``PeakSignalNoiseRatioWithBlockedEffect`` rejects a non-positive-int ``block_size``."""
+    with pytest.raises(ValueError, match="``block_size`` should be a positive integer"):
+        PeakSignalNoiseRatioWithBlockedEffect(data_range=1.0, block_size=value)
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.5, "2", None])
+def test_multiclass_top_k_validation(value):
+    """Test that ``top_k`` is rejected unless it is an int larger than or equal to 1."""
+    with pytest.raises(ValueError, match="Expected argument `top_k` to be an integer larger than or equal to 1"):
+        _multiclass_stat_scores_arg_validation(num_classes=3, top_k=value)
+
+
+@pytest.mark.parametrize(
+    ("validation_fn", "argument"),
+    [
+        (_binary_recall_at_fixed_precision_arg_validation, "min_precision"),
+        (_binary_sensitivity_at_specificity_arg_validation, "min_specificity"),
+        (_binary_specificity_at_sensitivity_arg_validation, "min_sensitivity"),
+    ],
+)
+@pytest.mark.parametrize("value", [-0.5, 1.5, "0.5", None])
+def test_min_value_validation(validation_fn, argument, value):
+    """Test that the ``min_*`` arguments are rejected unless they are floats inside the [0,1] range."""
+    with pytest.raises(ValueError, match=rf"Expected argument `{argument}` to be an float in the \[0,1\] range"):
+        validation_fn(**{argument: value})
+
+
+@pytest.mark.parametrize("value", [0.0, 0.5, 1.0])
+def test_min_value_validation_accepts_valid_floats(value):
+    """Test that floats on and inside the [0,1] boundaries still pass."""
+    _binary_recall_at_fixed_precision_arg_validation(min_precision=value)
+    _binary_sensitivity_at_specificity_arg_validation(min_specificity=value)
+    _binary_specificity_at_sensitivity_arg_validation(min_sensitivity=value)
+
+
+@pytest.mark.parametrize("value", [(0.0,), (0.0, 0.1, 0.2), [0.0, 0.1], "01", 0.1, None])
+def test_logauc_fpr_range_validation(value):
+    """Test that ``fpr_range`` is rejected unless it is a tuple of exactly two floats."""
+    with pytest.raises(ValueError, match="`fpr_range` should be a tuple of two floats"):
+        _validate_fpr_range(value)
+
+
+@pytest.mark.parametrize("spacing", [(1.0,), (1.0, 1.0, 1.0), [1.0, 1.0], 1.0, None])
+def test_table_contour_length_spacing_validation(spacing):
+    """Test that ``table_contour_length`` rejects a ``spacing`` that is not a tuple of length 2."""
+    with pytest.raises(ValueError, match=r"The spacing must be a tuple of length 2\."):
+        table_contour_length(spacing)
+
+
+# a list is unhashable and trips the `lru_cache` on `table_surface_area` before validation runs
+@pytest.mark.parametrize("spacing", [(1.0,), (1.0, 1.0), 1.0, None])
+def test_table_surface_area_spacing_validation(spacing):
+    """Test that ``table_surface_area`` rejects a ``spacing`` that is not a tuple of length 3."""
+    with pytest.raises(ValueError, match=r"The spacing must be a tuple of length 3\."):
+        table_surface_area(spacing)
+
+
+@pytest.mark.parametrize("functional_metric", [retrieval_average_precision, retrieval_reciprocal_rank])
+@pytest.mark.parametrize("value", [-1, 1.5, "2"])
+def test_retrieval_top_k_validation(functional_metric, value):
+    """Test that retrieval metrics reject a ``top_k`` that is not a positive int."""
+    preds = torch.tensor([0.2, 0.3, 0.5])
+    target = torch.tensor([False, False, True])
+    with pytest.raises(ValueError, match="``top_k`` has to be a positive integer or None"):
+        functional_metric(preds, target, top_k=value)


### PR DESCRIPTION
## What does this PR do?

Fixes several argument validation checks that used `not isinstance(x, T) and x <= 0` instead of `or`, which meant the check could never raise since a non-`T` value can't satisfy the numeric comparison. Also fixes a missing f-string prefix in `pearson.py`. Adds a test covering the fixed validation logic.