### PR TITLE
Return zero V-measure for zero-information clusterings

### DIFF
--- a/src/torchmetrics/functional/clustering/homogeneity_completeness_v_measure.py
+++ b/src/torchmetrics/functional/clustering/homogeneity_completeness_v_measure.py
@@ -110,5 +110,5 @@ def v_measure_score(preds: Tensor, target: Tensor, beta: float = 1.0) -> Tensor:
     """
     completeness, homogeneity = _completeness_score_compute(preds, target)
     if homogeneity + completeness == 0.0:
-        return torch.ones_like(homogeneity)
+        return torch.zeros_like(homogeneity)
     return (1 + beta) * homogeneity * completeness / (beta * homogeneity + completeness)

--- a/tests/unittests/clustering/test_homogeneity_completeness_v_measure.py
+++ b/tests/unittests/clustering/test_homogeneity_completeness_v_measure.py
@@ -14,6 +14,7 @@
 from functools import partial
 
 import pytest
+import torch
 from sklearn.metrics import completeness_score as sklearn_completeness_score
 from sklearn.metrics import homogeneity_score as sklearn_homogeneity_score
 from sklearn.metrics import v_measure_score as sklearn_v_measure_score
@@ -96,3 +97,14 @@ def test_homogeneity_completeness_vmeasure_functional_raises_invalid_task(functi
     preds, target = _float_inputs_extrinsic
     with pytest.raises(ValueError, match=r"Expected *"):
         functional_metric(preds, target)
+
+
+@pytest.mark.parametrize("beta", [0.5, 1.0, 2.0])
+def test_v_measure_zero_mutual_information(beta):
+    """Check that independent nontrivial clusterings have zero V-measure."""
+    preds = torch.tensor([0, 1, 0, 1])
+    target = torch.tensor([0, 0, 1, 1])
+    expected = torch.tensor(sklearn_v_measure_score(target, preds, beta=beta), dtype=torch.float32)
+
+    assert torch.allclose(v_measure_score(preds, target, beta=beta), expected)
+    assert torch.allclose(VMeasureScore(beta=beta)(preds, target), expected)


### PR DESCRIPTION
## What does this PR do?

Fixes #3484

I was checking V-measure edge cases and noticed that the zero-information branch returned `1`, even though both homogeneity and completeness are zero. This changes that branch to return `0`, matching scikit-learn and the metric definition.

I added regression coverage for both the functional and class APIs with `beta` values `0.5`, `1.0`, and `2.0`. I also checked every partition pair through five samples against scikit-learn (8,877 cases); the full clustering suite passes (`178 passed, 8 skipped`), and Ruff is clean.

I also wrote a small Lean formalization of this edge case and can attach it if useful :)