### PR TITLE
Preserve group IDs in fairness metrics

### DIFF
--- a/src/torchmetrics/functional/classification/group_fairness.py
+++ b/src/torchmetrics/functional/classification/group_fairness.py
@@ -24,24 +24,20 @@ from torchmetrics.functional.classification.stat_scores import (
 )
 from torchmetrics.utilities import rank_zero_warn
 from torchmetrics.utilities.compute import _safe_divide
-from torchmetrics.utilities.data import _flexible_bincount
+from torchmetrics.utilities.data import _bincount
 
 
 def _groups_validation(groups: torch.Tensor, num_groups: int) -> None:
     """Validate groups tensor.
 
-    - The largest number in the tensor should not be larger than the number of groups. The group identifiers should
-    be ``0, 1, ..., (num_groups - 1)``.
+    - The group identifiers should be ``0, 1, ..., (num_groups - 1)``.
     - The group tensor should be dtype long.
 
     """
-    if torch.max(groups) > num_groups:
-        raise ValueError(
-            f"The largest number in the groups tensor is {torch.max(groups)}, which is larger than the specified",
-            f"number of groups {num_groups}. The group identifiers should be ``0, 1, ..., (num_groups - 1)``.",
-        )
     if groups.dtype != torch.long:
         raise ValueError(f"Expected dtype of argument groups to be long, not {groups.dtype}.")
+    if torch.any((groups < 0) | (groups >= num_groups)):
+        raise ValueError(f"Expected all group identifiers to be in the [0, {num_groups - 1}] range.")
 
 
 def _groups_format(groups: torch.Tensor) -> torch.Tensor:
@@ -71,11 +67,19 @@ def _binary_groups_stat_scores(
     preds, target = _binary_stat_scores_format(preds, target, threshold, ignore_index)
     groups = _groups_format(groups)
 
-    indexes, indices = torch.sort(groups.squeeze(1))
-    preds = preds[indices]
-    target = target[indices]
-
-    split_sizes = _flexible_bincount(indexes).detach().cpu().tolist()
+    if groups.shape[0] != preds.shape[0] or groups.shape[1] not in (1, preds.shape[1]):
+        raise ValueError(
+            "Expected argument `groups` to have the same shape as `preds` and `target`, or one group per sample."
+        )
+    if groups.shape[1] == 1:
+        indexes, indices = torch.sort(groups.squeeze(1))
+        preds = preds[indices]
+        target = target[indices]
+    else:
+        indexes, indices = torch.sort(groups.reshape(-1))
+        preds = preds.reshape(-1)[indices].unsqueeze(1)
+        target = target.reshape(-1)[indices].unsqueeze(1)
+    split_sizes = _bincount(indexes, minlength=num_groups).detach().cpu().tolist()
 
     group_preds = list(torch.split(preds, split_sizes, dim=0))
     group_target = list(torch.split(target, split_sizes, dim=0))

--- a/tests/unittests/classification/test_group_fairness.py
+++ b/tests/unittests/classification/test_group_fairness.py
@@ -25,8 +25,8 @@ from scipy.special import expit as sigmoid
 from torch import Tensor
 
 from torchmetrics import Metric
-from torchmetrics.classification.group_fairness import BinaryFairness
-from torchmetrics.functional.classification.group_fairness import binary_fairness
+from torchmetrics.classification.group_fairness import BinaryFairness, BinaryGroupStatRates
+from torchmetrics.functional.classification.group_fairness import binary_fairness, binary_groups_stat_rates
 from unittests import THRESHOLD
 from unittests._helpers import seed_all
 from unittests._helpers.testers import (
@@ -41,6 +41,59 @@ from unittests._helpers.testers import _assert_tensor as _core_assert_tensor
 from unittests.classification._inputs import _group_cases
 
 seed_all(42)
+
+
+def test_binary_group_stat_rates_preserves_group_ids() -> None:
+    """Test that batches with missing groups update the matching group states."""
+    preds = torch.tensor([1, 0])
+    target = torch.tensor([1, 0])
+    groups = torch.tensor([2, 2])
+    expected_group_2 = torch.tensor([0.5, 0.0, 0.5, 0.0])
+
+    functional_result = binary_groups_stat_rates(preds, target, groups, num_groups=3)
+    assert functional_result.keys() == {"group_0", "group_1", "group_2"}
+    assert torch.isnan(functional_result["group_0"]).all()
+    assert torch.isnan(functional_result["group_1"]).all()
+    assert torch.equal(functional_result["group_2"], expected_group_2)
+
+    metric = BinaryGroupStatRates(num_groups=3)
+    metric.update(preds, target, groups)
+    metric_result = metric.compute()
+    assert torch.isnan(metric_result["group_0"]).all()
+    assert torch.isnan(metric_result["group_1"]).all()
+    assert torch.equal(metric_result["group_2"], expected_group_2)
+
+
+def test_binary_group_stat_rates_multidimensional_input() -> None:
+    """Test that additional dimensions are flattened consistently for every input."""
+    preds = torch.tensor([[1, 0], [1, 0]])
+    target = torch.tensor([[1, 0], [1, 0]])
+    groups = torch.tensor([[0, 1], [1, 0]])
+    expected = torch.tensor([0.5, 0.0, 0.5, 0.0])
+
+    functional_result = binary_groups_stat_rates(preds, target, groups, num_groups=2)
+    assert torch.equal(functional_result["group_0"], expected)
+    assert torch.equal(functional_result["group_1"], expected)
+
+    metric = BinaryGroupStatRates(num_groups=2)
+    metric.update(preds, target, groups)
+    metric_result = metric.compute()
+    assert torch.equal(metric_result["group_0"], expected)
+    assert torch.equal(metric_result["group_1"], expected)
+
+
+@pytest.mark.parametrize("groups", [torch.tensor([-1, 0]), torch.tensor([0, 2])])
+def test_binary_group_stat_rates_rejects_invalid_group_ids(groups: Tensor) -> None:
+    """Test that group identifiers must be in the configured range."""
+    preds = torch.tensor([1, 0])
+    target = torch.tensor([1, 0])
+
+    with pytest.raises(ValueError, match="group identifiers"):
+        binary_groups_stat_rates(preds, target, groups, num_groups=2)
+
+    metric = BinaryGroupStatRates(num_groups=2)
+    with pytest.raises(ValueError, match="group identifiers"):
+        metric.update(preds, target, groups)
 
 
 def _reference_fairlearn_binary(preds, target, groups, ignore_index):


### PR DESCRIPTION
## What does this PR do?

Fixes #3489

I was checking `BinaryGroupStatRates` with batches that do not contain every configured group and noticed the IDs get compressed. For example, a batch containing only group `2` updates `group_0`. The same path accepts invalid IDs and fails on documented multidimensional group tensors.

This keeps count slots aligned with `num_groups`, validates the configured ID range, and handles both per-sample and elementwise group tensors. I added regression coverage for the functional and class APIs.

The full group-fairness test file passes, along with pre-commit, deterministic CPU/CUDA checks, and 500 randomized partition cases. I can also add a small Lean/TorchLean model of the partition invariant if useful :)
