### PR TITLE
refactor: drop the dead torch<2.6 compatibility paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed support for PyTorch 2.0-2.5, the minimum required version is now 2.6 ([#3449](https://github.com/Lightning-AI/torchmetrics/pull/3449))
 
 
+- Removed the dead `torch<2.6` compatibility branches left behind by the 2.6 floor, including the internal `_cumsum` workaround ([#3450](https://github.com/Lightning-AI/torchmetrics/pull/3450))
+
+
 ### Fixed
 
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed support for PyTorch 2.0-2.5, the minimum required version is now 2.6 ([#3449](https://github.com/Lightning-AI/torchmetrics/pull/3449))
 
 
-- Removed the dead `torch<2.6` compatibility branches left behind by the 2.6 floor, including the internal `_cumsum` workaround ([#3450](https://github.com/Lightning-AI/torchmetrics/pull/3450))
+- Removed the dead `torch<2.6` compatibility branches left behind by the 2.6 floor, including the internal `_cumsum` workaround ([#3483](https://github.com/Lightning-AI/torchmetrics/pull/3483))
 
 
 ### Fixed

--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -493,9 +493,8 @@ In practice this means that:
 A functional metric is differentiable if its corresponding modular metric is differentiable.
 
 .. caution::
-    For PyTorch versions 2.1 or higher, differentiation in DDP mode is enabled, allowing autograd graph
-    propagation after the ``all_gather`` operation. This is useful for synchronizing metrics used as
-    loss functions in a DDP setting.
+    Differentiation in DDP mode is enabled, allowing autograd graph propagation after the ``all_gather``
+    operation. This is useful for synchronizing metrics used as loss functions in a DDP setting.
 
 ***************************************
 Metrics and hyperparameter optimization

--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -493,8 +493,9 @@ In practice this means that:
 A functional metric is differentiable if its corresponding modular metric is differentiable.
 
 .. caution::
-    Differentiation in DDP mode is enabled, allowing autograd graph propagation after the ``all_gather``
-    operation. This is useful for synchronizing metrics used as loss functions in a DDP setting.
+    For PyTorch versions 2.1 or higher, differentiation in DDP mode is enabled, allowing autograd graph
+    propagation after the ``all_gather`` operation. This is useful for synchronizing metrics used as
+    loss functions in a DDP setting.
 
 ***************************************
 Metrics and hyperparameter optimization

--- a/src/torchmetrics/detection/_mean_ap.py
+++ b/src/torchmetrics/detection/_mean_ap.py
@@ -22,7 +22,6 @@ from torch import IntTensor, Tensor
 
 from torchmetrics.detection.helpers import _fix_empty_tensors, _input_validator
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.data import _cumsum
 from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE, _PYCOCOTOOLS_AVAILABLE, _TORCHVISION_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
 
@@ -830,8 +829,8 @@ class MeanAveragePrecision(Metric):
         tps = torch.logical_and(det_matches, torch.logical_not(det_ignore))
         fps = torch.logical_and(torch.logical_not(det_matches), torch.logical_not(det_ignore))
 
-        tp_sum = _cumsum(tps, dim=1, dtype=torch.float)
-        fp_sum = _cumsum(fps, dim=1, dtype=torch.float)
+        tp_sum = torch.cumsum(tps, dim=1, dtype=torch.float)
+        fp_sum = torch.cumsum(fps, dim=1, dtype=torch.float)
         for idx, (tp, fp) in enumerate(zip(tp_sum, fp_sum)):
             tp_len = len(tp)
             rc = tp / npig

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -22,7 +22,7 @@ from typing_extensions import Literal
 
 from torchmetrics.utilities.checks import _check_same_shape
 from torchmetrics.utilities.compute import _safe_divide, interp, normalize_logits_if_needed
-from torchmetrics.utilities.data import _bincount, _cumsum
+from torchmetrics.utilities.data import _bincount
 from torchmetrics.utilities.enums import ClassificationTask
 from torchmetrics.utilities.prints import rank_zero_warn
 
@@ -70,12 +70,12 @@ def _binary_clf_curve(
         distinct_value_indices = torch.where(preds[1:] - preds[:-1])[0]
         threshold_idxs = F.pad(distinct_value_indices, [0, 1], value=target.size(0) - 1)
         target = (target == pos_label).to(torch.long)
-        tps = _cumsum(target * weight, dim=0)[threshold_idxs]
+        tps = torch.cumsum(target * weight, dim=0)[threshold_idxs]
 
         if sample_weights is not None:
             # express fps as a cumsum to ensure fps is increasing even in
             # the presence of floating point errors
-            fps = _cumsum((1 - target) * weight, dim=0)[threshold_idxs]
+            fps = torch.cumsum((1 - target) * weight, dim=0)[threshold_idxs]
         else:
             fps = 1 + threshold_idxs - tps
 

--- a/src/torchmetrics/functional/classification/ranking.py
+++ b/src/torchmetrics/functional/classification/ranking.py
@@ -21,7 +21,6 @@ from torchmetrics.functional.classification.confusion_matrix import (
     _multilabel_confusion_matrix_format,
     _multilabel_confusion_matrix_tensor_validation,
 )
-from torchmetrics.utilities.data import _cumsum
 
 
 def _rank_data(x: Tensor) -> Tensor:
@@ -29,7 +28,7 @@ def _rank_data(x: Tensor) -> Tensor:
     # torch.unique does not support input that requires grad
     with torch.no_grad():
         _, inverse, counts = torch.unique(x, sorted=True, return_inverse=True, return_counts=True)
-    ranks = _cumsum(counts, dim=0)
+    ranks = torch.cumsum(counts, dim=0)
     return ranks[inverse]
 
 

--- a/src/torchmetrics/functional/image/arniqa.py
+++ b/src/torchmetrics/functional/image/arniqa.py
@@ -25,7 +25,7 @@ from torch import Tensor, nn
 from torch.nn.functional import normalize as normalize_fn
 from typing_extensions import Literal
 
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_2, _TORCHVISION_AVAILABLE
+from torchmetrics.utilities.imports import _TORCHVISION_AVAILABLE
 
 if _TORCHVISION_AVAILABLE:
     from torchvision import transforms
@@ -41,7 +41,7 @@ _TYPE_REGRESSOR_DATASET = Literal["kadid10k", "koniq10k"]
 _base_url = "https://github.com/miccunifi/ARNIQA/releases/download/weights"
 
 
-if not (_TORCH_GREATER_EQUAL_2_2 and _TORCHVISION_AVAILABLE):
+if not _TORCHVISION_AVAILABLE:
     __doctest_skip__ = ["arniqa"]
 
 
@@ -55,9 +55,6 @@ class _ARNIQA(nn.Module):
 
     def __init__(self, regressor_dataset: _TYPE_REGRESSOR_DATASET = "koniq10k") -> None:
         super().__init__()
-
-        if not _TORCH_GREATER_EQUAL_2_2:  # ToDo: RuntimeError: "slow_conv2d_cpu" not implemented for 'Half'
-            raise RuntimeError("ARNIQA metric requires PyTorch >= 2.2.0")
 
         if not _TORCHVISION_AVAILABLE:
             raise ModuleNotFoundError(

--- a/src/torchmetrics/functional/regression/kendall.py
+++ b/src/torchmetrics/functional/regression/kendall.py
@@ -19,7 +19,7 @@ from typing_extensions import Literal
 
 from torchmetrics.functional.regression.utils import _check_data_shape_to_num_outputs
 from torchmetrics.utilities.checks import _check_same_shape
-from torchmetrics.utilities.data import _bincount, _cumsum, dim_zero_cat
+from torchmetrics.utilities.data import _bincount, dim_zero_cat
 from torchmetrics.utilities.enums import EnumStr
 
 
@@ -91,7 +91,7 @@ def _convert_sequence_to_dense_rank(x: Tensor, sort: bool = False) -> Tensor:
     if sort:
         x = x.sort(dim=0).values
     _ones = torch.zeros(1, x.shape[1], dtype=torch.int32, device=x.device)
-    return _cumsum(torch.cat([_ones, (x[1:] != x[:-1]).int()], dim=0), dim=0)
+    return torch.cumsum(torch.cat([_ones, (x[1:] != x[:-1]).int()], dim=0), dim=0)
 
 
 def _get_ties(x: Tensor) -> tuple[Tensor, Tensor, Tensor]:

--- a/src/torchmetrics/functional/retrieval/precision_recall_curve.py
+++ b/src/torchmetrics/functional/retrieval/precision_recall_curve.py
@@ -18,7 +18,6 @@ from torch import Tensor
 from torch.nn.functional import pad
 
 from torchmetrics.utilities.checks import _check_retrieval_functional_inputs
-from torchmetrics.utilities.data import _cumsum
 
 
 def retrieval_precision_recall_curve(
@@ -92,7 +91,7 @@ def retrieval_precision_recall_curve(
         return torch.zeros(max_k, device=preds.device), torch.zeros(max_k, device=preds.device), topk
 
     relevant = target[preds.topk(min(max_k, preds.shape[-1]), dim=-1)[1]].float()
-    relevant = _cumsum(pad(relevant, (0, max(0, max_k - len(relevant))), "constant", 0.0), dim=0)
+    relevant = torch.cumsum(pad(relevant, (0, max(0, max_k - len(relevant))), "constant", 0.0), dim=0)
 
     recall = relevant / target.sum()
     precision = relevant / topk

--- a/src/torchmetrics/functional/text/helper_embedding_metric.py
+++ b/src/torchmetrics/functional/text/helper_embedding_metric.py
@@ -20,7 +20,6 @@ import torch
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
 
-from torchmetrics.utilities.data import _cumsum
 from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_GREATER_EQUAL_4_4
 
 if TYPE_CHECKING:
@@ -43,7 +42,7 @@ def _process_attention_mask_for_special_tokens(attention_mask: Tensor) -> Tensor
     # Make attention_mask zero for [CLS] token
     attention_mask[:, 0] = 0
     # Make attention_mask zero for [SEP] token
-    sep_token_position = _cumsum((attention_mask - 0.1), dim=-1).argmax(-1)
+    sep_token_position = torch.cumsum((attention_mask - 0.1), dim=-1).argmax(-1)
     attention_mask[torch.arange(attention_mask.size(0)).long(), sep_token_position] = 0
     return attention_mask
 

--- a/src/torchmetrics/image/arniqa.py
+++ b/src/torchmetrics/image/arniqa.py
@@ -27,13 +27,13 @@ from torchmetrics.functional.image.arniqa import (
 )
 from torchmetrics.metric import Metric
 from torchmetrics.utilities.checks import _SKIP_SLOW_DOCTEST, _try_proceed_with_timeout
-from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE, _TORCH_GREATER_EQUAL_2_2, _TORCHVISION_AVAILABLE
+from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE, _TORCHVISION_AVAILABLE
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
 
 if not _MATPLOTLIB_AVAILABLE:
     __doctest_skip__ = ["ARNIQA.plot"]
 
-if _TORCH_GREATER_EQUAL_2_2 and _TORCHVISION_AVAILABLE:
+if _TORCHVISION_AVAILABLE:
 
     def _download_arniqa() -> None:
         _ARNIQA(regressor_dataset="koniq10k")
@@ -138,9 +138,6 @@ class ARNIQA(Metric):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-
-        if not _TORCH_GREATER_EQUAL_2_2:  # ToDo: RuntimeError: "slow_conv2d_cpu" not implemented for 'Half'
-            raise RuntimeError("ARNIQA metric requires PyTorch >= 2.2.0")
 
         if not _TORCHVISION_AVAILABLE:
             raise ModuleNotFoundError(

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -39,7 +39,7 @@ from torchmetrics.utilities.data import (
 )
 from torchmetrics.utilities.distributed import gather_all_tensors
 from torchmetrics.utilities.exceptions import TorchMetricsUserError
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1, _TORCH_GREATER_EQUAL_2_8
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_8
 from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE, plot_single_or_multi_val
 from torchmetrics.utilities.prints import rank_zero_warn
 
@@ -111,8 +111,6 @@ class Metric(Module, ABC):
         # see (https://github.com/pytorch/pytorch/blob/3e6bb5233f9ca2c5aa55d9cda22a7ee85439aa6e/
         # torch/nn/modules/module.py#L227)
         torch._C._log_api_usage_once(f"torchmetrics.metric.{self.__class__.__name__}")
-        # magic patch for `RuntimeError: DataLoader worker (pid(s) 104) exited unexpectedly`
-        self._TORCH_GREATER_EQUAL_2_1 = bool(_TORCH_GREATER_EQUAL_2_1)
         # before 2.8, `get_default_device` only tracked `set_default_device`, not an active `torch.device` context
         self._device = torch.get_default_device() if _TORCH_GREATER_EQUAL_2_8 else torch.empty(0).device
         self._dtype = torch.get_default_dtype()
@@ -508,12 +506,7 @@ class Metric(Module, ABC):
                 input_dict[attr] = [dim_zero_cat(input_dict[attr])]
 
             # cornor case in distributed settings where a rank have not received any data, create empty to concatenate
-            if (
-                self._TORCH_GREATER_EQUAL_2_1
-                and reduction_fn == dim_zero_cat
-                and isinstance(input_dict[attr], list)
-                and len(input_dict[attr]) == 0
-            ):
+            if reduction_fn == dim_zero_cat and isinstance(input_dict[attr], list) and len(input_dict[attr]) == 0:
                 input_dict[attr] = [torch.tensor([], device=self.device, dtype=self.dtype)]
 
         output_dict = apply_to_collection(

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -505,7 +505,7 @@ class Metric(Module, ABC):
             if reduction_fn == dim_zero_cat and isinstance(input_dict[attr], list) and len(input_dict[attr]) > 1:
                 input_dict[attr] = [dim_zero_cat(input_dict[attr])]
 
-            # cornor case in distributed settings where a rank have not received any data, create empty to concatenate
+            # corner case in distributed settings where a rank has not received any data, create empty to concatenate
             if reduction_fn == dim_zero_cat and isinstance(input_dict[attr], list) and len(input_dict[attr]) == 0:
                 input_dict[attr] = [torch.tensor([], device=self.device, dtype=self.dtype)]
 

--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
 from collections.abc import Sequence
 from typing import Any, List, Optional, Union
 
@@ -19,9 +18,7 @@ import torch
 from lightning_utilities import apply_to_collection
 from torch import Tensor
 
-from torchmetrics.utilities.exceptions import TorchMetricsUserWarning
-from torchmetrics.utilities.imports import _TORCH_LESS_THAN_2_6, _XLA_AVAILABLE
-from torchmetrics.utilities.prints import rank_zero_warn
+from torchmetrics.utilities.imports import _XLA_AVAILABLE
 
 METRIC_EPS = 1e-6
 
@@ -204,20 +201,6 @@ def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
         return torch.eq(x.reshape(-1, 1), mesh).sum(dim=0)
 
     return torch.bincount(x, minlength=minlength)
-
-
-def _cumsum(x: Tensor, dim: Optional[int] = 0, dtype: Optional[torch.dtype] = None) -> Tensor:
-    """Implement custom cumulative summation for Torch versions which does not support it natively."""
-    is_cuda_fp_deterministic = torch.are_deterministic_algorithms_enabled() and x.is_cuda and x.is_floating_point()
-    if _TORCH_LESS_THAN_2_6 and is_cuda_fp_deterministic and sys.platform != "win32":
-        rank_zero_warn(
-            "You are trying to use a metric in deterministic mode on GPU that uses `torch.cumsum`, which is currently"
-            " not supported. The tensor will be copied to the CPU memory to compute it and then copied back to GPU."
-            " Expect some slowdowns.",
-            TorchMetricsUserWarning,
-        )
-        return x.cpu().cumsum(dim=dim, dtype=dtype).to(x.device)
-    return torch.cumsum(x, dim=dim, dtype=dtype)
 
 
 def _flexible_bincount(x: Tensor) -> Tensor:

--- a/src/torchmetrics/utilities/imports.py
+++ b/src/torchmetrics/utilities/imports.py
@@ -19,12 +19,7 @@ import sys
 from lightning_utilities.core.imports import RequirementCache
 
 _PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-_TORCH_GREATER_EQUAL_2_1 = RequirementCache("torch>=2.1.0")
-_TORCH_GREATER_EQUAL_2_2 = RequirementCache("torch>=2.2.0")
-_TORCH_GREATER_EQUAL_2_3 = RequirementCache("torch>=2.3.0")
-_TORCH_GREATER_EQUAL_2_5 = RequirementCache("torch>=2.5.0")
 _TORCH_GREATER_EQUAL_2_8 = RequirementCache("torch>=2.8.0")
-_TORCH_LESS_THAN_2_6 = RequirementCache("torch<2.6.0")
 _TORCHMETRICS_GREATER_EQUAL_1_6 = RequirementCache("torchmetrics>=1.7.0")
 
 _NLTK_AVAILABLE = RequirementCache("nltk")

--- a/src/torchmetrics/utilities/imports.py
+++ b/src/torchmetrics/utilities/imports.py
@@ -20,7 +20,6 @@ from lightning_utilities.core.imports import RequirementCache
 
 _PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 _TORCH_GREATER_EQUAL_2_8 = RequirementCache("torch>=2.8.0")
-_TORCHMETRICS_GREATER_EQUAL_1_6 = RequirementCache("torchmetrics>=1.7.0")
 
 _NLTK_AVAILABLE = RequirementCache("nltk")
 _ROUGE_SCORE_AVAILABLE = RequirementCache("rouge_score")

--- a/tests/unittests/bases/test_ddp.py
+++ b/tests/unittests/bases/test_ddp.py
@@ -22,7 +22,6 @@ from torch import tensor
 from torchmetrics import Metric
 from torchmetrics.utilities.distributed import gather_all_tensors
 from torchmetrics.utilities.exceptions import TorchMetricsUserError
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_PROCESSES, USE_PYTEST_POOL
 from unittests._helpers import _IS_WINDOWS, seed_all
 from unittests._helpers.testers import DummyListMetric, DummyMetric, DummyMetricSum
@@ -319,7 +318,6 @@ def _test_sync_with_empty_lists(rank):
 
 
 @pytest.mark.DDP
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test only works on newer torch versions")
 @pytest.mark.skipif(_IS_WINDOWS, reason="DDP not available on windows")
 @pytest.mark.skipif(not USE_PYTEST_POOL, reason="DDP pool is not available.")
 def test_sync_with_empty_lists():
@@ -336,7 +334,6 @@ def _test_sync_with_unequal_size_lists(rank):
 
 
 @pytest.mark.DDP
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test only works on newer torch versions")
 @pytest.mark.skipif(_IS_WINDOWS, reason="DDP not available on windows")
 @pytest.mark.skipif(not USE_PYTEST_POOL, reason="DDP pool is not available.")
 def test_sync_with_unequal_size_lists():

--- a/tests/unittests/classification/test_accuracy.py
+++ b/tests/unittests/classification/test_accuracy.py
@@ -28,7 +28,6 @@ from torchmetrics.functional.classification.accuracy import (
     multilabel_accuracy,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -154,8 +153,6 @@ class TestBinaryAccuracy(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -311,8 +308,6 @@ class TestMulticlassAccuracy(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -708,8 +703,6 @@ class TestMultilabelAccuracy(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_auroc.py
+++ b/tests/unittests/classification/test_auroc.py
@@ -25,7 +25,6 @@ from torchmetrics.classification.auroc import AUROC, BinaryAUROC, MulticlassAURO
 from torchmetrics.functional.classification.auroc import binary_auroc, multiclass_auroc, multilabel_auroc
 from torchmetrics.functional.classification.roc import binary_roc
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -103,8 +102,6 @@ class TestBinaryAUROC(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_average_precision.py
+++ b/tests/unittests/classification/test_average_precision.py
@@ -34,7 +34,6 @@ from torchmetrics.functional.classification.average_precision import (
 )
 from torchmetrics.functional.classification.precision_recall_curve import binary_precision_recall_curve
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -107,8 +106,6 @@ class TestBinaryAveragePrecision(MetricTester):
     def test_binary_average_precision_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_calibration_error.py
+++ b/tests/unittests/classification/test_calibration_error.py
@@ -30,7 +30,6 @@ from torchmetrics.functional.classification.calibration_error import (
     multiclass_calibration_error,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -113,8 +112,6 @@ class TestBinaryCalibrationError(MetricTester):
     def test_binary_calibration_error_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_cohen_kappa.py
+++ b/tests/unittests/classification/test_cohen_kappa.py
@@ -22,7 +22,6 @@ from sklearn.metrics import cohen_kappa_score as sk_cohen_kappa
 from torchmetrics.classification.cohen_kappa import BinaryCohenKappa, CohenKappa, MulticlassCohenKappa
 from torchmetrics.functional.classification.cohen_kappa import binary_cohen_kappa, multiclass_cohen_kappa
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -104,8 +103,6 @@ class TestBinaryCohenKappa(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -207,8 +204,6 @@ class TestMulticlassCohenKappa(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_confusion_matrix.py
+++ b/tests/unittests/classification/test_confusion_matrix.py
@@ -31,7 +31,6 @@ from torchmetrics.functional.classification.confusion_matrix import (
     multilabel_confusion_matrix,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -115,8 +114,6 @@ class TestBinaryConfusionMatrix(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -368,8 +365,6 @@ class TestMultilabelConfusionMatrix(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_eer.py
+++ b/tests/unittests/classification/test_eer.py
@@ -25,7 +25,6 @@ from torchmetrics.classification.eer import EER, BinaryEER, MulticlassEER, Multi
 from torchmetrics.functional.classification.eer import binary_eer, multiclass_eer, multilabel_eer
 from torchmetrics.functional.classification.roc import binary_roc
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -97,8 +96,6 @@ class TestBinaryEER(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_exact_match.py
+++ b/tests/unittests/classification/test_exact_match.py
@@ -21,7 +21,6 @@ from scipy.special import expit as sigmoid
 from torchmetrics.classification.exact_match import ExactMatch, MulticlassExactMatch, MultilabelExactMatch
 from torchmetrics.functional.classification.exact_match import multiclass_exact_match, multilabel_exact_match
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index
@@ -122,8 +121,6 @@ class TestMulticlassExactMatch(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -252,8 +249,6 @@ class TestMultilabelExactMatch(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_f_beta.py
+++ b/tests/unittests/classification/test_f_beta.py
@@ -41,7 +41,6 @@ from torchmetrics.functional.classification.f_beta import (
     multilabel_fbeta_score,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -172,8 +171,6 @@ class TestBinaryFBetaScore(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -350,8 +347,6 @@ class TestMulticlassFBetaScore(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -706,8 +701,6 @@ class TestMultilabelFBetaScore(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_group_fairness.py
+++ b/tests/unittests/classification/test_group_fairness.py
@@ -27,7 +27,6 @@ from torch import Tensor
 from torchmetrics import Metric
 from torchmetrics.classification.group_fairness import BinaryFairness
 from torchmetrics.functional.classification.group_fairness import binary_fairness
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import (
@@ -287,8 +286,6 @@ class TestBinaryFairness(BinaryFairnessTester):
         """Test class implementation of metric."""
         preds, target, groups = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_hamming_distance.py
+++ b/tests/unittests/classification/test_hamming_distance.py
@@ -32,7 +32,6 @@ from torchmetrics.functional.classification.hamming import (
     multilabel_hamming_distance,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -139,8 +138,6 @@ class TestBinaryHammingDistance(MetricTester):
     def test_binary_hamming_distance_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -302,8 +299,6 @@ class TestMulticlassHammingDistance(MetricTester):
     def test_multiclass_hamming_distance_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -486,8 +481,6 @@ class TestMultilabelHammingDistance(MetricTester):
     def test_multilabel_hamming_distance_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_jaccard.py
+++ b/tests/unittests/classification/test_jaccard.py
@@ -33,7 +33,6 @@ from torchmetrics.functional.classification.jaccard import (
     multilabel_jaccard_index,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 from unittests.classification._inputs import _binary_cases, _multiclass_cases, _multilabel_cases
@@ -109,8 +108,6 @@ class TestBinaryJaccardIndex(MetricTester):
     def test_binary_jaccard_index_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -356,8 +353,6 @@ class TestMultilabelJaccardIndex(MetricTester):
     def test_multilabel_jaccard_index_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_logauc.py
+++ b/tests/unittests/classification/test_logauc.py
@@ -28,7 +28,6 @@ from torchmetrics.classification.logauc import BinaryLogAUC, LogAUC, MulticlassL
 from torchmetrics.functional.classification.logauc import binary_logauc, multiclass_logauc, multilabel_logauc
 from torchmetrics.functional.classification.roc import binary_roc
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -106,8 +105,6 @@ class TestBinaryLogAUC(MetricTester):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
 
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_matthews_corrcoef.py
+++ b/tests/unittests/classification/test_matthews_corrcoef.py
@@ -32,7 +32,6 @@ from torchmetrics.functional.classification.matthews_corrcoef import (
     multilabel_matthews_corrcoef,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -107,8 +106,6 @@ class TestBinaryMatthewsCorrCoef(MetricTester):
     def test_binary_matthews_corrcoef_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -289,8 +286,6 @@ class TestMultilabelMatthewsCorrCoef(MetricTester):
     def test_multilabel_matthews_corrcoef_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_negative_predictive_value.py
+++ b/tests/unittests/classification/test_negative_predictive_value.py
@@ -32,7 +32,6 @@ from torchmetrics.functional.classification.negative_predictive_value import (
     multilabel_negative_predictive_value,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index
@@ -156,8 +155,6 @@ class TestBinaryNegativePredictiveValue(MetricTester):
     def test_binary_negative_predictive_value_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -333,8 +330,6 @@ class TestMulticlassNegativePredictiveValue(MetricTester):
     def test_multiclass_negative_predictive_value_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -539,8 +534,6 @@ class TestMultilabelNegativePredictiveValue(MetricTester):
     def test_multilabel_negative_predictive_value_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_precision_fixed_recall.py
+++ b/tests/unittests/classification/test_precision_fixed_recall.py
@@ -33,7 +33,6 @@ from torchmetrics.functional.classification.precision_fixed_recall import (
     multilabel_precision_at_fixed_recall,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -126,8 +125,6 @@ class TestBinaryPrecisionAtFixedRecall(MetricTester):
     def test_binary_precision_at_fixed_recall_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_precision_recall.py
+++ b/tests/unittests/classification/test_precision_recall.py
@@ -41,7 +41,6 @@ from torchmetrics.functional.classification.precision_recall import (
     multilabel_recall,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -173,8 +172,6 @@ class TestBinaryPrecisionRecall(MetricTester):
     def test_binary_precision_recall_half_cpu(self, inputs, module, functional, compare, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -356,8 +353,6 @@ class TestMulticlassPrecisionRecall(MetricTester):
     def test_multiclass_precision_recall_half_cpu(self, inputs, module, functional, compare, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -712,8 +707,6 @@ class TestMultilabelPrecisionRecall(MetricTester):
     def test_multilabel_precision_recall_half_cpu(self, inputs, module, functional, compare, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_precision_recall_curve.py
+++ b/tests/unittests/classification/test_precision_recall_curve.py
@@ -33,7 +33,6 @@ from torchmetrics.functional.classification.precision_recall_curve import (
     multilabel_precision_recall_curve,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -106,8 +105,6 @@ class TestBinaryPrecisionRecallCurve(MetricTester):
     def test_binary_precision_recall_curve_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_ranking.py
+++ b/tests/unittests/classification/test_ranking.py
@@ -31,7 +31,6 @@ from torchmetrics.functional.classification.ranking import (
     multilabel_ranking_average_precision,
     multilabel_ranking_loss,
 )
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index
@@ -118,8 +117,6 @@ class TestMultilabelRanking(MetricTester):
     def test_multilabel_ranking_dtype_cpu(self, inputs, metric, functional_metric, ref_metric, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         if dtype == torch.half and functional_metric == multilabel_ranking_average_precision:
             pytest.xfail(
                 reason="multilabel_ranking_average_precision requires torch.unique which is not implemented for half"

--- a/tests/unittests/classification/test_recall_fixed_precision.py
+++ b/tests/unittests/classification/test_recall_fixed_precision.py
@@ -33,7 +33,6 @@ from torchmetrics.functional.classification.recall_fixed_precision import (
     multilabel_recall_at_fixed_precision,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -130,8 +129,6 @@ class TestBinaryRecallAtFixedPrecision(MetricTester):
     def test_binary_recall_at_fixed_precision_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_roc.py
+++ b/tests/unittests/classification/test_roc.py
@@ -24,7 +24,6 @@ from sklearn.metrics import roc_curve as sk_roc_curve
 from torchmetrics.classification.roc import ROC, BinaryROC, MulticlassROC, MultilabelROC
 from torchmetrics.functional.classification.roc import binary_roc, multiclass_roc, multilabel_roc
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -99,8 +98,6 @@ class TestBinaryROC(MetricTester):
     def test_binary_roc_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_sensitivity_specificity.py
+++ b/tests/unittests/classification/test_sensitivity_specificity.py
@@ -34,7 +34,6 @@ from torchmetrics.functional.classification.sensitivity_specificity import (
     multilabel_sensitivity_at_specificity,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import _SKLEARN_GREATER_EQUAL_1_3, seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -153,8 +152,6 @@ class TestBinarySensitivityAtSpecificity(MetricTester):
     def test_binary_sensitivity_at_specificity_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_specificity.py
+++ b/tests/unittests/classification/test_specificity.py
@@ -32,7 +32,6 @@ from torchmetrics.functional.classification.specificity import (
     multilabel_specificity,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index
@@ -152,8 +151,6 @@ class TestBinarySpecificity(MetricTester):
     def test_binary_specificity_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -329,8 +326,6 @@ class TestMulticlassSpecificity(MetricTester):
     def test_multiclass_specificity_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -558,8 +553,6 @@ class TestMultilabelSpecificity(MetricTester):
     def test_multilabel_specificity_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_specificity_sensitivity.py
+++ b/tests/unittests/classification/test_specificity_sensitivity.py
@@ -34,7 +34,6 @@ from torchmetrics.functional.classification.specificity_sensitivity import (
     multilabel_specificity_at_sensitivity,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -149,8 +148,6 @@ class TestBinarySpecificityAtSensitivity(MetricTester):
     def test_binary_specificity_at_sensitivity_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/classification/test_stat_scores.py
+++ b/tests/unittests/classification/test_stat_scores.py
@@ -33,7 +33,6 @@ from torchmetrics.functional.classification.stat_scores import (
     multilabel_stat_scores,
 )
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import NUM_CLASSES, THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
@@ -137,8 +136,6 @@ class TestBinaryStatScores(MetricTester):
     def test_binary_stat_scores_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -302,8 +299,6 @@ class TestMulticlassStatScores(MetricTester):
     def test_multiclass_stat_scores_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,
@@ -610,8 +605,6 @@ class TestMultilabelStatScores(MetricTester):
     def test_multilabel_stat_scores_dtype_cpu(self, inputs, dtype):
         """Test dtype support of the metric on CPU."""
         preds, target = inputs
-        if not _TORCH_GREATER_EQUAL_2_1 and (preds < 0).any() and dtype == torch.half:
-            pytest.xfail(reason="torch.sigmoid in metric does not support cpu + half precision for torch<2.1")
         self.run_precision_test_cpu(
             preds=preds,
             target=target,

--- a/tests/unittests/clustering/test_cluster_accuracy.py
+++ b/tests/unittests/clustering/test_cluster_accuracy.py
@@ -16,7 +16,7 @@ import torch
 
 from torchmetrics.clustering.cluster_accuracy import ClusterAccuracy
 from torchmetrics.functional.clustering.cluster_accuracy import cluster_accuracy
-from torchmetrics.utilities.imports import _AEON_AVAILABLE, _TORCH_GREATER_EQUAL_2_1, _TORCH_LINEAR_ASSIGNMENT_AVAILABLE
+from torchmetrics.utilities.imports import _AEON_AVAILABLE, _TORCH_LINEAR_ASSIGNMENT_AVAILABLE
 from unittests import NUM_CLASSES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -29,7 +29,6 @@ else:
 seed_all(42)
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test requires PyTorch 2.1 or higher")
 @pytest.mark.skipif(not _TORCH_LINEAR_ASSIGNMENT_AVAILABLE, reason="test requires torch linear assignment package")
 @pytest.mark.skipif(not _AEON_AVAILABLE, reason="test requires aeon package")
 @pytest.mark.parametrize(
@@ -65,7 +64,6 @@ class TestAdjustedMutualInfoScore(MetricTester):
         )
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test requires PyTorch 2.1 or higher")
 @pytest.mark.skipif(not _TORCH_LINEAR_ASSIGNMENT_AVAILABLE, reason="test requires torch linear assignment package")
 def test_cluster_accuracy_sanity_check():
     """Check that metric works with the simplest possible inputs."""
@@ -76,7 +74,6 @@ def test_cluster_accuracy_sanity_check():
     assert torch.allclose(res, torch.tensor(1.0))
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_1, reason="test requires PyTorch 2.1 or higher")
 @pytest.mark.skipif(not _TORCH_LINEAR_ASSIGNMENT_AVAILABLE, reason="test requires torch linear assignment package")
 def test_cluster_accuracy_functional_raises_invalid_task():
     """Check that metric rejects continuous-valued inputs."""

--- a/tests/unittests/image/test_arniqa.py
+++ b/tests/unittests/image/test_arniqa.py
@@ -20,7 +20,7 @@ from torch import Tensor
 
 from torchmetrics.functional.image.arniqa import arniqa
 from torchmetrics.image.arniqa import ARNIQA
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_2, _TORCHVISION_AVAILABLE
+from torchmetrics.utilities.imports import _TORCHVISION_AVAILABLE
 from unittests._helpers import seed_all, skip_on_connection_issues
 from unittests._helpers.testers import MetricTester
 
@@ -68,7 +68,6 @@ def _reference_arniqa(img: Tensor, target: Tensor, regressor_dataset: str, reduc
 
 
 @skip_on_connection_issues()
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_2, reason="`slow_conv2d_cpu` does not support cpu + half precision")
 @pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
 class TestARNIQA(MetricTester):
     """Test class for `ARNIQA` metric."""
@@ -115,7 +114,6 @@ class TestARNIQA(MetricTester):
         self.run_precision_test_gpu(preds=_input_img, target=_input_img, metric_module=ARNIQATesterClass)
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_2, reason="`slow_conv2d_cpu` does not support cpu + half precision")
 @pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
 def test_normalize_arg():
     """Test that normalize argument works as expected."""
@@ -127,7 +125,6 @@ def test_normalize_arg():
     assert torch.allclose(res, res2, atol=1e-6), f"Results differ: max difference {torch.max((res - res2).abs())}"
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_2, reason="`slow_conv2d_cpu` does not support cpu + half precision")
 @pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
 def test_error_on_wrong_init():
     """Test class raises the expected errors."""
@@ -138,7 +135,6 @@ def test_error_on_wrong_init():
         ARNIQA(regressor_dataset="koniq10k", reduction=None)
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_2, reason="`slow_conv2d_cpu` does not support cpu + half precision")
 @pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
 def test_error_on_wrong_input_shape():
     """Test error is raised on wrong input shape to update method."""
@@ -148,7 +144,6 @@ def test_error_on_wrong_input_shape():
         metric(inp)
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_2, reason="`slow_conv2d_cpu` does not support cpu + half precision")
 @pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
 def test_error_on_wrong_normalize_value():
     """Test error is raised on wrong normalize parameter value to update method."""
@@ -158,7 +153,6 @@ def test_error_on_wrong_normalize_value():
         metric(inp)
 
 
-@pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_2, reason="`slow_conv2d_cpu` does not support cpu + half precision")
 @pytest.mark.skipif(not _TORCHVISION_AVAILABLE, reason="test requires that torchvision is installed")
 def test_check_for_backprop():
     """Check that by default the metric supports propagation of gradients, but does not update its parameters."""

--- a/tests/unittests/image/test_ergas.py
+++ b/tests/unittests/image/test_ergas.py
@@ -20,7 +20,6 @@ from torch import Tensor
 
 from torchmetrics.functional.image.ergas import error_relative_global_dimensionless_synthesis
 from torchmetrics.image.ergas import ErrorRelativeGlobalDimensionlessSynthesis
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -104,11 +103,6 @@ class TestErrorRelativeGlobalDimensionlessSynthesis(MetricTester):
             metric_args={"ratio": ratio, "reduction": reduction},
         )
 
-    # ERGAS half + cpu does not work due to missing support in torch.log
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1,
-        reason="Pytoch below 2.1 does not support cpu + half precision used in ERGAS metric",
-    )
     def test_ergas_half_cpu(self, reduction, preds, target, ratio):
         """Test dtype support of the metric on CPU."""
         self.run_precision_test_cpu(

--- a/tests/unittests/image/test_psnr.py
+++ b/tests/unittests/image/test_psnr.py
@@ -21,7 +21,6 @@ from skimage.metrics import peak_signal_noise_ratio as skimage_peak_signal_noise
 
 from torchmetrics.functional import peak_signal_noise_ratio
 from torchmetrics.image import PeakSignalNoiseRatio
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, NUM_BATCHES, _Input
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -122,11 +121,6 @@ class TestPSNR(MetricTester):
             metric_args=_args,
         )
 
-    # PSNR half + cpu does not work due to missing support in torch.log
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1,
-        reason="Pytoch below 2.1 does not support cpu + half precision used in PSNR metric",
-    )
     def test_psnr_half_cpu(self, preds, target, data_range, reduction, dim, base, ref_metric):
         """Test dtype support of the metric on CPU."""
         self.run_precision_test_cpu(

--- a/tests/unittests/image/test_sam.py
+++ b/tests/unittests/image/test_sam.py
@@ -20,7 +20,6 @@ from torch.nn import functional as F  # noqa: N812
 
 from torchmetrics.functional.image.sam import spectral_angle_mapper
 from torchmetrics.image.sam import SpectralAngleMapper
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, NUM_BATCHES, _Input
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -85,10 +84,6 @@ class TestSpectralAngleMapper(MetricTester):
             metric_args={"reduction": reduction},
         )
 
-    # SAM half + cpu does not work due to missing support in torch.log
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1, reason="Pytoch below 2.1 does not support cpu + half precision used in SAM metric"
-    )
     def test_sam_half_cpu(self, reduction, preds, target):
         """Test dtype support of the metric on CPU."""
         self.run_precision_test_cpu(

--- a/tests/unittests/image/test_uqi.py
+++ b/tests/unittests/image/test_uqi.py
@@ -21,7 +21,6 @@ from torch import Tensor
 
 from torchmetrics.functional.image.uqi import universal_image_quality_index
 from torchmetrics.image.uqi import UniversalImageQualityIndex
-from torchmetrics.utilities.imports import _TORCH_LESS_THAN_2_6
 from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -109,8 +108,6 @@ class TestUQI(MetricTester):
             metric_args={"kernel_size": (kernel_size, kernel_size)},
         )
 
-    # UQI half + cpu does not work due to missing support in torch.log
-    @pytest.mark.xfail(condition=_TORCH_LESS_THAN_2_6, reason="UQI metric does not support cpu + half precision")
     def test_uqi_half_cpu(self, preds, target, multichannel, kernel_size):
         """Test dtype support of the metric on CPU."""
         self.run_precision_test_cpu(

--- a/tests/unittests/regression/test_concordance.py
+++ b/tests/unittests/regression/test_concordance.py
@@ -20,7 +20,6 @@ from scipy.stats import pearsonr
 
 from torchmetrics.functional.regression.concordance import concordance_corrcoef
 from torchmetrics.regression.concordance import ConcordanceCorrCoef
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, _Input
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -107,11 +106,6 @@ class TestConcordanceCorrCoef(MetricTester):
             metric_functional=concordance_corrcoef,
         )
 
-    # Spearman half + cpu does not work due to missing support in torch.arange
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1,
-        reason="Pytoch below 2.1 does not support cpu + half precision used in Concordance metric",
-    )
     def test_concordance_corrcoef_half_cpu(self, preds, target):
         """Test dtype support of the metric on CPU."""
         num_outputs = EXTRA_DIM if preds.ndim == 3 else 1

--- a/tests/unittests/regression/test_js_divergence.py
+++ b/tests/unittests/regression/test_js_divergence.py
@@ -23,7 +23,6 @@ from torch import Tensor
 
 from torchmetrics.functional.regression.js_divergence import jensen_shannon_divergence
 from torchmetrics.regression.js_divergence import JensenShannonDivergence
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -101,11 +100,6 @@ class TestJensenShannonDivergence(MetricTester):
             metric_args={"log_prob": log_prob, "reduction": reduction},
         )
 
-    # JensenShannonDivergence half + cpu does not work due to missing support in torch.clamp
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1,
-        reason="Pytoch below 2.1 does not support cpu + half precision used in JensenShannonDivergence metric",
-    )
     def test_jensen_shannon_divergence_half_cpu(self, reduction, p, q, log_prob):
         """Test dtype support of the metric on CPU."""
         self.run_precision_test_cpu(

--- a/tests/unittests/regression/test_kl_divergence.py
+++ b/tests/unittests/regression/test_kl_divergence.py
@@ -22,7 +22,6 @@ from torch import Tensor
 
 from torchmetrics.functional.regression.kl_divergence import kl_divergence
 from torchmetrics.regression.kl_divergence import KLDivergence
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -100,11 +99,6 @@ class TestKLDivergence(MetricTester):
             metric_args={"log_prob": log_prob, "reduction": reduction},
         )
 
-    # KLDivergence half + cpu does not work due to missing support in torch.clamp
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1,
-        reason="Pytoch below 2.1 does not support cpu + half precision used in KLDivergence metric",
-    )
     def test_kldivergence_half_cpu(self, reduction, p, q, log_prob):
         """Test dtype support of the metric on CPU."""
         self.run_precision_test_cpu(p, q, KLDivergence, kl_divergence, {"log_prob": log_prob, "reduction": reduction})

--- a/tests/unittests/regression/test_pearson.py
+++ b/tests/unittests/regression/test_pearson.py
@@ -19,7 +19,6 @@ from scipy.stats import pearsonr
 
 from torchmetrics.functional.regression.pearson import pearson_corrcoef
 from torchmetrics.regression.pearson import PearsonCorrCoef, _final_aggregation
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_5
 from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, _Input
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -99,7 +98,6 @@ class TestPearsonCorrCoef(MetricTester):
             metric_functional=pearson_corrcoef,
         )
 
-    @pytest.mark.skipif(not _TORCH_GREATER_EQUAL_2_5, reason="Requires torch>=2.5.0")
     def test_pearson_corrcoef_half_cpu(self, preds, target):
         """Test dtype support of the metric on CPU."""
         num_outputs = EXTRA_DIM if preds.ndim == 3 else 1

--- a/tests/unittests/regression/test_rse.py
+++ b/tests/unittests/regression/test_rse.py
@@ -19,7 +19,6 @@ import torch
 
 from torchmetrics.functional import relative_squared_error
 from torchmetrics.regression import RelativeSquaredError
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, NUM_BATCHES, _Input
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -107,10 +106,6 @@ class TestRelativeSquaredError(MetricTester):
             metric_args={"squared": squared},
         )
 
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1,
-        reason="Pytoch below 2.1 does not support cpu + half precision used in `clamp_min_cpu`",
-    )
     def test_rse_half_cpu(self, squared, preds, target, ref_metric, num_outputs):
         """Test dtype support of the metric on CPU."""
         self.run_precision_test_cpu(

--- a/tests/unittests/regression/test_spearman.py
+++ b/tests/unittests/regression/test_spearman.py
@@ -19,7 +19,6 @@ from scipy.stats import rankdata, spearmanr
 
 from torchmetrics.functional.regression.spearman import _rank_data, spearman_corrcoef
 from torchmetrics.regression.spearman import SpearmanCorrCoef
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, _Input
 from unittests._helpers import seed_all
 from unittests._helpers.testers import MetricTester
@@ -118,11 +117,6 @@ class TestSpearmanCorrCoef(MetricTester):
             metric_functional=spearman_corrcoef,
         )
 
-    # Spearman half + cpu does not work due to missing support in torch.arange
-    @pytest.mark.skipif(
-        not _TORCH_GREATER_EQUAL_2_1,
-        reason="Pytoch below 2.1 does not support cpu + half precision used in Spearman metric",
-    )
     def test_spearman_corrcoef_half_cpu(self, preds, target):
         """Test dtype support of the metric on CPU."""
         num_outputs = EXTRA_DIM if preds.ndim == 3 else 1

--- a/tests/unittests/text/test_perplexity.py
+++ b/tests/unittests/text/test_perplexity.py
@@ -19,7 +19,6 @@ from torch.nn import functional as F  # noqa: N812
 
 from torchmetrics.functional.text.perplexity import perplexity
 from torchmetrics.text.perplexity import Perplexity
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_2
 from unittests._helpers.testers import MetricTester
 from unittests.text._inputs import (
     MASK_INDEX,
@@ -85,15 +84,9 @@ class TestPerplexity(MetricTester):
     @pytest.mark.parametrize("dtype", [torch.half, torch.double])
     def test_perplexity_dtypes_cpu(self, preds, target, ignore_index, dtype):
         """Test dtype support of the metric on CPU."""
-        if dtype == torch.half and not _TORCH_GREATER_EQUAL_2_2:
-            with pytest.raises(RuntimeError, match="\"softmax_lastdim_kernel_impl\" not implemented for 'Half'"):
-                self.run_precision_test_cpu(
-                    preds, target, Perplexity, perplexity, metric_args={"ignore_index": ignore_index}, dtype=dtype
-                )
-        else:
-            self.run_precision_test_cpu(
-                preds, target, Perplexity, perplexity, metric_args={"ignore_index": ignore_index}, dtype=dtype
-            )
+        self.run_precision_test_cpu(
+            preds, target, Perplexity, perplexity, metric_args={"ignore_index": ignore_index}, dtype=dtype
+        )
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires cuda")
     @pytest.mark.parametrize("dtype", [torch.half, torch.double])

--- a/tests/unittests/utilities/test_utilities.py
+++ b/tests/unittests/utilities/test_utilities.py
@@ -11,21 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
-
 import numpy as np
 import pytest
 import torch
-from lightning_utilities.test.warning import no_warning_call
 from torch import tensor
-from unittests._helpers import _IS_WINDOWS
 
 from torchmetrics.regression import MeanSquaredError, PearsonCorrCoef
 from torchmetrics.utilities import check_forward_full_state_property, rank_zero_debug, rank_zero_info, rank_zero_warn
 from torchmetrics.utilities.checks import _allclose_recursive
 from torchmetrics.utilities.data import (
     _bincount,
-    _cumsum,
     _flatten,
     _flatten_dict,
     select_topk,
@@ -33,8 +28,6 @@ from torchmetrics.utilities.data import (
     to_onehot,
 )
 from torchmetrics.utilities.distributed import class_reduce, reduce
-from torchmetrics.utilities.exceptions import TorchMetricsUserWarning
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_2_2, _TORCH_LESS_THAN_2_6
 
 
 def test_prints():
@@ -173,36 +166,6 @@ def test_recursive_allclose(inputs, expected):
     assert res == expected
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU")
-@pytest.mark.xfail(_IS_WINDOWS or not _TORCH_LESS_THAN_2_6, reason="test will only fail on non-windows systems")
-def test_cumsum_still_not_supported(use_deterministic_algorithms):
-    """Make sure that cumsum on GPU and deterministic mode still fails.
-
-    If this test begins to pass, it means newer Pytorch versions support this and we can drop internal support.
-
-    """
-    with pytest.raises(RuntimeError, match="cumsum_cuda_kernel does not have a deterministic implementation.*"):
-        torch.arange(10).float().cuda().cumsum(0)
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU")
-def test_custom_cumsum(use_deterministic_algorithms):
-    """Test custom cumsum implementation."""
-    # check that cumsum works as expected on non-default cuda device
-    device = torch.device("cuda:1") if torch.cuda.device_count() > 1 else torch.device("cuda:0")
-    x = torch.arange(100).float().to(device)
-    with (
-        pytest.warns(
-            TorchMetricsUserWarning, match="You are trying to use a metric in deterministic mode on GPU that.*"
-        )
-        if sys.platform != "win32" and _TORCH_LESS_THAN_2_6 and torch.are_deterministic_algorithms_enabled()
-        else no_warning_call()
-    ):
-        ours = _cumsum(x, dim=0)
-    ref_np = np.cumsum(x.cpu(), axis=0)
-    assert torch.allclose(ours.cpu(), ref_np)
-
-
 def _reference_topk(x, dim, k):
     x = x.cpu().numpy()
     one_hot = np.zeros((x.shape[0], x.shape[1]), dtype=int)
@@ -226,18 +189,6 @@ def test_custom_topk(dtype, k, dim):
     assert top_k.dtype == torch.int
     ref = _reference_topk(x, dim=dim, k=k)
     assert torch.allclose(top_k, torch.from_numpy(ref).to(torch.int))
-
-
-@pytest.mark.skipif(_TORCH_GREATER_EQUAL_2_2, reason="Top-k does not support cpu + half precision")
-def test_half_precision_top_k_cpu_raises_error():
-    """Test that half precision topk raises error on cpu.
-
-    If this begins to fail, it means newer Pytorch versions support this, and we can drop internal support.
-
-    """
-    x = torch.randn(100, 10, dtype=torch.half)
-    with pytest.raises(RuntimeError, match="\"topk_cpu\" not implemented for 'Half'"):
-        torch.topk(x, k=3, dim=1)
 
 
 def test_safe_divide():

--- a/tests/unittests/wrappers/test_multitask.py
+++ b/tests/unittests/wrappers/test_multitask.py
@@ -20,7 +20,7 @@ import torch
 from torchmetrics import MetricCollection
 from torchmetrics.classification import BinaryAccuracy, BinaryF1Score
 from torchmetrics.regression import MeanAbsoluteError, MeanSquaredError
-from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE, _TORCH_GREATER_EQUAL_2_5
+from torchmetrics.utilities.imports import _MATPLOTLIB_AVAILABLE
 from torchmetrics.wrappers import MultitaskWrapper
 from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests._helpers import seed_all
@@ -91,15 +91,13 @@ def test_error_on_wrong_keys():
         "Classification": BinaryAccuracy(),
     })
 
-    order_dict = "" if _TORCH_GREATER_EQUAL_2_5 else "o"
-
     with pytest.raises(
         ValueError,
         match=re.escape(
             "Expected arguments `task_preds` and `task_targets` to have the same keys as the wrapped `task_metrics`."
             " Found task_preds.keys() = dict_keys(['Classification']),"
             " task_targets.keys() = dict_keys(['Classification', 'Regression'])"
-            f" and self.task_metrics.keys() = {order_dict}dict_keys(['Classification', 'Regression'])"
+            " and self.task_metrics.keys() = dict_keys(['Classification', 'Regression'])"
         ),
     ):
         multitask_metrics.update(wrong_key_preds, _multitask_targets)
@@ -110,7 +108,7 @@ def test_error_on_wrong_keys():
             "Expected arguments `task_preds` and `task_targets` to have the same keys as the wrapped `task_metrics`."
             " Found task_preds.keys() = dict_keys(['Classification', 'Regression']),"
             " task_targets.keys() = dict_keys(['Classification'])"
-            f" and self.task_metrics.keys() = {order_dict}dict_keys(['Classification', 'Regression'])"
+            " and self.task_metrics.keys() = dict_keys(['Classification', 'Regression'])"
         ),
     ):
         multitask_metrics.update(_multitask_preds, wrong_key_targets)
@@ -121,7 +119,7 @@ def test_error_on_wrong_keys():
             "Expected arguments `task_preds` and `task_targets` to have the same keys as the wrapped `task_metrics`."
             " Found task_preds.keys() = dict_keys(['Classification', 'Regression']),"
             " task_targets.keys() = dict_keys(['Classification', 'Regression'])"
-            f" and self.task_metrics.keys() = {order_dict}dict_keys(['Classification'])"
+            " and self.task_metrics.keys() = dict_keys(['Classification'])"
         ),
     ):
         wrong_key_multitask_metrics.update(_multitask_preds, _multitask_targets)


### PR DESCRIPTION
## What does this PR do?

Follow-up to #3449. With the floor at torch **2.6**, five version flags in `utilities/imports.py` are now constants. This removes them and the branches they guarded — no behaviour change on any supported torch.

- `Metric` no longer caches `self._TORCH_GREATER_EQUAL_2_1`; the `_sync_dist` empty-list guard becomes unconditional.
- `_cumsum` had degenerated into a pass-through, so it is removed and its 8 call sites use `torch.cumsum`.
- ARNIQA drops its unreachable `requires PyTorch >= 2.2.0` guard.
- ~60 test `skipif`/`xfail` guards that can no longer fire are gone.

<details>
<summary><b>Flags removed</b></summary>

| Flag | Evaluated to | Sites |
|---|---|---|
| `_TORCH_GREATER_EQUAL_2_1` | always `True` | 96 |
| `_TORCH_GREATER_EQUAL_2_2` | always `True` | 18 |
| `_TORCH_GREATER_EQUAL_2_3` | always `True` | 0 — defined, never referenced |
| `_TORCH_GREATER_EQUAL_2_5` | always `True` | 5 |
| `_TORCH_LESS_THAN_2_6` | always `False` | 5 |

`_TORCH_GREATER_EQUAL_2_8` stays — still live in `Metric.__init__`.

</details>

<details>
<summary><b>Two tests removed rather than un-gated</b></summary>

Each asserted that torch still *lacks* a feature, and each had become permanently skipped/xfailed on 2.6:

- `test_cumsum_still_not_supported` — "If this test begins to pass, it means newer Pytorch versions support this and we can drop internal support." It does, so this drops it.
- `test_half_precision_top_k_cpu_raises_error` — `skipif(_TORCH_GREATER_EQUAL_2_2)`, i.e. never ran. cpu+half `topk` works on current torch.

</details>

<details>
<summary><b>Left in place deliberately</b></summary>

- **`TorchMetricsUserWarning`** is now unused inside `src/` — its only warn site was in `_cumsum`. Kept, since it is public in `torchmetrics.utilities.exceptions`.
- **`_top_k_with_half_precision_support`** looks dead by the same argument, but its `argsort(stable=True).flip()` tie-breaking differs from `topk`, so removing it would change half-precision results rather than just delete dead code. Worth its own PR.

</details>
