### PR TITLE
Fix AMI for empty and singleton partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `AdjustedMutualInfoScore` for empty inputs and relabeled singleton partitions
+- Fixed `AdjustedMutualInfoScore` for empty inputs and relabeled singleton partitions ([#3498](https://github.com/Lightning-AI/torchmetrics/pull/3498))
 
 - Fixed `top_k` validation in multiclass classification metrics to reject negative integers and non-integer values ([#3406](https://github.com/Lightning-AI/torchmetrics/pull/3406))
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `AdjustedMutualInfoScore` for empty inputs and relabeled singleton partitions
+
 - Fixed `top_k` validation in multiclass classification metrics to reject negative integers and non-integer values ([#3406](https://github.com/Lightning-AI/torchmetrics/pull/3406))
 - Fixed malformed LaTeX in `CLIPScore` and `HausdorffDistance` docstring math so it renders correctly ([#3427](https://github.com/Lightning-AI/torchmetrics/pull/3427))
 

--- a/src/torchmetrics/functional/clustering/adjusted_mutual_info_score.py
+++ b/src/torchmetrics/functional/clustering/adjusted_mutual_info_score.py
@@ -47,6 +47,9 @@ def adjusted_mutual_info_score(
     """
     _validate_average_method_arg(average_method)
     contingency = _mutual_info_score_update(preds, target)
+    # Empty partitions and partitions with one cluster per sample agree up to relabeling.
+    if contingency.shape[0] == contingency.shape[1] == target.numel():
+        return tensor(1.0, device=preds.device)
     mutual_info = _mutual_info_score_compute(contingency)
     expected_mutual_info = expected_mutual_info_score(contingency, target.numel())
     normalizer = calculate_generalized_mean(

--- a/tests/unittests/clustering/test_adjusted_mutual_info_score.py
+++ b/tests/unittests/clustering/test_adjusted_mutual_info_score.py
@@ -29,6 +29,23 @@ seed_all(42)
 ATOL = 1e-5
 
 
+@pytest.mark.parametrize("average_method", ["min", "arithmetic", "geometric", "max"])
+@pytest.mark.parametrize(("preds", "target"), [([], []), ([0], [7]), ([0, 1, 2], [7, -3, 5])])
+@pytest.mark.parametrize("functional", [True, False])
+def test_adjusted_mutual_info_score_singleton_partitions(preds, target, average_method, functional):
+    """Empty and relabeled singleton partitions agree perfectly, matching sklearn."""
+    expected = sklearn_ami(preds, target, average_method=average_method)
+    preds, target = torch.tensor(preds, dtype=torch.long), torch.tensor(target, dtype=torch.long)
+    if functional:
+        result = adjusted_mutual_info_score(preds, target, average_method)
+    else:
+        metric = AdjustedMutualInfoScore(average_method=average_method)
+        metric.update(preds, target)
+        result = metric.compute()
+    assert expected == 1.0
+    torch.testing.assert_close(result, torch.tensor(expected, dtype=result.dtype, device=preds.device))
+
+
 @pytest.mark.parametrize(
     ("preds", "target"),
     [


### PR DESCRIPTION
## What does this PR do?

Addresses the empty-input and singleton-partition cases in #3495. AMI currently raises on two empty integer tensors and returns `0.0` for two partitions with one cluster per sample, even if the labels differ only by renaming. Both cases now return `1.0`, matching scikit-learn for every averaging method.

The guard uses the already validated contingency matrix: both dimensions equal the sample count exactly for these cases. Shape/type validation remains in place. The separate two-single-cluster case with multiple samples remains covered by the existing #3470; this PR does not duplicate that change or close the whole issue on its own.

Validation (Python 3.12.3, PyTorch 2.14.0+cpu, scikit-learn 1.7.2):

- All 24 new functional/class regression cases fail on the original implementation and pass with the fix.
- AMI, MI and NMI test modules: **105 passed**, including their CPU distributed cases.
- Changed-file pre-commit and `git diff --check`: passed.
- No CUDA or full repository/dependency matrix run locally. Public documentation is unchanged; changelog updated.

Read-only review found no concrete regression. Implementation and tests were prepared with OpenAI Codex; a GPT-5.6-luna agent assisted with read-only review.
