### PR TITLE
fix(wrappers): validate `ClasswiseWrapper` labels

### DIFF
--- a/src/torchmetrics/wrappers/classwise.py
+++ b/src/torchmetrics/wrappers/classwise.py
@@ -38,7 +38,8 @@ class ClasswiseWrapper(WrapperMetric):
     Args:
         metric: base metric that should be wrapped. It is assumed that the metric outputs a single
             tensor that is split along the first dimension.
-        labels: list of strings indicating the different classes.
+        labels: list of unique strings indicating the different classes. The number of labels must match the number of
+            values returned by the wrapped metric.
         prefix: string that is prepended to the metric names.
         postfix: string that is appended to the metric names.
 
@@ -130,6 +131,8 @@ class ClasswiseWrapper(WrapperMetric):
 
         if labels is not None and not (isinstance(labels, list) and all(isinstance(lab, str) for lab in labels)):
             raise ValueError(f"Expected argument `labels` to either be `None` or a list of strings but got {labels}")
+        if labels is not None and len(set(labels)) != len(labels):
+            raise ValueError(f"Expected argument `labels` to contain unique values, but got {labels}")
         self.labels = labels
 
         if prefix is not None and not isinstance(prefix, str):
@@ -162,6 +165,10 @@ class ClasswiseWrapper(WrapperMetric):
             postfix = self._postfix or ""
         if self.labels is None:
             return {f"{prefix}{i}{postfix}": val for i, val in enumerate(x)}
+        if len(self.labels) != len(x):
+            raise ValueError(
+                f"Expected argument `labels` to contain {len(x)} labels, but got {len(self.labels)}: {self.labels}"
+            )
         return {f"{prefix}{lab}{postfix}": val for lab, val in zip(self.labels, x)}
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:

--- a/tests/unittests/wrappers/test_classwise.py
+++ b/tests/unittests/wrappers/test_classwise.py
@@ -15,11 +15,23 @@ def test_raises_error_on_wrong_input():
     with pytest.raises(ValueError, match="Expected argument `labels` to either be `None` or a list of strings.*"):
         ClasswiseWrapper(MulticlassAccuracy(num_classes=3), "hest")
 
+    with pytest.raises(ValueError, match="Expected argument `labels` to contain unique values"):
+        ClasswiseWrapper(MulticlassAccuracy(num_classes=3), ["horse", "horse", "cat"])
+
     with pytest.raises(ValueError, match="Expected argument `prefix` to either be `None` or a string.*"):
         ClasswiseWrapper(MulticlassAccuracy(num_classes=3), prefix=1)
 
     with pytest.raises(ValueError, match="Expected argument `postfix` to either be `None` or a string.*"):
         ClasswiseWrapper(MulticlassAccuracy(num_classes=3), postfix=1)
+
+
+@pytest.mark.parametrize("labels", [["horse", "fish"], ["horse", "fish", "cat", "dog"]])
+def test_raises_error_on_wrong_number_of_labels(labels):
+    """Test that metric values are not silently dropped by mismatched labels."""
+    metric = ClasswiseWrapper(MulticlassAccuracy(num_classes=3, average=None), labels=labels)
+
+    with pytest.raises(ValueError, match="Expected argument `labels` to contain 3 labels, but got"):
+        metric(torch.tensor([0, 1, 2]), torch.tensor([0, 1, 2]))
 
 
 def test_output_no_labels():


### PR DESCRIPTION
## What does this PR do?

Fixes #3472.

`ClasswiseWrapper` previously built its output with `zip(self.labels, x)`. A shorter or longer label list therefore silently truncated one side, while duplicate labels overwrote dictionary entries. In both cases class-level metric values could disappear without an error.

This change:

- rejects duplicate custom labels during initialization;
- checks the label count against the wrapped metric output before constructing the result dictionary;
- documents the one-to-one label requirement;
- adds regressions for shorter, longer, and duplicate label lists.

The count check lives in the shared output conversion path because generic wrapped metrics do not necessarily expose their output length during initialization. It therefore protects both `forward()` and `compute()` without restricting which metric types can be wrapped.

<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/agreed via a Github issue? (#3472)
- [x] Did you read the contributor guideline?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## Validation

- Before the source fix, the three new regression cases failed because no `ValueError` was raised.
- `pytest -q tests/unittests/wrappers/test_classwise.py tests/unittests/wrappers/test_tracker.py` — 39 passed, 1 skipped.
- Wrapper suite excluding the optional feature-sharing dependency — 124 passed, 10 skipped.
- `pre-commit run --files src/torchmetrics/wrappers/classwise.py tests/unittests/wrappers/test_classwise.py` — all hooks passed.

## Did you have fun?

Yes.