### PR TITLE
Keep the accumulated state when the batch computation in `forward` raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 - Fixed `Metric` ignoring an active `torch.device` context manager on torch 2.3-2.7 ([#3448](https://github.com/Lightning-AI/torchmetrics/pull/3448))
+- Fixed `Metric.forward` dropping the previously accumulated state when the batch computation raises ([#3497](https://github.com/Lightning-AI/torchmetrics/pull/3497))
 
 
 - Fixed `PESQ` metric aborting on a batch containing a sample the backend cannot score, which now returns `nan` for that sample instead of raising ([#3304](https://github.com/Lightning-AI/torchmetrics/issues/3304))

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -339,24 +339,26 @@ class Metric(Module, ABC):
 
         # call reset, update, compute, on single batch
         self._enable_grad = True  # allow grads for batch computation
-        self.reset()
-        self.update(*args, **kwargs)
-        batch_val = self.compute()
+        try:
+            self.reset()
+            self.update(*args, **kwargs)
+            batch_val = self.compute()
+        finally:
+            # restore the accumulated state also when the batch computation raised; the failed batch itself was
+            # already accumulated by the global ``update`` above and stays part of the state
+            for attr, val in cache.items():
+                setattr(self, attr, val)
+            self._update_count = _update_count
 
-        # restore context
-        for attr, val in cache.items():
-            setattr(self, attr, val)
-        self._update_count = _update_count
-
-        # restore context
-        self._is_synced = False
-        self._should_unsync = True
-        self._to_sync = self.sync_on_compute
-        self._computed = None
-        self._enable_grad = False
-        self.compute_on_cpu = _temp_compute_on_cpu
-        if self.compute_on_cpu:
-            self._move_list_states_to_cpu()
+            # restore context
+            self._is_synced = False
+            self._should_unsync = True
+            self._to_sync = self.sync_on_compute
+            self._computed = None
+            self._enable_grad = False
+            self.compute_on_cpu = _temp_compute_on_cpu
+            if self.compute_on_cpu:
+                self._move_list_states_to_cpu()
 
         return batch_val
 
@@ -379,24 +381,31 @@ class Metric(Module, ABC):
         self.compute_on_cpu = False
         self._enable_grad = True  # allow grads for batch computation
 
-        # calculate batch state and compute batch value
-        self.update(*args, **kwargs)
-        batch_val = self.compute()
-
-        # reduce batch and global state
-        self._update_count = _update_count + 1
-        with torch.no_grad():
-            self._reduce_states(global_state)
-
-        # restore context
-        self._is_synced = False
-        self._should_unsync = True
-        self._to_sync = self.sync_on_compute
-        self._computed = None
-        self._enable_grad = False
-        self.compute_on_cpu = _temp_compute_on_cpu
-        if self.compute_on_cpu:
-            self._move_list_states_to_cpu()
+        try:
+            # calculate batch state and compute batch value
+            self.update(*args, **kwargs)
+            batch_val = self.compute()
+        except Exception:
+            # the batch state may be incomplete, so drop it and put the accumulated state back instead of losing it
+            for attr, val in global_state.items():
+                setattr(self, attr, val)
+            self._update_count = _update_count
+            raise
+        else:
+            # reduce batch and global state
+            self._update_count = _update_count + 1
+            with torch.no_grad():
+                self._reduce_states(global_state)
+        finally:
+            # restore context
+            self._is_synced = False
+            self._should_unsync = True
+            self._to_sync = self.sync_on_compute
+            self._computed = None
+            self._enable_grad = False
+            self.compute_on_cpu = _temp_compute_on_cpu
+            if self.compute_on_cpu:
+                self._move_list_states_to_cpu()
 
         return batch_val
 

--- a/tests/unittests/bases/test_metric.py
+++ b/tests/unittests/bases/test_metric.py
@@ -710,3 +710,44 @@ def test_merge_state_feature_for_different_metrics(metric_class, preds, target):
     # should not be the same because it has only seen half the data
     res3 = metric1_2.compute()
     assert not torch.allclose(res3, res2)
+
+
+class _RejectingBatchMetric(DummyMetricSum):
+    """Sum metric whose ``compute`` rejects a sentinel batch, like a metric validating its input at compute time."""
+
+    full_state_update = True
+
+    def compute(self):
+        if self.x == -1:
+            raise ValueError("invalid batch")
+        return self.x
+
+
+class _RejectingBatchMetricReduce(_RejectingBatchMetric):
+    full_state_update = False
+
+
+@pytest.mark.parametrize("full_state_update", [True, False])
+def test_forward_keeps_accumulated_state_when_batch_computation_raises(full_state_update):
+    """State accumulated before a failing ``forward`` call must survive the failure (#3487)."""
+    metric = (_RejectingBatchMetric if full_state_update else _RejectingBatchMetricReduce)()
+    metric.update(5)
+
+    with pytest.raises(ValueError, match="invalid batch"):
+        metric(-1)
+
+    if full_state_update:
+        # the batch was accumulated by the global update before its computation failed
+        assert metric.x == 4
+        assert metric._update_count == 2
+    else:
+        # the batch state was dropped, the accumulated state is back
+        assert metric.x == 5
+        assert metric._update_count == 1
+    assert metric._enable_grad is False
+    assert metric._should_unsync is True
+    assert metric._computed is None
+
+    metric.update(3)
+    assert metric.compute() == (7 if full_state_update else 8)
+    assert metric(1) == 1


### PR DESCRIPTION
## What does this PR do?

Fixes #3487

Both `forward` implementations restored (full-state path) or merged (reduce path) the global state only after the batch computation had returned. If `update`/`compute` on the single batch raised (the report uses `RetrievalMRR(empty_target_action="error")` with a query that has no positive target), the restoration step was skipped: everything accumulated before the `forward` call was lost, and the internal context flags (`_enable_grad`, `_should_unsync`, `_to_sync`, `compute_on_cpu`) stayed in their batch-mode values.

Change:
- `_forward_full_state_update`: restore the cached global state, `_update_count` and the context in a `finally` block. The failed batch stays part of the accumulated state, because the global `update` at the top had already accumulated it before the batch computation ran (the "retain failed batch" variant from the issue, `0.75` in its example).
- `_forward_reduce_state_update`: on an error, put the global state and `_update_count` back and drop the possibly incomplete batch state, then re-raise; the context is restored in a `finally` block too. A partially updated batch cannot be merged, so this path discards it.

The behaviors of the two paths differ for the failed batch itself, but in both cases the state accumulated before the call remains intact; the docstrings/comments say which is which. If you would rather roll the batch back on the full-state path as well, that needs a second state copy before the global `update` (one extra copy per `forward`), which I did not want to add without asking.

Tests (`tests/unittests/bases/test_metric.py`): `test_forward_keeps_accumulated_state_when_batch_computation_raises`, parametrized over `full_state_update=True/False`, with a `DummyMetricSum` subclass whose `compute` rejects a sentinel batch. Asserts the accumulated state, `_update_count`, the restored context flags, and that `update`/`compute`/`forward` continue to work afterwards. Fails on `master` (state lost on both paths), passes with the change; the rest of `test_metric.py` still passes.

<details>
  <summary>Before submitting</summary>

- [x] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Yes.
