### PR TITLE
Restore local states in `sync_context` when the body raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
+- Fixed `Metric.sync_context` leaving the metric synchronized when the body (e.g. `compute`) raises ([#3496](https://github.com/Lightning-AI/torchmetrics/pull/3496))
 
 
 - Fixed `PESQ` metric aborting on a batch containing a sample the backend cannot score, which now returns `nan` for that sample instead of raising ([#3304](https://github.com/Lightning-AI/torchmetrics/issues/3304))

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -663,9 +663,12 @@ class Metric(Module, ABC):
             distributed_available=distributed_available,
         )
 
-        yield
-
-        self.unsync(should_unsync=self._is_synced and should_unsync)
+        try:
+            yield
+        finally:
+            # restore the local states also when the body raised (e.g. ``compute`` rejecting the input), otherwise the
+            # metric stays synchronized and the next ``compute`` fails with "The Metric has already been synced."
+            self.unsync(should_unsync=self._is_synced and should_unsync)
 
     def _wrap_compute(self, compute: Callable) -> Callable:
         @functools.wraps(compute)

--- a/tests/unittests/bases/test_metric.py
+++ b/tests/unittests/bases/test_metric.py
@@ -710,3 +710,55 @@ def test_merge_state_feature_for_different_metrics(metric_class, preds, target):
     # should not be the same because it has only seen half the data
     res3 = metric1_2.compute()
     assert not torch.allclose(res3, res2)
+
+
+def _fake_gather(tensor, group=None):
+    """Stand-in for ``gather_all_tensors`` that pretends there are two identical ranks."""
+    return [tensor, tensor]
+
+
+def test_sync_context_unsyncs_when_body_raises():
+    """A raise inside ``sync_context`` must not leave the metric synchronized (#3486)."""
+    metric = DummyMetricSum()
+    metric.update(1)
+    seen_synced_state = []
+
+    def body_that_raises():
+        with metric.sync_context(dist_sync_fn=_fake_gather, distributed_available=lambda: True):
+            seen_synced_state.append((metric._is_synced, metric.x.item()))
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        body_that_raises()
+
+    assert seen_synced_state == [(True, 2.0)]
+    assert not metric._is_synced
+    assert metric._cache is None
+    assert metric.x == 1
+    metric.update(2)
+    assert metric.x == 3
+
+
+def test_compute_error_does_not_leave_metric_synced():
+    """``compute`` raising during the synchronized section must not break the next ``compute`` (#3486)."""
+
+    class _RejectingCompute(DummyMetricSum):
+        reject = True
+
+        def compute(self):
+            if self.reject:
+                raise ValueError("no positive target")
+            return self.x
+
+    metric = _RejectingCompute(dist_sync_fn=_fake_gather, distributed_available_fn=lambda: True)
+    metric.update(1)
+    with pytest.raises(ValueError, match="no positive target"):
+        metric.compute()
+    assert not metric._is_synced
+    assert metric.x == 1
+
+    metric.reject = False
+    metric.update(2)
+    # (1 + 2) gathered from the two fake ranks
+    assert metric.compute() == 6
+    assert not metric._is_synced


### PR DESCRIPTION
## What does this PR do?

Fixes #3486

After a successful distributed synchronization, an exception raised inside the `sync_context` body (typically `compute()` rejecting the input, e.g. a retrieval metric with `empty_target_action="error"`) skipped the `unsync()` at the end of the context manager. The metric stayed synchronized (`_is_synced=True`, `_cache` still set), so the next `update()` + `compute()` failed with `TorchMetricsUserError: The Metric has already been synced.` even though the accumulated state had become valid.

The unsync now runs in a `finally` block, so the local states are restored on the error path as well; the error itself still propagates unchanged.

Tests (`tests/unittests/bases/test_metric.py`, with a fake two-rank gather so no distributed backend is needed):
- `test_sync_context_unsyncs_when_body_raises`: a raise inside `sync_context` leaves `_is_synced=False`, `_cache=None`, the local state restored, and accumulation continues.
- `test_compute_error_does_not_leave_metric_synced`: a `compute()` that raises once no longer breaks the following `compute()`.

Both fail on `master` and pass with the change.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Yes.
