### PR TITLE
Keep `LogCoshError` finite for large residuals

### DIFF
--- a/src/torchmetrics/functional/regression/log_cosh.py
+++ b/src/torchmetrics/functional/regression/log_cosh.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import torch
 from torch import Tensor
 
@@ -43,8 +45,14 @@ def _log_cosh_error_update(preds: Tensor, target: Tensor, num_outputs: int) -> t
     _check_data_shape_to_num_outputs(preds, target, num_outputs)
 
     preds, target = _unsqueeze_tensors(preds, target)
+    if preds.dtype == torch.float16 or preds.dtype == torch.bfloat16:
+        preds = preds.float()
+    if target.dtype == torch.float16 or target.dtype == torch.bfloat16:
+        target = target.float()
     diff = preds - target
-    sum_log_cosh_error = torch.log((torch.exp(diff) + torch.exp(-diff)) / 2).sum(0).squeeze()
+    if not diff.is_floating_point():
+        diff = diff.float()
+    sum_log_cosh_error = (torch.logaddexp(diff, -diff) - math.log(2.0)).sum(0).squeeze()
     num_obs = torch.tensor(target.shape[0], device=preds.device)
     return sum_log_cosh_error, num_obs
 

--- a/src/torchmetrics/functional/regression/log_cosh.py
+++ b/src/torchmetrics/functional/regression/log_cosh.py
@@ -43,6 +43,8 @@ def _log_cosh_error_update(preds: Tensor, target: Tensor, num_outputs: int) -> t
     """
     _check_same_shape(preds, target)
     _check_data_shape_to_num_outputs(preds, target, num_outputs)
+    if preds.is_complex() or target.is_complex():
+        raise ValueError("Expected `preds` and `target` to be real tensors.")
 
     preds, target = _unsqueeze_tensors(preds, target)
     if preds.dtype == torch.float16 or preds.dtype == torch.bfloat16:

--- a/tests/unittests/regression/test_log_cosh_error.py
+++ b/tests/unittests/regression/test_log_cosh_error.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 from functools import partial
 
 import numpy as np
@@ -42,9 +43,47 @@ _multi_target_inputs = _Input(
 def _reference_log_cosh_error(preds, target):
     preds, target = preds.numpy(), target.numpy()
     diff = preds - target
+    log_cosh = np.logaddexp(diff, -diff) - np.log(2)
     if diff.ndim == 1:
-        return np.mean(np.log((np.exp(diff) + np.exp(-diff)) / 2))
-    return np.mean(np.log((np.exp(diff) + np.exp(-diff)) / 2), axis=0)
+        return np.mean(log_cosh)
+    return np.mean(log_cosh, axis=0)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "value", "num_samples", "rtol"),
+    [
+        (torch.float16, 500.0, 1001, 1e-3),
+        (torch.bfloat16, 100.0, 2, 5e-3),
+        (torch.float32, 100.0, 2, 1e-6),
+        (torch.float64, 1000.0, 2, 1e-6),
+    ],
+)
+@pytest.mark.parametrize("metric_class", [None, LogCoshError], ids=["functional", "class"])
+def test_log_cosh_error_large_residuals(metric_class, dtype, value, num_samples, rtol):
+    """Test that large finite residuals produce a finite result."""
+    preds = torch.full((num_samples,), value, dtype=dtype)
+    preds[1::2] = -value
+    target = torch.zeros_like(preds)
+
+    result = log_cosh_error(preds, target) if metric_class is None else metric_class()(preds, target)
+    expected = torch.tensor(value - math.log(2.0), dtype=result.dtype)
+
+    assert torch.isfinite(result)
+    torch.testing.assert_close(result, expected, rtol=rtol, atol=0)
+
+
+@pytest.mark.parametrize("metric_class", [None, LogCoshError], ids=["functional", "class"])
+def test_log_cosh_error_half_residual_exceeds_dtype_range(metric_class):
+    """Test that subtraction is performed after promoting half-precision inputs."""
+    value = torch.finfo(torch.float16).max
+    preds = torch.tensor([value, -value], dtype=torch.float16)
+    target = -preds
+
+    result = log_cosh_error(preds, target) if metric_class is None else metric_class()(preds, target)
+    expected = torch.tensor(2 * value - math.log(2.0), dtype=result.dtype)
+
+    assert torch.isfinite(result)
+    torch.testing.assert_close(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/regression/test_log_cosh_error.py
+++ b/tests/unittests/regression/test_log_cosh_error.py
@@ -86,6 +86,29 @@ def test_log_cosh_error_half_residual_exceeds_dtype_range(metric_class):
     torch.testing.assert_close(result, expected)
 
 
+@pytest.mark.parametrize("metric_class", [None, LogCoshError], ids=["functional", "class"])
+def test_log_cosh_error_integer_inputs(metric_class):
+    """Test that integer inputs retain the behavior of the previous implementation."""
+    preds = torch.tensor([0, 2, -2])
+    target = torch.tensor([0, 0, 0])
+    diff = (preds - target).float()
+    expected = (torch.logaddexp(diff, -diff) - math.log(2.0)).mean()
+
+    result = log_cosh_error(preds, target) if metric_class is None else metric_class()(preds, target)
+
+    torch.testing.assert_close(result, expected)
+
+
+@pytest.mark.parametrize("metric_class", [None, LogCoshError], ids=["functional", "class"])
+def test_log_cosh_error_rejects_complex_inputs(metric_class):
+    """Test that complex inputs are rejected instead of silently losing their imaginary component."""
+    preds = torch.tensor([0.25 + 0.5j, -0.7 + 1.2j], dtype=torch.complex64)
+    target = torch.tensor([0.1 - 0.25j, 0.2 + 0.1j], dtype=torch.complex64)
+
+    with pytest.raises(ValueError, match=r"Expected `preds` and `target` to be real tensors\."):
+        log_cosh_error(preds, target) if metric_class is None else metric_class()(preds, target)
+
+
 @pytest.mark.parametrize(
     ("preds", "target"),
     [


### PR DESCRIPTION
## What does this PR do?

Fixes #3488

I was checking `LogCoshError` with larger residuals and noticed the direct exponential expression can return `inf` even when the metric is finite. Half-precision inputs can also overflow during subtraction or accumulation.

This uses the equivalent `logaddexp(diff, -diff) - log(2)` expression and promotes float16/bfloat16 inputs before subtraction. I added regression coverage for both APIs across float16, bfloat16, float32, and float64.

The full LogCosh test file passes, along with pre-commit, TorchScript, `torch.compile`, gradient, and CUDA checks. I can also add a small Lean/TorchLean proof of the equivalence if useful :)
