### PR TITLE
docs(auroc): clarify per-batch logit/probability check in BinaryAUROC

### DIFF
--- a/src/torchmetrics/classification/auroc.py
+++ b/src/torchmetrics/classification/auroc.py
@@ -57,6 +57,13 @@ class BinaryAUROC(BinaryPrecisionRecallCurve):
       therefore only contain {0,1} values (except if `ignore_index` is specified). The value 1 always encodes the
       positive class.
 
+    .. note::
+       The probabilities-or-logits check above is applied independently on every ``update()`` call, i.e. per batch
+       rather than across the full accumulated dataset. If you call ``update()`` with small batches, a batch whose
+       predictions happen to all fall inside ``[0, 1]`` will **not** have sigmoid applied, even if other batches in
+       the same run were treated as logits. To avoid inconsistent results, either pass probabilities (post-sigmoid)
+       consistently across all batches, or apply ``torch.sigmoid`` yourself before calling ``update()``.
+
     As output to ``forward`` and ``compute`` the metric returns the following output:
 
     - ``b_auroc`` (:class:`~torch.Tensor`): A single scalar with the auroc score.


### PR DESCRIPTION
## What does this PR do?

Fixes #2195

`BinaryAUROC.update()` (inherited from `BinaryPrecisionRecallCurve`) checks per batch whether `preds` looks like logits (values outside `[0, 1]`) and applies `sigmoid` if so. This check runs independently on every `update()` call rather than once across the full accumulated dataset, so with small batch sizes it's possible for some batches to be treated as probabilities and others as logits within the same run, producing inconsistent results.

Per the reporter's suggested resolution, this PR documents that behavior more prominently in `BinaryAUROC`'s class docstring rather than changing the underlying per-batch logic (which other metrics also rely on), to keep this a minimal, low-risk documentation fix. Happy to extend this to the base `BinaryPrecisionRecallCurve` docstring too, or take a different approach, if maintainers prefer.

## Before submitting
- [x] Was this discussed/agreed via a GitHub issue? (#2195)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (n/a — this PR is the doc update)
- [ ] Did you write any new necessary tests? (n/a — documentation-only change, no behavior change)
- [ ] Did you verify new and existing tests pass locally?
- [ ] Did you list all the breaking changes introduced by this pull request?

This is my first contribution to this repo — feedback welcome.