### PR TITLE
Forward `batch_size` in `PerceptualPathLength.compute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 
 
+- Fixed `PerceptualPathLength` ignoring the `batch_size` argument, which left it running at the functional default of 64 ([#3482](https://github.com/Lightning-AI/torchmetrics/pull/3482))
+
+
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
 
 

--- a/src/torchmetrics/image/perceptual_path_length.py
+++ b/src/torchmetrics/image/perceptual_path_length.py
@@ -172,6 +172,7 @@ class PerceptualPathLength(Metric):
             generator=self.generator,
             num_samples=self.num_samples,
             conditional=self.conditional,
+            batch_size=self.batch_size,
             interpolation_method=self.interpolation_method,
             epsilon=self.epsilon,
             resize=self.resize,

--- a/tests/unittests/image/test_perceptual_path_length.py
+++ b/tests/unittests/image/test_perceptual_path_length.py
@@ -23,7 +23,7 @@ from torch_fidelity.utils import batch_interp
 from torchmetrics.functional.image.lpips import _LPIPS
 from torchmetrics.functional.image.perceptual_path_length import _interpolate, perceptual_path_length
 from torchmetrics.image.perceptual_path_length import PerceptualPathLength
-from torchmetrics.utilities.imports import _TORCH_FIDELITY_AVAILABLE
+from torchmetrics.utilities.imports import _TORCH_FIDELITY_AVAILABLE, _TORCHVISION_AVAILABLE
 from unittests._helpers import seed_all, skip_on_running_out_of_memory
 
 seed_all(42)
@@ -174,6 +174,7 @@ def test_raises_error_on_wrong_generator(generator, errortype, match):
         ppl.update(generator=generator)
 
 
+@pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="metric requires torchvision")
 def test_batch_size_is_forwarded():
     """The class metric must use the ``batch_size`` it was given, not the functional default."""
 
@@ -184,7 +185,8 @@ def test_batch_size_is_forwarded():
 
         def forward(self, img1, img2):
             self.batch_sizes.append(img1.shape[0])
-            return torch.rand(img1.shape[0])
+            # mirror LPIPS: (N, 1, 1, 1) on the same device/dtype as the input
+            return torch.rand(img1.shape[0], 1, 1, 1, device=img1.device, dtype=img1.dtype)
 
     class _TinyGenerator(nn.Module):
         num_classes = 0
@@ -193,7 +195,8 @@ def test_batch_size_is_forwarded():
             return torch.randn(num_samples, 8)
 
         def forward(self, z):
-            return torch.rand(z.shape[0], 3, 8, 8)
+            # the functional documents generator output as scaled to [0, 255]
+            return 255 * torch.rand(z.shape[0], 3, 8, 8)
 
     sim_net = _CountingSimNet()
     metric = PerceptualPathLength(num_samples=64, batch_size=32, sim_net=sim_net)

--- a/tests/unittests/image/test_perceptual_path_length.py
+++ b/tests/unittests/image/test_perceptual_path_length.py
@@ -174,6 +174,35 @@ def test_raises_error_on_wrong_generator(generator, errortype, match):
         ppl.update(generator=generator)
 
 
+def test_batch_size_is_forwarded():
+    """The class metric must use the ``batch_size`` it was given, not the functional default."""
+
+    class _CountingSimNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.batch_sizes = []
+
+        def forward(self, img1, img2):
+            self.batch_sizes.append(img1.shape[0])
+            return torch.rand(img1.shape[0])
+
+    class _TinyGenerator(nn.Module):
+        num_classes = 0
+
+        def sample(self, num_samples):
+            return torch.randn(num_samples, 8)
+
+        def forward(self, z):
+            return torch.rand(z.shape[0], 3, 8, 8)
+
+    sim_net = _CountingSimNet()
+    metric = PerceptualPathLength(num_samples=64, batch_size=32, sim_net=sim_net)
+    metric.update(_TinyGenerator())
+    metric.compute()
+
+    assert max(sim_net.batch_sizes) == 32
+
+
 @pytest.mark.skipif(not _TORCH_FIDELITY_AVAILABLE, reason="metric requires torch-fidelity")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
 @skip_on_running_out_of_memory()


### PR DESCRIPTION
## What does this PR do?

`PerceptualPathLength.__init__` documents `batch_size`, validates it, and stores it as `self.batch_size` — but that attribute is never read again. `compute()` forwards ten arguments to the functional `perceptual_path_length` and `batch_size` is not one of them, so the functional default of 64 always wins over the class default of 128.

Measured with a counting `sim_net` at `num_samples=256`:

| requested `batch_size` | class: passes / effective | functional: passes / effective |
|---|---|---|
| 128 | 4 / **64** | 2 / 128 |
| 256 | 4 / **64** | 1 / 256 |

The class ignores the argument entirely. The fix is to forward it:

```python
 return perceptual_path_length(
     generator=self.generator,
     num_samples=self.num_samples,
     conditional=self.conditional,
+    batch_size=self.batch_size,
     interpolation_method=self.interpolation_method,
```

`batch_size` only chunks the sampling loop before `torch.cat`, so the returned values are unchanged — what changes is how many generator and LPIPS forward passes run. At the library default `num_samples=10_000`, a user asking for 1024 currently gets 157 batches instead of 10.

Two things worth flagging:

- The default *effective* batch size goes 64 → 128, so peak memory at default settings roughly doubles. 128 is the documented and validated default, so honouring it looks like the correct behaviour, but it is a real change for anyone relying on the current default.
- Different batch shapes reassociate the float32 sum, so results shift by ~6e-7 relative. That is well inside the existing reference-test tolerance and the suite is unchanged.

## Testing

Added `test_batch_size_is_forwarded`, which drives the metric with a `sim_net` that records the batch dimension it receives and asserts the largest matches the requested `batch_size`.

- before the fix: `assert 64 == 32` — fails
- after the fix: passes
- full `tests/unittests/image/test_perceptual_path_length.py`: 17 passed, 1 skipped (unchanged from master)

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**? (no doc change needed — the docstring already describes the intended behaviour)
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Yes — chasing an attribute that was assigned and then quietly forgotten is a fun kind of bug.
