### PR TITLE
Handle one-sided empty inputs consistently in intersection metrics

### DIFF
--- a/src/torchmetrics/detection/iou.py
+++ b/src/torchmetrics/detection/iou.py
@@ -192,12 +192,14 @@ class IntersectionOverUnion(Metric):
             self.pred_labels.append(p_i["labels"])
 
             iou_matrix = self._iou_update_fn(det_boxes, gt_boxes, self.iou_threshold, self._invalid_val)  # N x M
-            if self.respect_labels:
-                if det_boxes.numel() > 0 and gt_boxes.numel() > 0:
-                    label_eq = p_i["labels"].unsqueeze(1) == t_i["labels"].unsqueeze(0)  # N x M
-                else:
-                    label_eq = torch.eye(iou_matrix.shape[0], dtype=bool, device=iou_matrix.device)  # type: ignore[call-overload]
-                iou_matrix[~label_eq] = self._invalid_val
+            if det_boxes.numel() == 0 or gt_boxes.numel() == 0:
+                valid_pairs = torch.eye(iou_matrix.shape[0], dtype=bool, device=iou_matrix.device)  # type: ignore[call-overload]
+            elif self.respect_labels:
+                valid_pairs = p_i["labels"].unsqueeze(1) == t_i["labels"].unsqueeze(0)  # N x M
+            else:
+                valid_pairs = None
+            if valid_pairs is not None:
+                iou_matrix[~valid_pairs] = self._invalid_val
             self.iou_matrix.append(iou_matrix)
 
     def _get_safe_item_values(self, boxes: Tensor) -> Tensor:
@@ -232,8 +234,9 @@ class IntersectionOverUnion(Metric):
                 masked_iou = torch.zeros_like(score)
                 observed = torch.zeros_like(score)
 
-                for mat, gt_lab in zip(self.iou_matrix, self.groundtruth_labels):
-                    scores = mat[:, gt_lab == cl]
+                for mat, gt_lab, pred_lab in zip(self.iou_matrix, self.groundtruth_labels, self.pred_labels):
+                    column_labels = gt_lab if gt_lab.numel() > 0 else pred_lab
+                    scores = mat[:, column_labels == cl]
                     valid_scores = scores[scores != self._invalid_val]
                     masked_iou += valid_scores.sum()
                     observed += valid_scores.numel()

--- a/src/torchmetrics/detection/iou.py
+++ b/src/torchmetrics/detection/iou.py
@@ -191,7 +191,8 @@ class IntersectionOverUnion(Metric):
             self.groundtruth_labels.append(t_i["labels"])
             self.pred_labels.append(p_i["labels"])
 
-            iou_matrix = self._iou_update_fn(det_boxes, gt_boxes, self.iou_threshold, self._invalid_val)  # N x M
+            # N x M, or K x K for one-sided empty inputs where K is the nonempty side's box count
+            iou_matrix = self._iou_update_fn(det_boxes, gt_boxes, self.iou_threshold, self._invalid_val)
             if det_boxes.numel() == 0 or gt_boxes.numel() == 0:
                 valid_pairs = torch.eye(iou_matrix.shape[0], dtype=bool, device=iou_matrix.device)  # type: ignore[call-overload]
             elif self.respect_labels:

--- a/tests/unittests/detection/test_intersection.py
+++ b/tests/unittests/detection/test_intersection.py
@@ -376,6 +376,39 @@ class TestIntersectionMetrics(MetricTester):
         for val in res.values():
             assert val == torch.tensor(0.0)
 
+    @pytest.mark.parametrize("respect_labels", [True, False])
+    @pytest.mark.parametrize("empty_side", ["preds", "target"])
+    @pytest.mark.parametrize("class_metrics", [True, False])
+    def test_empty_inputs_are_weighted_once(
+        self, class_metric, functional_metric, reference_metric, respect_labels, empty_side, class_metrics
+    ):
+        """Check that each unmatched box contributes one zero score."""
+        perfect = {
+            "boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0]]),
+            "labels": torch.tensor([0]),
+        }
+        empty = {
+            "boxes": torch.empty((0, 4)),
+            "labels": torch.empty((0,), dtype=torch.long),
+        }
+        two_boxes = {
+            "boxes": torch.tensor([[0.0, 0.0, 1.0, 1.0], [2.0, 2.0, 3.0, 3.0]]),
+            "labels": torch.tensor([0, 1]),
+        }
+
+        if empty_side == "preds":
+            preds, target = [perfect, empty], [perfect, two_boxes]
+        else:
+            preds, target = [perfect, two_boxes], [perfect, empty]
+
+        metric = class_metric(respect_labels=respect_labels, class_metrics=class_metrics)
+        result = metric(preds, target)
+        torch.testing.assert_close(result[metric._iou_type], torch.tensor(1 / 3))
+        if class_metrics:
+            assert set(result) == {metric._iou_type, f"{metric._iou_type}/cl_0", f"{metric._iou_type}/cl_1"}
+            torch.testing.assert_close(result[f"{metric._iou_type}/cl_0"], torch.tensor(0.5))
+            torch.testing.assert_close(result[f"{metric._iou_type}/cl_1"], torch.tensor(0.0))
+
     def test_empty_preds_and_target(self, class_metric, functional_metric, reference_metric):
         """Check that for either empty preds and targets that the metric returns 0 in these cases before averaging."""
         x = [


### PR DESCRIPTION
Fixes #3493

I ran into two related one-sided empty cases in IoU, GIoU, DIoU, and CIoU. With `respect_labels=False`, the synthetic matrix counted N² zeros instead of one zero per unmatched box. With `class_metrics=True`, prediction-only boxes were indexed using empty target labels.

This keeps one zero per unmatched box and uses labels from the nonempty side for the synthetic columns. I added regression coverage across all four metrics, both empty directions, both label modes, and class metrics on/off :)