### PR TITLE
Fix chrF dropping the reference n-grams of a zero-scoring sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
 
 
+- Fixed `CHRFScore` dropping the reference n-grams of a sentence that matches no reference n-gram, which inflated the corpus-level score ([#3481](https://github.com/Lightning-AI/torchmetrics/pull/3481))
+
+
 ---
 
 ## [1.9.0] - 2026-03-05

--- a/src/torchmetrics/functional/text/chrf.py
+++ b/src/torchmetrics/functional/text/chrf.py
@@ -334,7 +334,7 @@ def _calculate_sentence_level_chrf_score(
     best_target_char_n_grams: dict[int, Tensor] = defaultdict(lambda: tensor(0.0))
     best_target_word_n_grams: dict[int, Tensor] = defaultdict(lambda: tensor(0.0))
 
-    for target in targets:
+    for i, target in enumerate(targets):
         (
             target_char_n_grams_counts,
             target_word_n_grams_counts,
@@ -355,7 +355,9 @@ def _calculate_sentence_level_chrf_score(
             beta,
         )
 
-        if f_score > best_f_score:
+        # The first reference always wins the tie so that a hypothesis scoring exactly 0.0 still reports that
+        # reference's n-gram counts; otherwise the caller sums zeros into the corpus recall denominator.
+        if i == 0 or f_score > best_f_score:
             best_f_score = f_score
             best_matching_char_n_grams = matching_char_n_grams
             best_matching_word_n_grams = matching_word_n_grams

--- a/tests/unittests/text/test_chrf.py
+++ b/tests/unittests/text/test_chrf.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 from functools import partial
 
 import pytest
+import torch
 from torch import Tensor, tensor
 
 from torchmetrics.functional.text.chrf import chrf_score
@@ -161,3 +162,25 @@ def test_chrf_return_sentence_level_class():
     targets = _inputs_single_sentence_multiple_references.target
     _, chrf_sentence_score = chrf(preds, targets)
     isinstance(chrf_sentence_score, Tensor)
+
+
+def test_chrf_keeps_reference_n_grams_of_a_zero_scoring_sentence():
+    """Test that a hypothesis sharing no n-gram with its reference still contributes the reference n-grams.
+
+    Dropping them shrinks the corpus-level recall denominator and inflates the score.
+
+    """
+    preds = ["the cat sat on the mat", "zzz"]
+    targets = [["the cat sat on a mat"], ["supercalifragilistic"]]
+    expected = _reference_sacrebleu_chrf(preds, targets, char_order=6, word_order=2, lowercase=False, whitespace=False)
+    assert torch.allclose(chrf_score(preds, targets), expected, atol=1e-6)
+
+
+def test_chrf_does_not_reward_a_degraded_hypothesis():
+    """Test that replacing one hypothesis with a worse one cannot raise the corpus-level score."""
+    targets = [["the cat sat on a mat"], ["hello there my friend"]]
+    scores = [
+        chrf_score(["the cat sat on the mat", pred], targets)
+        for pred in ["hello there my friend", "hello there", "hello", "zzzz"]
+    ]
+    assert scores == sorted(scores, reverse=True), scores

--- a/tests/unittests/text/test_chrf.py
+++ b/tests/unittests/text/test_chrf.py
@@ -179,8 +179,6 @@ def test_chrf_keeps_reference_n_grams_of_a_zero_scoring_sentence():
 def test_chrf_does_not_reward_a_degraded_hypothesis():
     """Test that replacing one hypothesis with a worse one cannot raise the corpus-level score."""
     targets = [["the cat sat on a mat"], ["hello there my friend"]]
-    scores = [
-        chrf_score(["the cat sat on the mat", pred], targets)
-        for pred in ["hello there my friend", "hello there", "hello", "zzzz"]
-    ]
-    assert scores == sorted(scores, reverse=True), scores
+    preds = ["hello there my friend", "hello there", "hello", "zzzz"]
+    scores = torch.stack([chrf_score(["the cat sat on the mat", pred], targets) for pred in preds])
+    assert torch.all(scores[:-1] >= scores[1:]).item(), scores


### PR DESCRIPTION
## What does this PR do?

Fixes #3480

`_calculate_sentence_level_chrf_score` starts `best_f_score` at `tensor(0.0)` and only records a reference under `if f_score > best_f_score`. A hypothesis that shares no character or word n-gram with any of its references scores exactly `0.0`, so the guard never fires and the function returns its zero-filled defaults. `_chrf_score_update` then adds those zeros to the corpus reference totals while still adding the hypothesis n-grams, so the sentence drops out of the recall denominator and the corpus score is inflated. On the example in the issue that is 0.7080 against sacrebleu's 0.4217, and it makes the metric non-monotonic: garbage can outscore a partly correct translation.

The fix keeps the first reference unconditionally, which is what sacrebleu does with its `best_f_score = -1.0` sentinel. A better-scoring later reference still wins, so multi-reference behavior is unchanged.

Two tests, both verified to fail on `master`: one checks the corpus score against `_reference_sacrebleu_chrf`, the other checks that degrading a hypothesis cannot raise the score.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**? (no docs change needed, the documented behavior was already the intended one)
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Chasing a metric that rewards worse translations was a good one, yes.