### PR TITLE
Fix swapped hypothesis and reference in TER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
 
 
+- Fixed swapped hypothesis and reference arguments in `TER`, which made an empty hypothesis score a perfect 0.0 ([#3479](https://github.com/Lightning-AI/torchmetrics/pull/3479))
+
+
 ---
 
 ## [1.9.0] - 2026-03-05

--- a/src/torchmetrics/functional/text/ter.py
+++ b/src/torchmetrics/functional/text/ter.py
@@ -444,7 +444,7 @@ def _compute_sentence_statistics(pred_words: list[str], target_words: list[list[
     best_num_edits = tensor(2e16)
 
     for tgt_words in target_words:
-        num_edits = _translation_edit_rate(tgt_words, pred_words)
+        num_edits = _translation_edit_rate(pred_words, tgt_words)
         tgt_lengths += len(tgt_words)
         if num_edits < best_num_edits:
             best_num_edits = num_edits

--- a/tests/unittests/text/test_ter.py
+++ b/tests/unittests/text/test_ter.py
@@ -176,3 +176,22 @@ def test_ter_return_sentence_level_class():
     targets = _inputs_single_sentence_multiple_references.target
     _, sentence_ter = ter_metric(preds, targets)
     isinstance(sentence_ter, Tensor)
+
+
+def test_ter_empty_hypothesis_is_not_a_perfect_score():
+    """Test that a hypothesis producing nothing is charged one deletion per reference word."""
+    assert translation_edit_rate([""], [["hello world foo"]]) == tensor(1.0)
+
+
+def test_ter_matches_reference_when_shifts_are_asymmetric():
+    """Test that edits are counted from hypothesis to reference, not the other way around.
+
+    The shift search is not symmetric, so swapping the two sides changes the number of edits found.
+
+    """
+    preds = ["hello hello the a dog"]
+    targets = [["jumps dog lazy the"]]
+    expected = _reference_sacrebleu_ter(
+        preds, targets, normalized=False, no_punct=False, asian_support=False, case_sensitive=True
+    )
+    assert translation_edit_rate(preds, targets, lowercase=False) == expected


### PR DESCRIPTION
## What does this PR do?

Fixes #3478

`_compute_sentence_statistics` called `_translation_edit_rate(tgt_words, pred_words)`, but that function is declared `(pred_words, target_words)` and treats argument two as the reference: it builds `_LevenshteinEditDistance(target_words)` (parameter name `reference_tokens`) and shifts argument one against it. So TER was computed in the wrong direction.

Levenshtein distance is symmetric, so most scores were unaffected and the existing tests passed. Two things are not symmetric:

- **The shift search.** `hello hello the a dog` against `jumps dog lazy the` scored 1.0; sacrebleu gives 1.25.
- **The empty guard.** `if len(target_words) == 0: return tensor(0.0)` was testing the prediction, so a system that transcribed nothing scored 0.0, the best possible TER.

The fix is the argument order alone.

## Verification

sacrebleu is the reference implementation named in the metric's docstring, and `_reference_sacrebleu_ter` in the existing tests already uses it as ground truth.

| case | before | after | sacrebleu |
|---|---|---|---|
| empty hypothesis vs 3-word reference | 0.000 | 1.000 | 1.000 |
| asymmetric shift case | 1.000 | 1.250 | 1.250 |
| simple swap | 0.500 | 0.500 | 0.500 |

`unittests/text/test_ter.py`: 26 passed, 6 skipped. All four pre-existing empty-input tests pass unchanged. Both new tests fail on master with `assert tensor(0.) == tensor(1.)` and `assert tensor(1.) == tensor(1.2500)`.

## Not included, deliberately

An empty *reference* (`[[""]]`) returns `tensor(0.)` where sacrebleu returns 1.0, and `_compute_ter_score_from_statistics`'s docstring says "1 if reference_length == 0". That comes from the `num_edits > 0` conditions in that function rather than the argument order; correcting the order just moves which input reaches it. I left it out to keep this a one-line correctness fix, and can send it separately if you want it changed.

I have not added a CHANGELOG entry yet since the number was not known; happy to push one.
